### PR TITLE
Use S.foldl' on each chunk when strictly folding a lazy bytestring.

### DIFF
--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -479,7 +479,7 @@ foldl' :: (a -> Word8 -> a) -> a -> ByteString -> a
 foldl' f z = go z
   where go a _ | a `seq` False = undefined
         go a Empty        = a
-        go a (Chunk c cs) = go (S.foldl f a c) cs
+        go a (Chunk c cs) = go (S.foldl' f a c) cs
 {-# INLINE foldl' #-}
 
 -- | 'foldr', applied to a binary operator, a starting value


### PR DESCRIPTION
This improves the performance of the digest-pure library by more than an order of magnitude.
