### PR TITLE
Add trustworthy pragmas to various safe builder modules.

### DIFF
--- a/Data/ByteString/Builder.hs
+++ b/Data/ByteString/Builder.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE CPP, BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports -fno-warn-orphans #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Trustworthy #-}
+#endif
 {- | Copyright   : (c) 2010 Jasper Van der Jeugt
                    (c) 2010 - 2011 Simon Meier
 License     : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables, CPP, ForeignFunctionInterface #-}
 {-# OPTIONS_HADDOCK hide #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Trustworthy #-}
+#endif
 -- | Copyright : (c) 2010 - 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
 --

--- a/Data/ByteString/Builder/Extra.hs
+++ b/Data/ByteString/Builder/Extra.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Trustworthy #-}
+#endif
 -----------------------------------------------------------------------------
 -- | Copyright : (c) 2010      Jasper Van der Jeugt
 --               (c) 2010-2011 Simon Meier

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables, CPP, BangPatterns, Rank2Types #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Unsafe #-}
+#endif
 {-# OPTIONS_HADDOCK hide #-}
 -- | Copyright : (c) 2010 - 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE CPP, BangPatterns, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Trustworthy #-}
+#endif
 {- | Copyright : (c) 2010-2011 Simon Meier
                  (c) 2010      Jasper van der Jeugt
 License        : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/Prim/Internal.hs
+++ b/Data/ByteString/Builder/Prim/Internal.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables, CPP, BangPatterns #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Unsafe #-}
+#endif
 {-# OPTIONS_HADDOCK hide #-}
 -- |
 -- Copyright   : 2010-2011 Simon Meier, 2010 Jasper van der Jeugt

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -2,6 +2,9 @@
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE UnliftedFFITypes, MagicHash,
             UnboxedTuples, DeriveDataTypeable #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Unsafe #-}
+#endif
 #endif
 {-# OPTIONS_HADDOCK hide #-}
 

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface, BangPatterns #-}
 #if __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable #-}
+#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE Unsafe #-}
+#endif
 #endif
 {-# OPTIONS_HADDOCK hide #-}
 


### PR DESCRIPTION
This adds the correct Safe Haskell pragmas to the new builder modules of ByteString and also marks a few internal modules as explicitly unsafe since they expose access to ByteStrings constructor or various Builder constructor routines. Unrestricted access to these would easily allow breaking the ByteString invariants and so break its safety.
