### PR TITLE
Eta expand continuation of empty

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -385,7 +385,11 @@ runBuilderWith (Builder b) = b
 -- only exported for use in rewriting rules. Use 'mempty' otherwise.
 {-# INLINE[1] empty #-}
 empty :: Builder
-empty = Builder id
+empty = Builder (\cont -> (\range -> cont range))
+-- This eta expansion (hopefully) allows GHC to worker-wrapper the
+-- 'BufferRange' in the 'empty' base case of loops (since
+-- worker-wrapper requires (TODO: verify this) that all paths match
+-- against the wrapped argument.
 
 -- | Concatenate two 'Builder's. This function is only exported for use in rewriting
 -- rules. Use 'mappend' otherwise.


### PR DESCRIPTION
`Builder` is currently much slower than necessary due to the
unnecessary creation of `BufferRange` values between
`BuilderStep`s. Take this example,

```haskell
import Data.Monoid
import qualified Data.ByteString.Builder as B
import qualified Data.ByteString.Lazy as L
 
main = do
  let run = L.length . B.toLazyByteString
  n = 1 * (2 ^ (28 :: Int)) -- one MB
  print $ run $ putWord8N16 n
 
putWord8N16 :: Int -> B.Builder
putWord8N16 = loop 0
  where loop s n | s `seq` n `seq` False = undefined
    loop _ 0 = mempty
    loop s n =
    B.word8 (s+15) <>
    loop (s+16) (n-16)
```

This will produce the following
([full Core](https://gist.github.com/bgamari/091e3dac9c45ee9accf1#file-slow-hs-L1)),

```haskell
Main.$wa [InlPrag=[0], Occ=LoopBreaker]
  :: GHC.Prim.Word#
     -> GHC.Prim.Int#
     -> forall r_aKUt.
        Data.ByteString.Builder.Internal.BuildStep r_aKUt
        -> Data.ByteString.Builder.Internal.BuildStep r_aKUt
[GblId, Arity=3, Caf=NoCafRefs, Str=DmdType <L,U><S,1*U><L,1*U>]
Main.$wa =
  \ (ww_s10YU :: GHC.Prim.Word#)
    (ww1_s10YY :: GHC.Prim.Int#)
    (@ r_aKUt)
    (w_s10YR :: Data.ByteString.Builder.Internal.BuildStep r_aKUt) ->
    case ww1_s10YY of wild_XE {
      __DEFAULT -> ...
	  0 -> w_s10YR
    }
```

While the elided branch pattern matches on the `BufferRange`
constructor, the base case (due to `mempty`), does not. This is enough
to hide the potential for constructor specialization from GHC. If we
instead eta expand empty to ensure that the `BufferRange` is matched
against,
```haskell
empty :: Builder
empty = Builder (\cont -> (\range -> cont range))
```

We find that a nice fast loop is produced, where the only
`BufferRange` constructors mentions are found in the case where the
[buffer is full](https://gist.github.com/bgamari/091e3dac9c45ee9accf1#file-fast-hs-L53).

Ideally GHC would be a bit more robust against this sort of
thing. I'll open up a GHC bug to track this.
