### PR TITLE
`cabal repl` error

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -125,6 +125,7 @@ library
                     -fmax-simplifier-iterations=10
                     -fdicts-cheap
                     -fspec-constr-count=6
+                    -fobject-code
 
   c-sources:         cbits/fpstring.c
                      cbits/itoa.c


### PR DESCRIPTION
I'm not sure if this is an intended issue or flaw, but on GHC-7.8.3 running on an Intel i7 in linux, I could not seem to get into an interactive repl unless `-fobject-code` was also added - the `Data.ByteString.Builder.ASCII` module wasn't compiling. Here is the error for more detail: http://lpaste.net/128004