### PR TITLE
Fixed issue #56, split x empty

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -950,10 +950,10 @@ spanEnd  p ps = splitAt (findFromEndUntil (not.p) ps) ps
 -- separators result in an empty component in the output.  eg.
 --
 -- > splitWith (=='a') "aabbaca" == ["","","bb","c",""]
--- > splitWith (=='a') []        == []
+-- > splitWith (=='a') ""        == [""]
 --
 splitWith :: (Word8 -> Bool) -> ByteString -> [ByteString]
-splitWith _pred (PS _  _   0) = []
+splitWith _pred ps@(PS _  _   0) = [ps]
 splitWith pred_ (PS fp off len) = splitWith0 pred# off len fp
   where pred# c# = pred_ (W8# c#)
 
@@ -984,6 +984,8 @@ splitWith pred_ (PS fp off len) = splitWith0 pred# off len fp
 -- > split '\n' "a\nb\nd\ne" == ["a","b","d","e"]
 -- > split 'a'  "aXaXaXa"    == ["","X","X","X",""]
 -- > split 'x'  "x"          == ["",""]
+-- > split 'x'  ""           == [""]
+-- > length (split a b)      == 1 + length (elemIndices a b)
 --
 -- and
 --
@@ -995,7 +997,7 @@ splitWith pred_ (PS fp off len) = splitWith0 pred# off len fp
 -- are slices of the original.
 --
 split :: Word8 -> ByteString -> [ByteString]
-split _ (PS _ _ 0) = []
+split _ ps@(PS _ _ 0) = [ps]
 split w (PS x s l) = loop 0
     where
         loop !n =

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -769,10 +769,10 @@ span p = break (not . p)
 -- separators result in an empty component in the output.  eg.
 --
 -- > splitWith (=='a') "aabbaca" == ["","","bb","c",""]
--- > splitWith (=='a') []        == []
+-- > splitWith (=='a') ""        == [""]
 --
 splitWith :: (Word8 -> Bool) -> ByteString -> [ByteString]
-splitWith _ Empty          = []
+splitWith _ Empty          = [Empty]
 splitWith p (Chunk c0 cs0) = comb [] (S.splitWith p c0) cs0
 
   where comb :: [P.ByteString] -> [P.ByteString] -> ByteString -> [ByteString]
@@ -798,7 +798,7 @@ splitWith p (Chunk c0 cs0) = comb [] (S.splitWith p c0) cs0
 -- are slices of the original.
 --
 split :: Word8 -> ByteString -> [ByteString]
-split _ Empty     = []
+split _ Empty     = [Empty]
 split w (Chunk c0 cs0) = comb [] (S.split w c0) cs0
 
   where comb :: [P.ByteString] -> [P.ByteString] -> ByteString -> [ByteString]

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -708,19 +708,19 @@ prop_span xs a = (span (/=a) xs) == (let (x,y) = L.span (/=a) (pack xs) in (unpa
 prop_split c xs = (map L.unpack . map checkInvariant . L.split c $ xs)
                == (map P.unpack . P.split c . P.pack . L.unpack $ xs)
 
-prop_splitWith f xs = (l1 == l2 || l1 == l2+1) &&
+prop_splitWith f xs = l1 == l2+1 &&
         sum (map L.length splits) == L.length xs - l2
   where splits = L.splitWith f xs
         l1 = fromIntegral (length splits)
         l2 = L.length (L.filter f xs)
 
-prop_splitWith_D f xs = (l1 == l2 || l1 == l2+1) &&
+prop_splitWith_D f xs = l1 == l2+1 &&
         sum (map D.length splits) == D.length xs - l2
   where splits = D.splitWith f xs
         l1 = fromIntegral (length splits)
         l2 = D.length (D.filter f xs)
 
-prop_splitWith_C f xs = (l1 == l2 || l1 == l2+1) &&
+prop_splitWith_C f xs = l1 == l2+1 &&
         sum (map C.length splits) == C.length xs - l2
   where splits = C.splitWith f xs
         l1 = fromIntegral (length splits)
@@ -878,7 +878,7 @@ prop_wordsLC xs =
 prop_unwordsSBB xss = C.unwords (map C.pack xss) == C.pack (unwords xss)
 prop_unwordsSLC xss = LC.unwords (map LC.pack xss) == LC.pack (unwords xss)
 
-prop_splitWithBB f xs = (l1 == l2 || l1 == l2+1) &&
+prop_splitWithBB f xs = l1 == l2+1 &&
         sum (map P.length splits) == P.length xs - l2
   where splits = P.splitWith f xs
         l1 = length splits


### PR DESCRIPTION
This seemed like the safest way. Here's a new pull request to replace [pull request #92](https://github.com/haskell/bytestring/pull/92). It contains only the fix for issue #56.
