### PR TITLE
fix Char8.unwords type in module's comment

### DIFF
--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -135,7 +135,7 @@ module Data.ByteString.Char8 (
         lines,                  -- :: ByteString -> [ByteString]
         words,                  -- :: ByteString -> [ByteString]
         unlines,                -- :: [ByteString] -> ByteString
-        unwords,                -- :: ByteString -> [ByteString]
+        unwords,                -- :: [ByteString] -> ByteString
 
         -- * Predicates
         isPrefixOf,             -- :: ByteString -> ByteString -> Bool


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>