### PR TITLE
Radically reduce #ifdefs

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__
 {-# LANGUAGE MagicHash, UnboxedTuples,
             NamedFieldPuns, BangPatterns #-}
-#endif
 {-# OPTIONS_HADDOCK prune #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
@@ -227,12 +225,7 @@ import qualified Data.List as List
 import Data.Word                (Word8)
 import Data.Maybe               (isJust, listToMaybe)
 
--- Control.Exception.assert not available in yhc or nhc
-#ifndef __NHC__
 import Control.Exception        (finally, bracket, assert, throwIO)
-#else
-import Control.Exception       (bracket, finally)
-#endif
 import Control.Monad            (when)
 
 import Foreign.C.String         (CString, CStringLen)
@@ -258,14 +251,6 @@ import System.IO.Error          (mkIOError, illegalOperationErrorType)
 import Data.Monoid              (Monoid(..))
 #endif
 
-#if !defined(__GLASGOW_HASKELL__)
-import System.IO.Unsafe
-import qualified System.Environment
-import qualified System.IO      (hGetLine)
-import System.IO                (hIsEOF)
-#endif
-
-#if defined(__GLASGOW_HASKELL__)
 
 import System.IO                (hGetBufNonBlocking, hPutBufNonBlocking)
 
@@ -275,7 +260,6 @@ import System.IO                (hGetBufSome)
 import System.IO                (hWaitForInput, hIsEOF)
 #endif
 
-#if __GLASGOW_HASKELL__ >= 611
 import Data.IORef
 import GHC.IO.Handle.Internals
 import GHC.IO.Handle.Types
@@ -284,37 +268,10 @@ import GHC.IO.BufferedIO as Buffered
 import GHC.IO                   (unsafePerformIO, unsafeDupablePerformIO)
 import Data.Char                (ord)
 import Foreign.Marshal.Utils    (copyBytes)
-#else
-import System.IO.Error          (isEOFError)
-import GHC.IOBase
-import GHC.Handle
-#endif
 
 import GHC.Prim                 (Word#)
 import GHC.Base                 (build)
 import GHC.Word hiding (Word8)
-
-#endif
-
--- An alternative to Control.Exception (assert) for nhc98
-#ifdef __NHC__
-
-import System.IO (Handle)
-
-#define assert  assertS "__FILE__ : __LINE__"
-assertS :: String -> Bool -> a -> a
-assertS _ True  = id
-assertS s False = error ("assertion failed at "++s)
-
--- An alternative to hWaitForInput
-hWaitForInput :: Handle -> Int -> IO ()
-hWaitForInput _ _ = return ()
-#endif
-
-#ifndef __GLASGOW_HASKELL__
-unsafeDupablePerformIO = unsafePerformIO
-#endif
-
 
 -- -----------------------------------------------------------------------------
 -- Introducing and eliminating 'ByteString's
@@ -358,10 +315,6 @@ pack = packBytes
 
 -- | /O(n)/ Converts a 'ByteString' to a '[Word8]'.
 unpack :: ByteString -> [Word8]
-#if !defined(__GLASGOW_HASKELL__)
-unpack = unpackBytes
-#else
-
 unpack bs = build (unpackFoldr bs)
 {-# INLINE unpack #-}
 
@@ -376,8 +329,6 @@ unpackFoldr bs k z = foldr k z bs
 "ByteString unpack-list" [1]  forall bs .
     unpackFoldr bs (:) [] = unpackBytes bs
  #-}
-
-#endif
 
 -- ---------------------------------------------------------------------
 -- Basic interface
@@ -887,9 +838,7 @@ dropWhile f ps = unsafeDrop (findIndexOrEnd (not . f) ps) ps
 --
 break :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
 break p ps = case findIndexOrEnd p ps of n -> (unsafeTake n ps, unsafeDrop n ps)
-#if __GLASGOW_HASKELL__ 
 {-# INLINE [1] break #-}
-#endif
 
 {-# RULES
 "ByteString specialise break (x==)" forall x.
@@ -923,9 +872,7 @@ breakEnd  p ps = splitAt (findFromEndUntil p ps) ps
 -- equivalent to @('takeWhile' p xs, 'dropWhile' p xs)@
 span :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
 span p ps = break (not . p) ps
-#if __GLASGOW_HASKELL__
 {-# INLINE [1] span #-}
-#endif
 
 -- | 'spanByte' breaks its ByteString argument at the first
 -- occurence of a byte other than its argument. It is more efficient
@@ -976,8 +923,6 @@ spanEnd  p ps = splitAt (findFromEndUntil (not.p) ps) ps
 -- > splitWith (=='a') []        == []
 --
 splitWith :: (Word8 -> Bool) -> ByteString -> [ByteString]
-
-#if defined(__GLASGOW_HASKELL__)
 splitWith _pred (PS _  _   0) = []
 splitWith pred_ (PS fp off len) = splitWith0 pred# off len fp
   where pred# c# = pred_ (W8# c#)
@@ -1002,15 +947,6 @@ splitWith pred_ (PS fp off len) = splitWith0 pred# off len fp
                               splitWith0 pred' (off'+idx'+1) (len'-idx'-1) fp')
                    else splitLoop pred' p (idx'+1) off' len' fp'
 {-# INLINE splitWith #-}
-
-#else
-splitWith _ (PS _ _ 0) = []
-splitWith p ps = loop p ps
-    where
-        loop !q !qs = if null rest then [chunk]
-                                   else chunk : loop q (unsafeTail rest)
-            where (chunk,rest) = break q qs
-#endif
 
 -- | /O(n)/ Break a 'ByteString' into pieces separated by the byte
 -- argument, consuming the delimiter. I.e.
@@ -1555,13 +1491,6 @@ getLine = hGetLine stdin
 -- | Read a line from a handle
 
 hGetLine :: Handle -> IO ByteString
-
-#if !defined(__GLASGOW_HASKELL__)
-
-hGetLine h = System.IO.hGetLine h >>= return . pack . P.map c2w
-
-#elif __GLASGOW_HASKELL__ >= 611
-
 hGetLine h =
   wantReadableHandle_ "Data.ByteString.hGetLine" h $
     \ h_@Handle__{haByteBuffer} -> do
@@ -1616,72 +1545,6 @@ mkPS buf start end =
  where
    len = end - start
 
-#else
--- GHC 6.10 and older, pre-Unicode IO library
-
-hGetLine h = wantReadableHandle "Data.ByteString.hGetLine" h $ \ handle_ -> do
-    case haBufferMode handle_ of
-       NoBuffering -> error "no buffering"
-       _other      -> hGetLineBuffered handle_
-
- where
-    hGetLineBuffered handle_ = do
-        let ref = haBuffer handle_
-        buf <- readIORef ref
-        hGetLineBufferedLoop handle_ ref buf 0 []
-
-    hGetLineBufferedLoop handle_ ref
-            buf@Buffer{ bufRPtr=r, bufWPtr=w, bufBuf=raw } !len xss = do
-        off <- findEOL r w raw
-        let new_len = len + off - r
-        xs <- mkPS raw r off
-
-      -- if eol == True, then off is the offset of the '\n'
-      -- otherwise off == w and the buffer is now empty.
-        if off /= w
-            then do if (w == off + 1)
-                            then writeIORef ref buf{ bufRPtr=0, bufWPtr=0 }
-                            else writeIORef ref buf{ bufRPtr = off + 1 }
-                    mkBigPS new_len (xs:xss)
-            else do
-                 maybe_buf <- maybeFillReadBuffer (haFD handle_) True (haIsStream handle_)
-                                    buf{ bufWPtr=0, bufRPtr=0 }
-                 case maybe_buf of
-                    -- Nothing indicates we caught an EOF, and we may have a
-                    -- partial line to return.
-                    Nothing -> do
-                         writeIORef ref buf{ bufRPtr=0, bufWPtr=0 }
-                         if new_len > 0
-                            then mkBigPS new_len (xs:xss)
-                            else ioe_EOF
-                    Just new_buf ->
-                         hGetLineBufferedLoop handle_ ref new_buf new_len (xs:xss)
-
-    -- find the end-of-line character, if there is one
-    findEOL r w raw
-        | r == w = return w
-        | otherwise =  do
-            (c,r') <- readCharFromBuffer raw r
-            if c == '\n'
-                then return r -- NB. not r': don't include the '\n'
-                else findEOL r' w raw
-
-    maybeFillReadBuffer fd is_line is_stream buf = catch
-        (do buf' <- fillReadBuffer fd is_line is_stream buf
-            return (Just buf'))
-        (\e -> if isEOFError e then return Nothing else ioError e)
-
--- TODO, rewrite to use normal memcpy
-mkPS :: RawBuffer -> Int -> Int -> IO ByteString
-mkPS buf start end =
-    let len = end - start
-    in create len $ \p -> do
-        memcpy_ptr_baoff p buf (fromIntegral start) (fromIntegral len)
-        return ()
-
-memcpy_ptr_baoff dst src src_off sz = memcpy dst (src+src_off) sz
-#endif
-
 mkBigPS :: Int -> [ByteString] -> IO ByteString
 mkBigPS _ [ps] = return ps
 mkBigPS _ pss = return $! concat (P.reverse pss)
@@ -1703,13 +1566,9 @@ hPut h (PS ps s l) = withForeignPtr ps $ \p-> hPutBuf h (p `plusPtr` s) l
 -- function does not work correctly; it behaves identically to 'hPut'.
 --
 hPutNonBlocking :: Handle -> ByteString -> IO ByteString
-#if defined(__GLASGOW_HASKELL__)
 hPutNonBlocking h bs@(PS ps s l) = do
   bytesWritten <- withForeignPtr ps $ \p-> hPutBufNonBlocking h (p `plusPtr` s) l
   return $! drop bytesWritten bs
-#else
-hPutNonBlocking h bs = hPut h bs >> return empty
-#endif
 
 -- | A synonym for @hPut@, for compatibility 
 hPutStr :: Handle -> ByteString -> IO ()
@@ -1765,14 +1624,10 @@ hGet h i
 -- function does not work correctly; it behaves identically to 'hGet'.
 --
 hGetNonBlocking :: Handle -> Int -> IO ByteString
-#if defined(__GLASGOW_HASKELL__)
 hGetNonBlocking h i
     | i >  0    = createAndTrim i $ \p -> hGetBufNonBlocking h p i
     | i == 0    = return empty
     | otherwise = illegalBufferSize h "hGetNonBlocking" i
-#else
-hGetNonBlocking = hGet
-#endif
 
 -- | Like 'hGet', except that a shorter 'ByteString' may be returned
 -- if there are not enough bytes immediately available to satisfy the
@@ -1912,12 +1767,7 @@ moduleError fun msg = error (moduleErrorMsg fun msg)
 {-# NOINLINE moduleError #-}
 
 moduleErrorIO :: String -> String -> IO a
-moduleErrorIO fun msg =
-#if MIN_VERSION_base(4,0,0)
-    throwIO . userError $ moduleErrorMsg fun msg
-#else
-    throwIO . IOException . userError $ moduleErrorMsg fun msg
-#endif
+moduleErrorIO fun msg = throwIO . userError $ moduleErrorMsg fun msg
 {-# NOINLINE moduleErrorIO #-}
 
 moduleErrorMsg :: String -> String -> String

--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -85,7 +85,7 @@ import qualified Data.ByteString.Builder.Prim                   as P
 import           Foreign
 
 
-#if defined(__GLASGOW_HASKELL__) && defined(INTEGER_GMP)
+#if defined(INTEGER_GMP)
 
 #if !(MIN_VERSION_base(4,8,0))
 import           Data.Monoid (mappend)
@@ -304,7 +304,7 @@ lazyByteStringHex = P.primMapLazyByteStringFixed P.word8HexFixed
 -- Fast decimal 'Integer' encoding.
 ------------------------------------------------------------------------------
 
-#if defined(__GLASGOW_HASKELL__) && defined(INTEGER_GMP)
+#if defined(INTEGER_GMP)
 -- An optimized version of the integer serialization code
 -- in blaze-textual (c) 2011 MailRank, Inc. Bryan O'Sullivan
 -- <bos@mailrank.com>. It is 2.5x faster on Int-sized integers and 4.5x faster

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -132,9 +132,8 @@ import           Control.Arrow (second)
 
 #if !(MIN_VERSION_base(4,8,0))
 import           Data.Monoid
-import           Control.Applicative (Applicative(..))
+import           Control.Applicative (Applicative(..),(<$>))
 #endif
-import           Control.Applicative ((<$>))
 
 import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal      as S
@@ -490,21 +489,18 @@ instance Applicative Put where
   pure x = Put $ \k -> k x
   {-# INLINE (<*>) #-}
   Put f <*> Put a = Put $ \k -> f (\f' -> a (\a' -> k (f' a')))
-#if MIN_VERSION_base(4,2,0)
   {-# INLINE (<*) #-}
   (<*) = ap_l
   {-# INLINE (*>) #-}
   (*>) = ap_r
-#endif
 
 instance Monad Put where
   {-# INLINE return #-}
-  return x = Put $ \k -> k x
+  return = pure
   {-# INLINE (>>=) #-}
   Put m >>= f = Put $ \k -> m (\m' -> unPut (f m') k)
   {-# INLINE (>>) #-}
-  (>>) = ap_r
-
+  (>>) = (*>)
 
 -- Conversion between Put and Builder
 -------------------------------------

--- a/Data/ByteString/Builder/Prim/Internal/UncheckedShifts.hs
+++ b/Data/ByteString/Builder/Prim/Internal/UncheckedShifts.hs
@@ -18,7 +18,7 @@
 -- These functions are undefined when the amount being shifted by is
 -- greater than the size in bits of a machine Int#.-
 --
-#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+#if !defined(__HADDOCK__)
 #include "MachDeps.h"
 #endif
 
@@ -32,7 +32,7 @@ module Data.ByteString.Builder.Prim.Internal.UncheckedShifts (
   ) where
 
 
-#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+#if !defined(__HADDOCK__)
 import GHC.Base
 import GHC.Word (Word32(..),Word16(..),Word64(..))
 
@@ -70,19 +70,12 @@ shiftr_w w s = fromIntegral $ (`shiftr_w32` s) $ fromIntegral w
 shiftr_w w s = fromIntegral $ (`shiftr_w64` s) $ fromIntegral w
 #endif
 
-#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+#if !defined(__HADDOCK__)
 shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRL#`   i)
 shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`   i)
 
 #if WORD_SIZE_IN_BITS < 64
 shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL64#` i)
-
-#if __GLASGOW_HASKELL__ <= 606
--- Exported by GHC.Word in GHC 6.8 and higher
-foreign import ccall unsafe "stg_uncheckedShiftRL64"
-    uncheckedShiftRL64#     :: Word64# -> Int# -> Word64#
-#endif
-
 #else
 shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL#` i)
 #endif

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP, BangPatterns #-}
-#if __GLASGOW_HASKELL__
 {-# LANGUAGE MagicHash, UnboxedTuples #-}
-#endif
 {-# OPTIONS_HADDOCK prune #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
@@ -259,11 +257,7 @@ import Data.Char    ( isSpace )
 import qualified Data.List as List (intersperse)
 
 import System.IO    (Handle,stdout,openBinaryFile,hClose,hFileSize,IOMode(..))
-#ifndef __NHC__
 import Control.Exception        (bracket)
-#else
-import IO			(bracket)
-#endif
 import Foreign
 
 
@@ -499,9 +493,7 @@ takeWhile f = B.takeWhile (f . w2c)
 -- | 'dropWhile' @p xs@ returns the suffix remaining after 'takeWhile' @p xs@.
 dropWhile :: (Char -> Bool) -> ByteString -> ByteString
 dropWhile f = B.dropWhile (f . w2c)
-#if defined(__GLASGOW_HASKELL__)
 {-# INLINE [1] dropWhile #-}
-#endif
 
 {-# RULES
 "ByteString specialise dropWhile isSpace -> dropSpace"
@@ -511,9 +503,7 @@ dropWhile f = B.dropWhile (f . w2c)
 -- | 'break' @p@ is equivalent to @'span' ('not' . p)@.
 break :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
 break f = B.break (f . w2c)
-#if defined(__GLASGOW_HASKELL__)
 {-# INLINE [1] break #-}
-#endif
 
 {-# RULES
 "ByteString specialise break (x==)" forall x.

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface, BangPatterns #-}
-#if __GLASGOW_HASKELL__
 {-# LANGUAGE UnliftedFFITypes, MagicHash,
             UnboxedTuples, DeriveDataTypeable #-}
 #if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 #endif
 {-# OPTIONS_HADDOCK hide #-}
 
@@ -35,9 +33,7 @@ module Data.ByteString.Internal (
         packChars, packUptoLenChars, unsafePackLenChars,
         unpackBytes, unpackAppendBytesLazy, unpackAppendBytesStrict,
         unpackChars, unpackAppendCharsLazy, unpackAppendCharsStrict,
-#if defined(__GLASGOW_HASKELL__)
         unsafePackAddress,
-#endif
         checkedSum,
 
         -- * Low level imperative construction
@@ -98,30 +94,16 @@ import Data.Monoid              (Monoid(..))
 #endif
 import Control.DeepSeq          (NFData(rnf))
 
-#if MIN_VERSION_base(3,0,0)
 import Data.String              (IsString(..))
-#endif
 
-#ifndef __NHC__
 import Control.Exception        (assert)
-#endif
 
 import Data.Char                (ord)
 import Data.Word                (Word8)
 
 import Data.Typeable            (Typeable)
-#if MIN_VERSION_base(4,1,0)
-import Data.Data                (Data(..))
-#if MIN_VERSION_base(4,2,0)
-import Data.Data                (mkNoRepType)
-#else
-import Data.Data                (mkNorepType)
-#endif
-#else
-import Data.Generics            (Data(..), mkNorepType)
-#endif
+import Data.Data                (Data(..), mkNoRepType)
 
-#ifdef __GLASGOW_HASKELL__
 import GHC.Base                 (realWorld#,unsafeChr)
 #if MIN_VERSION_base(4,4,0)
 import GHC.CString              (unpackCString#)
@@ -139,42 +121,14 @@ import GHC.IO                   (unsafeDupablePerformIO)
 #else
 import GHC.IOBase               (unsafeDupablePerformIO)
 #endif
-#else
-import Data.Char                (chr)
-import System.IO.Unsafe         (unsafePerformIO)
-#endif
 
-#ifdef __GLASGOW_HASKELL__
-import GHC.ForeignPtr           (newForeignPtr_, mallocPlainForeignPtrBytes)
-import GHC.Ptr                  (Ptr(..), castPtr)
-#else
-import Foreign.ForeignPtr       (mallocForeignPtrBytes)
-#endif
-
-#ifdef __GLASGOW_HASKELL__
-import GHC.ForeignPtr           (ForeignPtr(ForeignPtr))
 import GHC.Base                 (nullAddr#)
-#else
-import Foreign.Ptr              (nullPtr)
-#endif
-
-#if __HUGS__
-import Hugs.ForeignPtr          (newForeignPtr_)
-#elif __GLASGOW_HASKELL__<=604
-import Foreign.ForeignPtr       (newForeignPtr_)
-#endif
+import GHC.ForeignPtr           (ForeignPtr(ForeignPtr)
+                                ,newForeignPtr_, mallocPlainForeignPtrBytes)
+import GHC.Ptr                  (Ptr(..), castPtr)
 
 -- CFILES stuff is Hugs only
 {-# CFILES cbits/fpstring.c #-}
-
--- An alternative to Control.Exception (assert) for nhc98
-#ifdef __NHC__
-#define assert  assertS "__FILE__ : __LINE__"
-assertS :: String -> Bool -> a -> a
-assertS _ True  = id
-assertS s False = error ("assertion failed at "++s)
-#endif
-
 
 -- -----------------------------------------------------------------------------
 
@@ -188,10 +142,7 @@ assertS s False = error ("assertion failed at "++s)
 data ByteString = PS {-# UNPACK #-} !(ForeignPtr Word8) -- payload
                      {-# UNPACK #-} !Int                -- offset
                      {-# UNPACK #-} !Int                -- length
-
-#if defined(__GLASGOW_HASKELL__)
     deriving (Typeable)
-#endif
 
 instance Eq  ByteString where
     (==)    = eq
@@ -213,20 +164,14 @@ instance Show ByteString where
 instance Read ByteString where
     readsPrec p str = [ (packChars x, y) | (x, y) <- readsPrec p str ]
 
-#if MIN_VERSION_base(3,0,0)
 instance IsString ByteString where
     fromString = packChars
-#endif
 
 instance Data ByteString where
   gfoldl f z txt = z packBytes `f` (unpackBytes txt)
   toConstr _     = error "Data.ByteString.ByteString.toConstr"
   gunfold _ _    = error "Data.ByteString.ByteString.gunfold"
-#if MIN_VERSION_base(4,2,0)
   dataTypeOf _   = mkNoRepType "Data.ByteString.ByteString"
-#else
-  dataTypeOf _   = mkNorepType "Data.ByteString.ByteString"
-#endif
 
 ------------------------------------------------------------------------
 -- Packing and unpacking from lists
@@ -237,14 +182,12 @@ packBytes ws = unsafePackLenBytes (List.length ws) ws
 packChars :: [Char] -> ByteString
 packChars cs = unsafePackLenChars (List.length cs) cs
 
-#if defined(__GLASGOW_HASKELL__)
 {-# INLINE [0] packChars #-}
 
 {-# RULES
 "ByteString packChars/packAddress" forall s .
    packChars (unpackCString# s) = accursedUnutterablePerformIO (unsafePackAddress s)
  #-}
-#endif
 
 unsafePackLenBytes :: Int -> [Word8] -> ByteString
 unsafePackLenBytes len xs0 =
@@ -260,7 +203,7 @@ unsafePackLenChars len cs0 =
     go !_ []     = return ()
     go !p (c:cs) = poke p (c2w c) >> go (p `plusPtr` 1) cs
 
-#if defined(__GLASGOW_HASKELL__)
+
 -- | /O(n)/ Pack a null-terminated sequence of bytes, pointed to by an
 -- Addr\# (an arbitrary machine address assumed to point outside the
 -- garbage-collected heap) into a @ByteString@. A much faster way to
@@ -291,7 +234,7 @@ unsafePackAddress addr# = do
     cstr :: CString
     cstr = Ptr addr#
 {-# INLINE unsafePackAddress #-}
-#endif
+
 
 packUptoLenBytes :: Int -> [Word8] -> (ByteString, [Word8])
 packUptoLenBytes len xs0 =
@@ -373,12 +316,7 @@ unpackAppendCharsStrict (PS fp off len) xs =
 
 -- | The 0 pointer. Used to indicate the empty Bytestring.
 nullForeignPtr :: ForeignPtr Word8
-#ifdef __GLASGOW_HASKELL__
 nullForeignPtr = ForeignPtr nullAddr# (error "nullForeignPtr") --TODO: should ForeignPtrContents be strict?
-#else
-nullForeignPtr = unsafePerformIO $ newForeignPtr_ nullPtr
-{-# NOINLINE nullForeignPtr #-}
-#endif
 
 -- ---------------------------------------------------------------------
 -- Low level constructors
@@ -418,12 +356,6 @@ unsafeCreateUptoN l f = unsafeDupablePerformIO (createUptoN l f)
 unsafeCreateUptoN' :: Int -> (Ptr Word8 -> IO (Int, a)) -> (ByteString, a)
 unsafeCreateUptoN' l f = unsafeDupablePerformIO (createUptoN' l f)
 {-# INLINE unsafeCreateUptoN' #-}
-
-#ifndef __GLASGOW_HASKELL__
--- for Hugs, NHC etc
-unsafeDupablePerformIO :: IO a -> a
-unsafeDupablePerformIO = unsafePerformIO
-#endif
 
 -- | Create ByteString of size @l@ and use action @f@ to fill it's contents.
 create :: Int -> (Ptr Word8 -> IO ()) -> IO ByteString
@@ -482,12 +414,7 @@ createAndTrim' l f = do
 -- | Wrapper of 'mallocForeignPtrBytes' with faster implementation for GHC
 --
 mallocByteString :: Int -> IO (ForeignPtr a)
-mallocByteString l = do
-#ifdef __GLASGOW_HASKELL__
-    mallocPlainForeignPtrBytes l
-#else
-    mallocForeignPtrBytes l
-#endif
+mallocByteString l = mallocPlainForeignPtrBytes l
 {-# INLINE mallocByteString #-}
 
 ------------------------------------------------------------------------
@@ -545,11 +472,7 @@ checkedSum fun = go 0
 
 -- | Conversion between 'Word8' and 'Char'. Should compile to a no-op.
 w2c :: Word8 -> Char
-#if !defined(__GLASGOW_HASKELL__)
-w2c = chr . fromIntegral
-#else
 w2c = unsafeChr . fromIntegral
-#endif
 {-# INLINE w2c #-}
 
 -- | Unsafe conversion between 'Char' and 'Word8'. This is a no-op and
@@ -615,11 +538,7 @@ overflowError fun = error $ "Data.ByteString." ++ fun ++ ": size overflow"
 --
 {-# INLINE accursedUnutterablePerformIO #-}
 accursedUnutterablePerformIO :: IO a -> a
-#if defined(__GLASGOW_HASKELL__)
 accursedUnutterablePerformIO (IO m) = case m realWorld# of (# _, r #) -> r
-#else
-accursedUnutterablePerformIO = unsafePerformIO
-#endif
 
 inlinePerformIO :: IO a -> a
 inlinePerformIO = accursedUnutterablePerformIO

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -233,11 +233,7 @@ import System.IO                (Handle,stdin,stdout,openBinaryFile,IOMode(..)
                                 ,hClose)
 import System.IO.Error          (mkIOError, illegalOperationErrorType)
 import System.IO.Unsafe
-#ifndef __NHC__
 import Control.Exception        (bracket)
-#else
-import IO		        (bracket)
-#endif
 
 import Foreign.ForeignPtr       (withForeignPtr)
 import Foreign.Ptr
@@ -1172,7 +1168,6 @@ hGetN _ h n = illegalBufferSize h "hGet" n
 -- is available. Chunks are read on demand, in @k@-sized chunks.
 --
 hGetNonBlockingN :: Int -> Handle -> Int -> IO ByteString
-#if defined(__GLASGOW_HASKELL__)
 hGetNonBlockingN k h n | n > 0= readChunks n
   where
     readChunks !i = do
@@ -1184,9 +1179,6 @@ hGetNonBlockingN k h n | n > 0= readChunks n
 
 hGetNonBlockingN _ _ 0 = return Empty
 hGetNonBlockingN _ h n = illegalBufferSize h "hGetNonBlocking" n
-#else
-hGetNonBlockingN = hGetN
-#endif
 
 illegalBufferSize :: Handle -> String -> Int -> IO a
 illegalBufferSize handle fn sz =
@@ -1220,12 +1212,8 @@ hGet = hGetN defaultChunkSize
 -- Note: on Windows and with Haskell implementation other than GHC, this
 -- function does not work correctly; it behaves identically to 'hGet'.
 --
-#if defined(__GLASGOW_HASKELL__)
 hGetNonBlocking :: Handle -> Int -> IO ByteString
 hGetNonBlocking = hGetNonBlockingN defaultChunkSize
-#else
-hGetNonBlocking = hGet
-#endif
 
 -- | Read an entire file /lazily/ into a 'ByteString'.
 -- The Handle will be held open until EOF is encountered.

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -223,12 +223,7 @@ import Prelude hiding
         ,zip,zipWith,unzip,notElem,repeat,iterate,interact,cycle)
 
 import System.IO            (Handle,stdout,hClose,openBinaryFile,IOMode(..))
-#ifndef __NHC__
 import Control.Exception    (bracket)
-#else
-import IO                   (bracket)
-#endif
-
 
 ------------------------------------------------------------------------
 

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface, BangPatterns #-}
-#if __GLASGOW_HASKELL__
 {-# LANGUAGE DeriveDataTypeable #-}
 #if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 #endif
 {-# OPTIONS_HADDOCK hide #-}
 
@@ -58,21 +56,10 @@ import Data.Monoid      (Monoid(..))
 #endif
 import Control.DeepSeq  (NFData, rnf)
 
-#if MIN_VERSION_base(3,0,0)
 import Data.String      (IsString(..))
-#endif
 
 import Data.Typeable            (Typeable)
-#if MIN_VERSION_base(4,1,0)
-import Data.Data                (Data(..))
-#if MIN_VERSION_base(4,2,0)
-import Data.Data                (mkNoRepType)
-#else
-import Data.Data                (mkNorepType)
-#endif
-#else
-import Data.Generics            (Data(..), mkNorepType)
-#endif
+import Data.Data                (Data(..), mkNoRepType)
 
 -- | A space-efficient representation of a 'Word8' vector, supporting many
 -- efficient operations.
@@ -82,10 +69,7 @@ import Data.Generics            (Data(..), mkNorepType)
 -- 8-bit characters.
 --
 data ByteString = Empty | Chunk {-# UNPACK #-} !S.ByteString ByteString
-
-#if defined(__GLASGOW_HASKELL__)
     deriving (Typeable)
-#endif
 
 instance Eq  ByteString where
     (==)    = eq
@@ -108,20 +92,14 @@ instance Show ByteString where
 instance Read ByteString where
     readsPrec p str = [ (packChars x, y) | (x, y) <- readsPrec p str ]
 
-#if MIN_VERSION_base(3,0,0)
 instance IsString ByteString where
     fromString = packChars
-#endif
 
 instance Data ByteString where
   gfoldl f z txt = z packBytes `f` unpackBytes txt
   toConstr _     = error "Data.ByteString.Lazy.ByteString.toConstr"
   gunfold _ _    = error "Data.ByteString.Lazy.ByteString.gunfold"
-#if MIN_VERSION_base(4,2,0)
   dataTypeOf _   = mkNoRepType "Data.ByteString.Lazy.ByteString"
-#else
-  dataTypeOf _   = mkNorepType "Data.ByteString.Lazy.ByteString"
-#endif
 
 ------------------------------------------------------------------------
 -- Packing and unpacking from lists

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -152,11 +152,7 @@ instance Data ShortByteString where
   gfoldl f z txt = z packBytes `f` (unpackBytes txt)
   toConstr _     = error "Data.ByteString.Short.ShortByteString.toConstr"
   gunfold _ _    = error "Data.ByteString.Short.ShortByteString.gunfold"
-#if MIN_VERSION_base(4,2,0)
   dataTypeOf _   = mkNoRepType "Data.ByteString.Short.ShortByteString"
-#else
-  dataTypeOf _   = mkNorepType "Data.ByteString.Short.ShortByteString"
-#endif
 
 ------------------------------------------------------------------------
 -- Simple operations

--- a/Data/ByteString/Unsafe.hs
+++ b/Data/ByteString/Unsafe.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__
 {-# LANGUAGE MagicHash #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
 #endif
@@ -43,12 +41,10 @@ module Data.ByteString.Unsafe (
         unsafePackMallocCString,-- :: CString -> IO ByteString
         unsafePackMallocCStringLen, -- :: CStringLen -> IO ByteString
 
-#if defined(__GLASGOW_HASKELL__)
         unsafePackAddress,          -- :: Addr# -> IO ByteString
         unsafePackAddressLen,       -- :: Int -> Addr# -> IO ByteString
         unsafePackCStringFinalizer, -- :: Ptr Word8 -> Int -> IO () -> IO ByteString
         unsafeFinalize,             -- :: ByteString -> IO ()
-#endif
 
   ) where
 
@@ -60,30 +56,15 @@ import Foreign.Ptr              (Ptr, plusPtr, castPtr)
 import Foreign.Storable         (Storable(..))
 import Foreign.C.String         (CString, CStringLen)
 
-#ifndef __NHC__
 import Control.Exception        (assert)
-#endif
 
 import Data.Word                (Word8)
 
-#if defined(__GLASGOW_HASKELL__)
 import qualified Foreign.ForeignPtr as FC (finalizeForeignPtr)
 import qualified Foreign.Concurrent as FC (newForeignPtr)
 
---import Data.Generics            (Data(..), Typeable(..))
-
 import GHC.Prim                 (Addr#)
 import GHC.Ptr                  (Ptr(..))
-#endif
-
--- An alternative to Control.Exception (assert) for nhc98
-#ifdef __NHC__
-#define assert	assertS "__FILE__ : __LINE__"
-assertS :: String -> Bool -> a -> a
-assertS _ True  = id
-assertS s False = error ("assertion failed at "++s)
-#endif
-
 
 -- ---------------------------------------------------------------------
 --
@@ -142,7 +123,6 @@ unsafeDrop n (PS x s l) = assert (0 <= n && n <= l) $ PS x (s+n) (l-n)
 {-# INLINE unsafeDrop #-}
 
 
-#if defined(__GLASGOW_HASKELL__)
 -- | /O(1)/ 'unsafePackAddressLen' provides constant-time construction of
 -- 'ByteString's, which is ideal for string literals. It packs a sequence
 -- of bytes into a @ByteString@, given a raw 'Addr#' to the string, and
@@ -191,8 +171,6 @@ unsafePackCStringFinalizer p l f = do
 --
 unsafeFinalize :: ByteString -> IO ()
 unsafeFinalize (PS p _ _) = FC.finalizeForeignPtr p
-
-#endif
 
 ------------------------------------------------------------------------
 -- Packing CStrings into ByteStrings

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -39,9 +39,7 @@ import           Data.ByteString.Builder.Prim.TestUtils
 
 import           Control.Exception (evaluate)
 import           System.IO (openTempFile, hPutStr, hClose, hSetBinaryMode)
-#if MIN_VERSION_base(4,2,0)
 import           System.IO (hSetEncoding, utf8)
-#endif
 import           System.Directory
 import           Foreign (ForeignPtr, withForeignPtr, castPtr)
 
@@ -61,9 +59,7 @@ import           Test.QuickCheck.Property
 tests :: [Test]
 tests =
   [ testBuilderRecipe
-#if MIN_VERSION_base(4,2,0)
   , testHandlePutBuilder
-#endif
   , testHandlePutBuilderChar8
   , testPut
   , testRunBuilder
@@ -96,7 +92,6 @@ testBuilderRecipe =
           , "diff  : " ++ show (dropWhile (uncurry (==)) $ zip x1 x2)
           ]
 
-#if MIN_VERSION_base(4,2,0)
 testHandlePutBuilder :: Test
 testHandlePutBuilder =
     testProperty "hPutBuilder" testRecipe
@@ -132,7 +127,6 @@ testHandlePutBuilder =
             success = lbs == lbsRef
         unless success (error msg)
         return success
-#endif
 
 testHandlePutBuilderChar8 :: Test
 testHandlePutBuilderChar8 =


### PR DESCRIPTION
This assumes that `__GLASGOW_HASKELL__` is 612 or later, as well as
`base >= 4.2` (c.f. `bytestring.cabal`).