### PR TITLE
Fix “iff” typos

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1271,7 +1271,7 @@ isPrefixOf (PS x1 s1 l1) (PS x2 s2 l2)
             return $! i == 0
 
 -- | /O(n)/ The 'stripPrefix' function takes two ByteStrings and returns 'Just'
--- the remainder of the second iff the first is its prefix, and otherwise
+-- the remainder of the second if the first is its prefix, and otherwise
 -- 'Nothing'.
 stripPrefix :: ByteString -> ByteString -> Maybe ByteString
 stripPrefix bs1@(PS _ _ l1) bs2
@@ -1279,7 +1279,7 @@ stripPrefix bs1@(PS _ _ l1) bs2
    | otherwise = Nothing
 
 -- | /O(n)/ The 'isSuffixOf' function takes two ByteStrings and returns 'True'
--- iff the first is a suffix of the second.
+-- if the first is a suffix of the second.
 --
 -- The following holds:
 --
@@ -1297,7 +1297,7 @@ isSuffixOf (PS x1 s1 l1) (PS x2 s2 l2)
             return $! i == 0
 
 -- | /O(n)/ The 'stripSuffix' function takes two ByteStrings and returns 'Just'
--- the remainder of the second iff the first is its suffix, and otherwise
+-- the remainder of the second if the first is its suffix, and otherwise
 -- 'Nothing'.
 stripSuffix :: ByteString -> ByteString -> Maybe ByteString
 stripSuffix bs1@(PS _ _ l1) bs2@(PS _ _ l2)

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -1000,7 +1000,7 @@ maximalCopySize = 2 * L.smallChunkSize
 --
 -- states that the first buffer is of size @firstBufSize@, all following buffers
 -- are of size @bufSize@, and a buffer of size @n@ filled with @k@ bytes should
--- be trimmed iff @trim k n@ is 'True'.
+-- be trimmed if @trim k n@ is 'True'.
 data AllocationStrategy = AllocationStrategy
          (Maybe (Buffer, Int) -> IO Buffer)
          {-# UNPACK #-} !Int

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1023,7 +1023,7 @@ partition p (Chunk x xs) = (chunk t ts, chunk f fs)
 -- Searching for substrings
 
 -- | /O(n)/ The 'isPrefixOf' function takes two ByteStrings and returns 'True'
--- iff the first is a prefix of the second.
+-- if the first is a prefix of the second.
 isPrefixOf :: ByteString -> ByteString -> Bool
 isPrefixOf Empty _  = True
 isPrefixOf _ Empty  = False
@@ -1035,7 +1035,7 @@ isPrefixOf (Chunk x xs) (Chunk y ys)
         (yh,yt) = S.splitAt (S.length x) y
 
 -- | /O(n)/ The 'stripPrefix' function takes two ByteStrings and returns 'Just'
--- the remainder of the second iff the first is its prefix, and otherwise
+-- the remainder of the second if the first is its prefix, and otherwise
 -- 'Nothing'.
 stripPrefix :: ByteString -> ByteString -> Maybe ByteString
 stripPrefix Empty bs  = Just bs
@@ -1048,7 +1048,7 @@ stripPrefix (Chunk x xs) (Chunk y ys)
                                     stripPrefix (Chunk xt xs) ys
 
 -- | /O(n)/ The 'isSuffixOf' function takes two ByteStrings and returns 'True'
--- iff the first is a suffix of the second.
+-- if the first is a suffix of the second.
 --
 -- The following holds:
 --
@@ -1059,7 +1059,7 @@ isSuffixOf x y = reverse x `isPrefixOf` reverse y
 --TODO: a better implementation
 
 -- | /O(n)/ The 'stripSuffix' function takes two ByteStrings and returns 'Just'
--- the remainder of the second iff the first is its suffix, and otherwise
+-- the remainder of the second if the first is its suffix, and otherwise
 -- 'Nothing'.
 stripSuffix :: ByteString -> ByteString -> Maybe ByteString
 stripSuffix x y = reverse <$> stripPrefix (reverse x) (reverse y)


### PR DESCRIPTION
It's a curious thing that the lib has so many “iff” typos, but I thought I'd better fix all of them.
