### PR TITLE
Add support for `deepseq-1.4.0.0`

### DIFF
--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -94,7 +94,7 @@ import Foreign.C.Types          (CInt, CSize, CULong)
 import Foreign.C.String         (CString)
 
 import Data.Monoid              (Monoid(..))
-import Control.DeepSeq          (NFData)
+import Control.DeepSeq          (NFData(rnf))
 
 #if MIN_VERSION_base(3,0,0)
 import Data.String              (IsString(..))
@@ -212,7 +212,8 @@ instance Monoid ByteString where
     mappend = append
     mconcat = concat
 
-instance NFData ByteString
+instance NFData ByteString where
+    rnf (PS _ _ _) = ()
 
 instance Show ByteString where
     showsPrec p ps r = showsPrec p (unpackChars ps) r

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -136,7 +136,8 @@ instance Monoid ShortByteString where
     mappend = append
     mconcat = concat
 
-instance NFData ShortByteString
+instance NFData ShortByteString where
+    rnf (SBS !_) = ()
 
 instance Show ShortByteString where
     showsPrec p ps r = showsPrec p (unpackChars ps) r


### PR DESCRIPTION
This change avoids relying on `rnf`'s default method implementation
which has changed in `deepseq-1.4.0.0`

NB: previously uploaded `bytestring` releases on Hackage need retroactive
    upper bounds on `deepseq`
