### PR TITLE
Bump test-builder dlist upper bound to 0.9

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -200,7 +200,7 @@ test-suite test-builder
                     deepseq,
                     QuickCheck                 >= 2.4,
                     byteorder                  == 1.0.*,
-                    dlist                      >= 0.5 && < 0.8,
+                    dlist                      >= 0.5 && < 0.9,
                     directory,
                     mtl                        >= 2.0 && < 2.3,
                     HUnit,


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `bytestring`, but I don't think it will be break anything.