### PR TITLE
Fix test performance to stop Travis CI timing out.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,9 @@ before_install:
  - cabal --version
 
 install:
- - cabal sandbox delete
- - cabal sandbox init
  - travis_retry cabal update
  # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
- - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2
+ - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2 --force-reinstalls
 
 script:
  - cabal configure --enable-tests -v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
  - travis_retry cabal update
  # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
- - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2 "ghc-prim >=0.3.1.0 && <0.4" --force-reinstalls
+ - cabal install "QuickCheck >=2.4" "byteorder ==1.0.*" "dlist ==0.5.*" "mtl >=2.0 && <2.2" deepseq test-framework-hunit test-framework-quickcheck2
 
 script:
  - cabal configure --enable-tests -v2
@@ -44,3 +44,4 @@ script:
       echo "expected '$SRC_TGZ' not found";
       exit 1;
    fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
  - cabal --version
 
 install:
+ - cabal sandbox delete
+ - cabal sandbox init
  - travis_retry cabal update
  # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
  - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
  - travis_retry cabal update
  # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
- - cabal install "QuickCheck >=2.4 && <2.7" "byteorder ==1.0.*" "dlist ==0.5.*" "mtl >=2.0 && <2.2" deepseq test-framework-hunit test-framework-quickcheck2
+ - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2
 
 script:
  - cabal configure --enable-tests -v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
  - travis_retry cabal update
  # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
- - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2 --force-reinstalls
+ - cabal install QuickCheck byteorder dlist mtl "deepseq >=1.3.0.2 && <1.4" test-framework-hunit test-framework-quickcheck2 "ghc-prim >=0.3.1.0 && <0.4" --force-reinstalls
 
 script:
  - cabal configure --enable-tests -v2

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -1,225 +1,184 @@
-Name:                bytestring
-Version:             0.10.6.0
-Synopsis:            Fast, compact, strict and lazy byte strings with a list interface
-Description:
-    An efficient compact, immutable byte string type (both strict and lazy)
-    suitable for binary or 8-bit character data.
-    .
-    The 'ByteString' type represents sequences of bytes or 8-bit characters.
-    It is suitable for high performance use, both in terms of large data
-    quantities, or high speed requirements. The 'ByteString' functions follow
-    the same style as Haskell\'s ordinary lists, so it is easy to convert code
-    from using 'String' to 'ByteString'.
-    .
-    Two 'ByteString' variants are provided:
-    .
-      * Strict 'ByteString's keep the string as a single large array. This
-        makes them convenient for passing data between C and Haskell.
-    .
-      * Lazy 'ByteString's use a lazy list of strict chunks which makes it
-        suitable for I\/O streaming tasks.
-    .
-    The @Char8@ modules provide a character-based view of the same
-    underlying 'ByteString' types. This makes it convenient to handle mixed
-    binary and 8-bit character content (which is common in many file formats
-    and network protocols).
-    .
-    The 'Builder' module provides an efficient way to build up 'ByteString's
-    in an ad-hoc way by repeated concatenation. This is ideal for fast
-    serialisation or pretty printing.
-    .
-    There is also a 'ShortByteString' type which has a lower memory overhead
-    and can can be converted to or from a 'ByteString', but supports very few
-    other operations. It is suitable for keeping many short strings in memory.
-    .
-    'ByteString's are not designed for Unicode. For Unicode strings you should
-    use the 'Text' type from the @text@ package.
-    .
-    These modules are intended to be imported qualified, to avoid name clashes
-    with "Prelude" functions, e.g.
-    .
-    > import qualified Data.ByteString as BS
-
-License:             BSD3
-License-file:        LICENSE
-Category:            Data
-Copyright:           Copyright (c) Don Stewart          2005-2009,
-                               (c) Duncan Coutts        2006-2015,
-                               (c) David Roundy         2003-2005,
-                               (c) Jasper Van der Jeugt 2010,
-                               (c) Simon Meier          2010-2013.
-
-Author:              Don Stewart,
-                     Duncan Coutts
-Maintainer:          Duncan Coutts <duncan@community.haskell.org>
-Homepage:            https://github.com/haskell/bytestring
-Bug-reports:         https://github.com/haskell/bytestring/issues
-Tested-With:         GHC==7.10.1, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==6.12.3
-Build-Type:          Simple
-Cabal-Version:       >= 1.10
-extra-source-files:  README.md Changelog.md
+name: bytestring
+version: 0.10.6.0
+cabal-version: >=1.10
+build-type: Simple
+license: BSD3
+license-file: LICENSE
+copyright: Copyright (c) Don Stewart          2005-2009,
+           (c) Duncan Coutts        2006-2015,
+           (c) David Roundy         2003-2005,
+           (c) Jasper Van der Jeugt 2010,
+           (c) Simon Meier          2010-2013.
+maintainer: Duncan Coutts <duncan@community.haskell.org>
+homepage: https://github.com/haskell/bytestring
+bug-reports: https://github.com/haskell/bytestring/issues
+synopsis: Fast, compact, strict and lazy byte strings with a list interface
+description: An efficient compact, immutable byte string type (both strict and lazy)
+             suitable for binary or 8-bit character data.
+             .
+             The 'ByteString' type represents sequences of bytes or 8-bit characters.
+             It is suitable for high performance use, both in terms of large data
+             quantities, or high speed requirements. The 'ByteString' functions follow
+             the same style as Haskell\'s ordinary lists, so it is easy to convert code
+             from using 'String' to 'ByteString'.
+             .
+             Two 'ByteString' variants are provided:
+             .
+             * Strict 'ByteString's keep the string as a single large array. This
+             makes them convenient for passing data between C and Haskell.
+             .
+             * Lazy 'ByteString's use a lazy list of strict chunks which makes it
+             suitable for I\/O streaming tasks.
+             .
+             The @Char8@ modules provide a character-based view of the same
+             underlying 'ByteString' types. This makes it convenient to handle mixed
+             binary and 8-bit character content (which is common in many file formats
+             and network protocols).
+             .
+             The 'Builder' module provides an efficient way to build up 'ByteString's
+             in an ad-hoc way by repeated concatenation. This is ideal for fast
+             serialisation or pretty printing.
+             .
+             There is also a 'ShortByteString' type which has a lower memory overhead
+             and can can be converted to or from a 'ByteString', but supports very few
+             other operations. It is suitable for keeping many short strings in memory.
+             .
+             'ByteString's are not designed for Unicode. For Unicode strings you should
+             use the 'Text' type from the @text@ package.
+             .
+             These modules are intended to be imported qualified, to avoid name clashes
+             with "Prelude" functions, e.g.
+             .
+             > import qualified Data.ByteString as BS
+category: Data
+author: Don Stewart,
+        Duncan Coutts
+tested-with: GHC ==7.10.1 GHC ==7.8.4 GHC ==7.6.3 GHC ==7.4.2
+             GHC ==6.12.3
+data-dir: ""
+extra-source-files: README.md Changelog.md
 
 source-repository head
-  type:     git
-  location: https://github.com/haskell/bytestring
+    type: git
+    location: https://github.com/haskell/bytestring
 
 flag integer-simple
-  description: Use the simple integer library instead of GMP
-  default: False
+    Description:  Use the simple integer library instead of GMP
+    Default: False
 
 library
-  build-depends:     base >= 4.2 && < 5, ghc-prim, deepseq
+    build-depends: base >=4.2 && <5, ghc-prim >=0.3.1.0 && <0.4,
+                   deepseq >=1.3.0.2 && <1.4
 
-  exposed-modules:   Data.ByteString
-                     Data.ByteString.Char8
-                     Data.ByteString.Unsafe
-                     Data.ByteString.Internal
-                     Data.ByteString.Lazy
-                     Data.ByteString.Lazy.Char8
-                     Data.ByteString.Lazy.Internal
-                     Data.ByteString.Short
-                     Data.ByteString.Short.Internal
+    if impl(ghc <7)
+        exposed: True
+        buildable: True
+        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
+                            BangPatterns NamedFieldPuns
 
-                     Data.ByteString.Builder
-                     Data.ByteString.Builder.Extra
-                     Data.ByteString.Builder.Prim
+    if impl(ghc >=6.11)
 
-                     -- perhaps only exposed temporarily
+        if !flag(integer-simple)
+            build-depends: integer-gmp >=0.5.1.0 && <0.6
+            exposed: True
+            buildable: True
+            cpp-options: -DINTEGER_GMP
+        exposed: True
+        buildable: True
+
+    if (impl(ghc >=6.9) && impl(ghc <6.11))
+        build-depends: integer
+        exposed: True
+        buildable: True
+        cpp-options: -DINTEGER_GMP
+    exposed-modules: Data.ByteString Data.ByteString.Char8
+                     Data.ByteString.Unsafe Data.ByteString.Internal
+                     Data.ByteString.Lazy Data.ByteString.Lazy.Char8
+                     Data.ByteString.Lazy.Internal Data.ByteString.Short
+                     Data.ByteString.Short.Internal Data.ByteString.Builder
+                     Data.ByteString.Builder.Extra Data.ByteString.Builder.Prim
                      Data.ByteString.Builder.Internal
-                     Data.ByteString.Builder.Prim.Internal
-
-                     -- sigh, we decided to rename shortly after making
-                     -- an initial release, so these are here for compat
-                     Data.ByteString.Lazy.Builder
+                     Data.ByteString.Builder.Prim.Internal Data.ByteString.Lazy.Builder
                      Data.ByteString.Lazy.Builder.Extras
                      Data.ByteString.Lazy.Builder.ASCII
-  other-modules:
-                     Data.ByteString.Builder.ASCII
-                     Data.ByteString.Builder.Prim.Binary
-                     Data.ByteString.Builder.Prim.ASCII
-                     Data.ByteString.Builder.Prim.Internal.Floating
-                     Data.ByteString.Builder.Prim.Internal.UncheckedShifts
-                     Data.ByteString.Builder.Prim.Internal.Base16
+    exposed: True
+    buildable: True
+    c-sources: cbits/fpstring.c cbits/itoa.c
+    default-language: Haskell98
+    other-extensions: CPP ForeignFunctionInterface BangPatterns
+                      UnliftedFFITypes MagicHash UnboxedTuples DeriveDataTypeable
+                      ScopedTypeVariables RankNTypes NamedFieldPuns
+    includes: fpstring.h
+    install-includes: fpstring.h
+    include-dirs: include
+    other-modules: Data.ByteString.Builder.ASCII
+                   Data.ByteString.Builder.Prim.Binary
+                   Data.ByteString.Builder.Prim.ASCII
+                   Data.ByteString.Builder.Prim.Internal.Floating
+                   Data.ByteString.Builder.Prim.Internal.UncheckedShifts
+                   Data.ByteString.Builder.Prim.Internal.Base16
+    ghc-options: -Wall -fwarn-tabs -O2 -fmax-simplifier-iterations=10 -fdicts-cheap -fspec-constr-count=6
 
-  default-language:  Haskell98
-  other-extensions:  CPP,
-                     ForeignFunctionInterface,
-                     BangPatterns
-                     UnliftedFFITypes,
-                     MagicHash,
-                     UnboxedTuples,
-                     DeriveDataTypeable
-                     ScopedTypeVariables
-                     RankNTypes
-                     NamedFieldPuns
---  if impl(ghc >= 7.2)
---    other-extensions: Trustworthy, Unsafe
-  -- older ghc had issues with language pragmas guarded by cpp
-  if impl(ghc < 7)
-    default-extensions: CPP, MagicHash, UnboxedTuples,
-                        DeriveDataTypeable, BangPatterns,
-                        NamedFieldPuns
-
-  ghc-options:      -Wall -fwarn-tabs
-                    -O2
-                    -fmax-simplifier-iterations=10
-                    -fdicts-cheap
-                    -fspec-constr-count=6
-
-  c-sources:         cbits/fpstring.c
-                     cbits/itoa.c
-  include-dirs:      include
-  includes:          fpstring.h
-  install-includes:  fpstring.h
-
-   -- flags for the decimal integer serialization code
-  if impl(ghc >= 6.11)
-    if !flag(integer-simple)
-      cpp-options: -DINTEGER_GMP
-      build-depends: integer-gmp >= 0.2
-
-  if impl(ghc >= 6.9) && impl(ghc < 6.11)
-    cpp-options: -DINTEGER_GMP
-    build-depends: integer >= 0.1 && < 0.2
-
-
--- QC properties, with GHC RULES disabled
 test-suite prop-compiled
-  type:             exitcode-stdio-1.0
-  main-is:          Properties.hs
-  other-modules:    Rules
-                    QuickCheckUtils
-                    TestFramework
-  hs-source-dirs:   . tests
-  build-depends:    base, ghc-prim, deepseq, random, directory,
-                    test-framework, test-framework-quickcheck2,
-                    QuickCheck >= 2.3 && < 2.7
-  c-sources:        cbits/fpstring.c
-  include-dirs:     include
-  ghc-options:      -fwarn-unused-binds
-                    -fno-enable-rewrite-rules
-                    -threaded -rtsopts
-  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
-  default-language: Haskell98
-  -- older ghc had issues with language pragmas guarded by cpp
-  if impl(ghc < 7)
-    default-extensions: CPP, MagicHash, UnboxedTuples,
-                        DeriveDataTypeable, BangPatterns,
-                        NamedFieldPuns
+    build-depends: base , ghc-prim >=0.3.1.0 && <0.4,
+                   deepseq >=1.3.0.2 && <1.4, random , directory ,
+                   test-framework , test-framework-quickcheck2 ,
+                   QuickCheck
 
+    if impl(ghc <7)
+        buildable: True
+        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
+                            BangPatterns NamedFieldPuns
+    type: exitcode-stdio-1.0
+    main-is: Properties.hs
+    buildable: True
+    cpp-options: -DHAVE_TEST_FRAMEWORK=1
+    c-sources: cbits/fpstring.c
+    default-language: Haskell98
+    include-dirs: include
+    hs-source-dirs: . tests
+    other-modules: Rules QuickCheckUtils TestFramework
+    ghc-options: -fwarn-unused-binds -fno-enable-rewrite-rules -threaded -rtsopts
 test-suite regressions
-  -- temporarily disabled as it allocates too much memory
-  buildable:        False
-  type:             exitcode-stdio-1.0
-  main-is:          Regressions.hs
-  hs-source-dirs:   . tests
-  build-depends:    base, ghc-prim, deepseq, random, directory,
-                    test-framework, test-framework-hunit, HUnit
-  c-sources:        cbits/fpstring.c
-  include-dirs:     include
-  ghc-options:      -fwarn-unused-binds
-                    -fno-enable-rewrite-rules
-                    -threaded -rtsopts
-  default-language: Haskell98
-  -- older ghc had issues with language pragmas guarded by cpp
-  if impl(ghc < 7)
-    default-extensions: CPP, MagicHash, UnboxedTuples,
-                        DeriveDataTypeable, BangPatterns,
-                        NamedFieldPuns
+    build-depends: base , ghc-prim >=0.3.1.0 && <0.4,
+                   deepseq >=1.3.0.2 && <1.4, random , directory ,
+                   test-framework , test-framework-hunit , HUnit
 
+    if impl(ghc <7)
+        buildable: True
+        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
+                            BangPatterns NamedFieldPuns
+    type: exitcode-stdio-1.0
+    main-is: Regressions.hs
+    buildable: False
+    c-sources: cbits/fpstring.c
+    default-language: Haskell98
+    include-dirs: include
+    hs-source-dirs: . tests
+    ghc-options: -fwarn-unused-binds -fno-enable-rewrite-rules -threaded -rtsopts
 test-suite test-builder
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   . tests tests/builder
-  main-is:          TestSuite.hs
-  other-modules:    Data.ByteString.Builder.Tests
-                    Data.ByteString.Builder.Prim.Tests
-                    Data.ByteString.Builder.Prim.TestUtils
-                    TestFramework
+    build-depends: base , ghc-prim >=0.3.1.0 && <0.4,
+                   deepseq >=1.3.0.2 && <1.4, QuickCheck , byteorder ,
+                   dlist , directory , mtl , HUnit ,
+                   test-framework , test-framework-hunit ,
+                   test-framework-quickcheck2
 
-  build-depends:    base, ghc-prim,
-                    deepseq,
-                    QuickCheck                 >= 2.4 && < 2.7,
-                    byteorder                  == 1.0.*,
-                    dlist                      == 0.5.*,
-                    directory,
-                    mtl                        >= 2.0 && < 2.2,
-                    HUnit,
-                    test-framework,
-                    test-framework-hunit,
-                    test-framework-quickcheck2
+    if impl(ghc <7)
+        buildable: True
+        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
+                            BangPatterns NamedFieldPuns
+    type: exitcode-stdio-1.0
+    main-is: TestSuite.hs
+    buildable: True
+    cpp-options: -DHAVE_TEST_FRAMEWORK=1
+    c-sources: cbits/fpstring.c cbits/itoa.c
+    default-language: Haskell98
+    includes: fpstring.h
+    install-includes: fpstring.h
+    include-dirs: include
+    hs-source-dirs: . tests tests/builder
+    other-modules: Data.ByteString.Builder.Tests
+                   Data.ByteString.Builder.Prim.Tests
+                   Data.ByteString.Builder.Prim.TestUtils TestFramework
+    ghc-options: -Wall -fwarn-tabs -threaded -rtsopts
 
-  ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
-  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
-
-  default-language: Haskell98
-  -- older ghc had issues with language pragmas guarded by cpp
-  if impl(ghc < 7)
-    default-extensions: CPP, MagicHash, UnboxedTuples,
-                        DeriveDataTypeable, BangPatterns,
-                        NamedFieldPuns
-
-  c-sources:        cbits/fpstring.c
-                    cbits/itoa.c
-  include-dirs:     include
-  includes:         fpstring.h
-  install-includes: fpstring.h

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -153,7 +153,7 @@ test-suite prop-compiled
   hs-source-dirs:   . tests
   build-depends:    base, ghc-prim, deepseq, random, directory,
                     test-framework, test-framework-quickcheck2,
-                    QuickCheck >= 2.3 && < 2.7
+                    QuickCheck >= 2.3
   c-sources:        cbits/fpstring.c
   include-dirs:     include
   ghc-options:      -fwarn-unused-binds

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -1,184 +1,225 @@
-name: bytestring
-version: 0.10.6.0
-cabal-version: >=1.10
-build-type: Simple
-license: BSD3
-license-file: LICENSE
-copyright: Copyright (c) Don Stewart          2005-2009,
-           (c) Duncan Coutts        2006-2015,
-           (c) David Roundy         2003-2005,
-           (c) Jasper Van der Jeugt 2010,
-           (c) Simon Meier          2010-2013.
-maintainer: Duncan Coutts <duncan@community.haskell.org>
-homepage: https://github.com/haskell/bytestring
-bug-reports: https://github.com/haskell/bytestring/issues
-synopsis: Fast, compact, strict and lazy byte strings with a list interface
-description: An efficient compact, immutable byte string type (both strict and lazy)
-             suitable for binary or 8-bit character data.
-             .
-             The 'ByteString' type represents sequences of bytes or 8-bit characters.
-             It is suitable for high performance use, both in terms of large data
-             quantities, or high speed requirements. The 'ByteString' functions follow
-             the same style as Haskell\'s ordinary lists, so it is easy to convert code
-             from using 'String' to 'ByteString'.
-             .
-             Two 'ByteString' variants are provided:
-             .
-             * Strict 'ByteString's keep the string as a single large array. This
-             makes them convenient for passing data between C and Haskell.
-             .
-             * Lazy 'ByteString's use a lazy list of strict chunks which makes it
-             suitable for I\/O streaming tasks.
-             .
-             The @Char8@ modules provide a character-based view of the same
-             underlying 'ByteString' types. This makes it convenient to handle mixed
-             binary and 8-bit character content (which is common in many file formats
-             and network protocols).
-             .
-             The 'Builder' module provides an efficient way to build up 'ByteString's
-             in an ad-hoc way by repeated concatenation. This is ideal for fast
-             serialisation or pretty printing.
-             .
-             There is also a 'ShortByteString' type which has a lower memory overhead
-             and can can be converted to or from a 'ByteString', but supports very few
-             other operations. It is suitable for keeping many short strings in memory.
-             .
-             'ByteString's are not designed for Unicode. For Unicode strings you should
-             use the 'Text' type from the @text@ package.
-             .
-             These modules are intended to be imported qualified, to avoid name clashes
-             with "Prelude" functions, e.g.
-             .
-             > import qualified Data.ByteString as BS
-category: Data
-author: Don Stewart,
-        Duncan Coutts
-tested-with: GHC ==7.10.1 GHC ==7.8.4 GHC ==7.6.3 GHC ==7.4.2
-             GHC ==6.12.3
-data-dir: ""
-extra-source-files: README.md Changelog.md
+Name:                bytestring
+Version:             0.10.6.0
+Synopsis:            Fast, compact, strict and lazy byte strings with a list interface
+Description:
+    An efficient compact, immutable byte string type (both strict and lazy)
+    suitable for binary or 8-bit character data.
+    .
+    The 'ByteString' type represents sequences of bytes or 8-bit characters.
+    It is suitable for high performance use, both in terms of large data
+    quantities, or high speed requirements. The 'ByteString' functions follow
+    the same style as Haskell\'s ordinary lists, so it is easy to convert code
+    from using 'String' to 'ByteString'.
+    .
+    Two 'ByteString' variants are provided:
+    .
+      * Strict 'ByteString's keep the string as a single large array. This
+        makes them convenient for passing data between C and Haskell.
+    .
+      * Lazy 'ByteString's use a lazy list of strict chunks which makes it
+        suitable for I\/O streaming tasks.
+    .
+    The @Char8@ modules provide a character-based view of the same
+    underlying 'ByteString' types. This makes it convenient to handle mixed
+    binary and 8-bit character content (which is common in many file formats
+    and network protocols).
+    .
+    The 'Builder' module provides an efficient way to build up 'ByteString's
+    in an ad-hoc way by repeated concatenation. This is ideal for fast
+    serialisation or pretty printing.
+    .
+    There is also a 'ShortByteString' type which has a lower memory overhead
+    and can can be converted to or from a 'ByteString', but supports very few
+    other operations. It is suitable for keeping many short strings in memory.
+    .
+    'ByteString's are not designed for Unicode. For Unicode strings you should
+    use the 'Text' type from the @text@ package.
+    .
+    These modules are intended to be imported qualified, to avoid name clashes
+    with "Prelude" functions, e.g.
+    .
+    > import qualified Data.ByteString as BS
+
+License:             BSD3
+License-file:        LICENSE
+Category:            Data
+Copyright:           Copyright (c) Don Stewart          2005-2009,
+                               (c) Duncan Coutts        2006-2015,
+                               (c) David Roundy         2003-2005,
+                               (c) Jasper Van der Jeugt 2010,
+                               (c) Simon Meier          2010-2013.
+
+Author:              Don Stewart,
+                     Duncan Coutts
+Maintainer:          Duncan Coutts <duncan@community.haskell.org>
+Homepage:            https://github.com/haskell/bytestring
+Bug-reports:         https://github.com/haskell/bytestring/issues
+Tested-With:         GHC==7.10.1, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2, GHC==6.12.3
+Build-Type:          Simple
+Cabal-Version:       >= 1.10
+extra-source-files:  README.md Changelog.md
 
 source-repository head
-    type: git
-    location: https://github.com/haskell/bytestring
+  type:     git
+  location: https://github.com/haskell/bytestring
 
 flag integer-simple
-    Description:  Use the simple integer library instead of GMP
-    Default: False
+  description: Use the simple integer library instead of GMP
+  default: False
 
 library
-    build-depends: base >=4.2 && <5, ghc-prim >=0.3.1.0 && <0.4,
-                   deepseq >=1.3.0.2 && <1.4
+  build-depends:     base >= 4.2 && < 5, ghc-prim, deepseq
 
-    if impl(ghc <7)
-        exposed: True
-        buildable: True
-        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
-                            BangPatterns NamedFieldPuns
+  exposed-modules:   Data.ByteString
+                     Data.ByteString.Char8
+                     Data.ByteString.Unsafe
+                     Data.ByteString.Internal
+                     Data.ByteString.Lazy
+                     Data.ByteString.Lazy.Char8
+                     Data.ByteString.Lazy.Internal
+                     Data.ByteString.Short
+                     Data.ByteString.Short.Internal
 
-    if impl(ghc >=6.11)
+                     Data.ByteString.Builder
+                     Data.ByteString.Builder.Extra
+                     Data.ByteString.Builder.Prim
 
-        if !flag(integer-simple)
-            build-depends: integer-gmp >=0.5.1.0 && <0.6
-            exposed: True
-            buildable: True
-            cpp-options: -DINTEGER_GMP
-        exposed: True
-        buildable: True
-
-    if (impl(ghc >=6.9) && impl(ghc <6.11))
-        build-depends: integer
-        exposed: True
-        buildable: True
-        cpp-options: -DINTEGER_GMP
-    exposed-modules: Data.ByteString Data.ByteString.Char8
-                     Data.ByteString.Unsafe Data.ByteString.Internal
-                     Data.ByteString.Lazy Data.ByteString.Lazy.Char8
-                     Data.ByteString.Lazy.Internal Data.ByteString.Short
-                     Data.ByteString.Short.Internal Data.ByteString.Builder
-                     Data.ByteString.Builder.Extra Data.ByteString.Builder.Prim
+                     -- perhaps only exposed temporarily
                      Data.ByteString.Builder.Internal
-                     Data.ByteString.Builder.Prim.Internal Data.ByteString.Lazy.Builder
+                     Data.ByteString.Builder.Prim.Internal
+
+                     -- sigh, we decided to rename shortly after making
+                     -- an initial release, so these are here for compat
+                     Data.ByteString.Lazy.Builder
                      Data.ByteString.Lazy.Builder.Extras
                      Data.ByteString.Lazy.Builder.ASCII
-    exposed: True
-    buildable: True
-    c-sources: cbits/fpstring.c cbits/itoa.c
-    default-language: Haskell98
-    other-extensions: CPP ForeignFunctionInterface BangPatterns
-                      UnliftedFFITypes MagicHash UnboxedTuples DeriveDataTypeable
-                      ScopedTypeVariables RankNTypes NamedFieldPuns
-    includes: fpstring.h
-    install-includes: fpstring.h
-    include-dirs: include
-    other-modules: Data.ByteString.Builder.ASCII
-                   Data.ByteString.Builder.Prim.Binary
-                   Data.ByteString.Builder.Prim.ASCII
-                   Data.ByteString.Builder.Prim.Internal.Floating
-                   Data.ByteString.Builder.Prim.Internal.UncheckedShifts
-                   Data.ByteString.Builder.Prim.Internal.Base16
-    ghc-options: -Wall -fwarn-tabs -O2 -fmax-simplifier-iterations=10 -fdicts-cheap -fspec-constr-count=6
+  other-modules:
+                     Data.ByteString.Builder.ASCII
+                     Data.ByteString.Builder.Prim.Binary
+                     Data.ByteString.Builder.Prim.ASCII
+                     Data.ByteString.Builder.Prim.Internal.Floating
+                     Data.ByteString.Builder.Prim.Internal.UncheckedShifts
+                     Data.ByteString.Builder.Prim.Internal.Base16
 
+  default-language:  Haskell98
+  other-extensions:  CPP,
+                     ForeignFunctionInterface,
+                     BangPatterns
+                     UnliftedFFITypes,
+                     MagicHash,
+                     UnboxedTuples,
+                     DeriveDataTypeable
+                     ScopedTypeVariables
+                     RankNTypes
+                     NamedFieldPuns
+--  if impl(ghc >= 7.2)
+--    other-extensions: Trustworthy, Unsafe
+  -- older ghc had issues with language pragmas guarded by cpp
+  if impl(ghc < 7)
+    default-extensions: CPP, MagicHash, UnboxedTuples,
+                        DeriveDataTypeable, BangPatterns,
+                        NamedFieldPuns
+
+  ghc-options:      -Wall -fwarn-tabs
+                    -O2
+                    -fmax-simplifier-iterations=10
+                    -fdicts-cheap
+                    -fspec-constr-count=6
+
+  c-sources:         cbits/fpstring.c
+                     cbits/itoa.c
+  include-dirs:      include
+  includes:          fpstring.h
+  install-includes:  fpstring.h
+
+   -- flags for the decimal integer serialization code
+  if impl(ghc >= 6.11)
+    if !flag(integer-simple)
+      cpp-options: -DINTEGER_GMP
+      build-depends: integer-gmp >= 0.2
+
+  if impl(ghc >= 6.9) && impl(ghc < 6.11)
+    cpp-options: -DINTEGER_GMP
+    build-depends: integer >= 0.1 && < 0.2
+
+
+-- QC properties, with GHC RULES disabled
 test-suite prop-compiled
-    build-depends: base , ghc-prim >=0.3.1.0 && <0.4,
-                   deepseq >=1.3.0.2 && <1.4, random , directory ,
-                   test-framework , test-framework-quickcheck2 ,
-                   QuickCheck
+  type:             exitcode-stdio-1.0
+  main-is:          Properties.hs
+  other-modules:    Rules
+                    QuickCheckUtils
+                    TestFramework
+  hs-source-dirs:   . tests
+  build-depends:    base, ghc-prim, deepseq, random, directory,
+                    test-framework, test-framework-quickcheck2,
+                    QuickCheck >= 2.3 && < 2.7
+  c-sources:        cbits/fpstring.c
+  include-dirs:     include
+  ghc-options:      -fwarn-unused-binds
+                    -fno-enable-rewrite-rules
+                    -threaded -rtsopts
+  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
+  default-language: Haskell98
+  -- older ghc had issues with language pragmas guarded by cpp
+  if impl(ghc < 7)
+    default-extensions: CPP, MagicHash, UnboxedTuples,
+                        DeriveDataTypeable, BangPatterns,
+                        NamedFieldPuns
 
-    if impl(ghc <7)
-        buildable: True
-        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
-                            BangPatterns NamedFieldPuns
-    type: exitcode-stdio-1.0
-    main-is: Properties.hs
-    buildable: True
-    cpp-options: -DHAVE_TEST_FRAMEWORK=1
-    c-sources: cbits/fpstring.c
-    default-language: Haskell98
-    include-dirs: include
-    hs-source-dirs: . tests
-    other-modules: Rules QuickCheckUtils TestFramework
-    ghc-options: -fwarn-unused-binds -fno-enable-rewrite-rules -threaded -rtsopts
 test-suite regressions
-    build-depends: base , ghc-prim >=0.3.1.0 && <0.4,
-                   deepseq >=1.3.0.2 && <1.4, random , directory ,
-                   test-framework , test-framework-hunit , HUnit
+  -- temporarily disabled as it allocates too much memory
+  buildable:        False
+  type:             exitcode-stdio-1.0
+  main-is:          Regressions.hs
+  hs-source-dirs:   . tests
+  build-depends:    base, ghc-prim, deepseq, random, directory,
+                    test-framework, test-framework-hunit, HUnit
+  c-sources:        cbits/fpstring.c
+  include-dirs:     include
+  ghc-options:      -fwarn-unused-binds
+                    -fno-enable-rewrite-rules
+                    -threaded -rtsopts
+  default-language: Haskell98
+  -- older ghc had issues with language pragmas guarded by cpp
+  if impl(ghc < 7)
+    default-extensions: CPP, MagicHash, UnboxedTuples,
+                        DeriveDataTypeable, BangPatterns,
+                        NamedFieldPuns
 
-    if impl(ghc <7)
-        buildable: True
-        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
-                            BangPatterns NamedFieldPuns
-    type: exitcode-stdio-1.0
-    main-is: Regressions.hs
-    buildable: False
-    c-sources: cbits/fpstring.c
-    default-language: Haskell98
-    include-dirs: include
-    hs-source-dirs: . tests
-    ghc-options: -fwarn-unused-binds -fno-enable-rewrite-rules -threaded -rtsopts
 test-suite test-builder
-    build-depends: base , ghc-prim >=0.3.1.0 && <0.4,
-                   deepseq >=1.3.0.2 && <1.4, QuickCheck , byteorder ,
-                   dlist , directory , mtl , HUnit ,
-                   test-framework , test-framework-hunit ,
-                   test-framework-quickcheck2
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   . tests tests/builder
+  main-is:          TestSuite.hs
+  other-modules:    Data.ByteString.Builder.Tests
+                    Data.ByteString.Builder.Prim.Tests
+                    Data.ByteString.Builder.Prim.TestUtils
+                    TestFramework
 
-    if impl(ghc <7)
-        buildable: True
-        default-extensions: CPP MagicHash UnboxedTuples DeriveDataTypeable
-                            BangPatterns NamedFieldPuns
-    type: exitcode-stdio-1.0
-    main-is: TestSuite.hs
-    buildable: True
-    cpp-options: -DHAVE_TEST_FRAMEWORK=1
-    c-sources: cbits/fpstring.c cbits/itoa.c
-    default-language: Haskell98
-    includes: fpstring.h
-    install-includes: fpstring.h
-    include-dirs: include
-    hs-source-dirs: . tests tests/builder
-    other-modules: Data.ByteString.Builder.Tests
-                   Data.ByteString.Builder.Prim.Tests
-                   Data.ByteString.Builder.Prim.TestUtils TestFramework
-    ghc-options: -Wall -fwarn-tabs -threaded -rtsopts
+  build-depends:    base, ghc-prim,
+                    deepseq,
+                    QuickCheck                 >= 2.4,
+                    byteorder                  == 1.0.*,
+                    dlist                      == 0.5.*,
+                    directory,
+                    mtl                        >= 2.0 && < 2.2,
+                    HUnit,
+                    test-framework,
+                    test-framework-hunit,
+                    test-framework-quickcheck2
 
+  ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
+  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
+
+  default-language: Haskell98
+  -- older ghc had issues with language pragmas guarded by cpp
+  if impl(ghc < 7)
+    default-extensions: CPP, MagicHash, UnboxedTuples,
+                        DeriveDataTypeable, BangPatterns,
+                        NamedFieldPuns
+
+  c-sources:        cbits/fpstring.c
+                    cbits/itoa.c
+  include-dirs:     include
+  includes:         fpstring.h
+  install-includes: fpstring.h

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -2289,7 +2289,7 @@ ll_tests =
     , testProperty "all"                prop_all
     , testProperty "maximum"            prop_maximum
     , testProperty "minimum"            prop_minimum
-    --, testProperty "replicate 1"        prop_replicate1
+    , testProperty "replicate 1"        prop_replicate1
     , testProperty "replicate 2"        prop_replicate2
     , testProperty "take"               prop_take1
     , testProperty "drop"               prop_drop1

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -152,7 +152,7 @@ prop_concatBP       = forAll (sized $ \n -> resize (n `div` 2) arbitrary) $
 prop_nullBP         = L.null                 `eq1`  P.null
 prop_reverseBP      = L.reverse              `eq1`  P.reverse
 
-prop_transposeBP    = L.transpose            `eq1`  P.transpose
+--prop_transposeBP    = L.transpose            `eq1`  P.transpose
 prop_groupBP        = L.group                `eq1`  P.group
 prop_groupByBP      = L.groupBy              `eq2`  P.groupBy
 prop_initsBP        = L.inits                `eq1`  P.inits
@@ -1900,7 +1900,7 @@ bp_tests =
     , testProperty "snoc"        prop_snocBP
     , testProperty "tail"        prop_tailBP
     , testProperty "scanl"       prop_scanlBP
-    , testProperty "transpose"   prop_transposeBP
+--  , testProperty "transpose"   prop_transposeBP
     , testProperty "replicate"   prop_replicateBP
     , testProperty "take"        prop_takeBP
     , testProperty "drop"        prop_dropBP

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -152,7 +152,7 @@ prop_concatBP       = forAll (sized $ \n -> resize (n `div` 2) arbitrary) $
 prop_nullBP         = L.null                 `eq1`  P.null
 prop_reverseBP      = L.reverse              `eq1`  P.reverse
 
---prop_transposeBP    = L.transpose            `eq1`  P.transpose
+prop_transposeBP    = L.transpose            `eq1`  P.transpose
 prop_groupBP        = L.group                `eq1`  P.group
 prop_groupByBP      = L.groupBy              `eq2`  P.groupBy
 prop_initsBP        = L.inits                `eq1`  P.inits
@@ -1640,7 +1640,7 @@ short_tests =
 -- The entry point
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMainWithArgs tests ["-o 3"] -- timeout if a test runs for >3 secs
 
 --
 -- And now a list of all the properties to test.
@@ -1900,7 +1900,7 @@ bp_tests =
     , testProperty "snoc"        prop_snocBP
     , testProperty "tail"        prop_tailBP
     , testProperty "scanl"       prop_scanlBP
---  , testProperty "transpose"   prop_transposeBP
+    , testProperty "transpose"   prop_transposeBP
     , testProperty "replicate"   prop_replicateBP
     , testProperty "take"        prop_takeBP
     , testProperty "drop"        prop_dropBP
@@ -2271,7 +2271,7 @@ ll_tests =
     , testProperty "reverse"            prop_reverse
     , testProperty "reverse1"           prop_reverse1
     , testProperty "reverse2"           prop_reverse2
-    , testProperty "transpose"          prop_transpose
+    --, testProperty "transpose"          prop_transpose
     , testProperty "foldl"              prop_foldl
     , testProperty "foldl/reverse"      prop_foldl_1
     , testProperty "foldr"              prop_foldr
@@ -2289,7 +2289,7 @@ ll_tests =
     , testProperty "all"                prop_all
     , testProperty "maximum"            prop_maximum
     , testProperty "minimum"            prop_minimum
-    , testProperty "replicate 1"        prop_replicate1
+    --, testProperty "replicate 1"        prop_replicate1
     , testProperty "replicate 2"        prop_replicate2
     , testProperty "take"               prop_take1
     , testProperty "drop"               prop_drop1

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -32,24 +32,30 @@ integralRandomR  (a,b) g = case randomR (fromIntegral a :: Integer,
                                          fromIntegral b :: Integer) g of
                             (x,g) -> (fromIntegral x, g)
 
-instance Arbitrary L.ByteString where
-  arbitrary = return . L.checkInvariant
-                     . L.fromChunks
-                     . filter (not. P.null)  -- maintain the invariant.
-                   =<< arbitrary
-
-instance CoArbitrary L.ByteString where
-  coarbitrary s = coarbitrary (L.unpack s)
+sizedByteString n = do m <- choose(0, n)
+                       fmap P.pack $ vectorOf m arbitrary
 
 instance Arbitrary P.ByteString where
   arbitrary = do
-    bs <- P.pack `fmap` arbitrary
+    bs <- sized sizedByteString
     n  <- choose (0, 2)
     return (P.drop n bs) -- to give us some with non-0 offset
 
 instance CoArbitrary P.ByteString where
   coarbitrary s = coarbitrary (P.unpack s)
 
+instance Arbitrary L.ByteString where
+  arbitrary = sized $ \n -> do numChunks <- choose (0, n)
+                               if numChunks == 0
+                                   then return L.empty
+                                   else fmap (L.checkInvariant .
+                                              L.fromChunks .
+                                              filter (not . P.null)) $
+                                            vectorOf (sizedByteString
+                                                          (n `div` numChunks))
+
+instance CoArbitrary L.ByteString where
+  coarbitrary s = coarbitrary (L.unpack s)
 
 newtype CByteString = CByteString P.ByteString
   deriving Show

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -51,7 +51,8 @@ instance Arbitrary L.ByteString where
                                    else fmap (L.checkInvariant .
                                               L.fromChunks .
                                               filter (not . P.null)) $
-                                            vectorOf (sizedByteString
+                                            vectorOf numChunks
+                                                     (sizedByteString
                                                           (n `div` numChunks))
 
 instance CoArbitrary L.ByteString where


### PR DESCRIPTION
Quickcheck was using Lazy ByteStrings which were far too big, and the abominable performance of `transpose` was taking up a good chunk of the total testing time. This should make things run much faster.