### PR TITLE
Revert "`cabal repl` error"

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -125,7 +125,6 @@ library
                     -fmax-simplifier-iterations=10
                     -fdicts-cheap
                     -fspec-constr-count=6
-                    -fobject-code
 
   c-sources:         cbits/fpstring.c
                      cbits/itoa.c


### PR DESCRIPTION
Reverts haskell/bytestring#46