### PR TITLE
Don't mention ISO-8859-1 in doc string for hGetContents

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1942,9 +1942,6 @@ illegalBufferSize handle fn sz =
 -- files > half of available memory, this may lead to memory exhaustion.
 -- Consider using 'readFile' in this case.
 --
--- As with 'hGet', the string representation in the file is assumed to
--- be ISO-8859-1.
---
 -- The Handle is closed once the contents have been read,
 -- or if an exception is thrown.
 --


### PR DESCRIPTION
Closes GHC [#5861](https://ghc.haskell.org/trac/ghc/ticket/5861).
