### PR TITLE
Reimplement floatDec/doubleDec

### DIFF
--- a/Data/ByteString/Builder.hs
+++ b/Data/ByteString/Builder.hs
@@ -252,6 +252,7 @@ module Data.ByteString.Builder
     , stringUtf8
 
     , module Data.ByteString.Builder.ASCII
+    , module Data.ByteString.Builder.RealFloat
 
     ) where
 
@@ -259,6 +260,7 @@ import           Data.ByteString.Builder.Internal
 import qualified Data.ByteString.Builder.Prim  as P
 import qualified Data.ByteString.Lazy.Internal as L
 import           Data.ByteString.Builder.ASCII
+import           Data.ByteString.Builder.RealFloat
 
 import           Data.String (IsString(..))
 import           System.IO (Handle)
@@ -406,20 +408,6 @@ floatBE = P.primFixed P.floatBE
 {-# INLINE doubleBE #-}
 doubleBE :: Double -> Builder
 doubleBE = P.primFixed P.doubleBE
-
-------------------------------------------------------------------------------
--- ASCII encoding
-------------------------------------------------------------------------------
-
--- | Char7 encode a 'Char'.
-{-# INLINE char7 #-}
-char7 :: Char -> Builder
-char7 = P.primFixed P.char7
-
--- | Char7 encode a 'String'.
-{-# INLINE string7 #-}
-string7 :: String -> Builder
-string7 = P.primMapListFixed P.char7
 
 ------------------------------------------------------------------------------
 -- ISO/IEC 8859-1 encoding

--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -18,7 +18,7 @@ module Data.ByteString.Builder.ASCII
       -- | Formatting of numbers as ASCII text.
       --
       -- Note that you can also use these functions for the ISO/IEC 8859-1 and
-      -- UTF-8 encodings, as the ASCII encoding is equivalent on the 
+      -- UTF-8 encodings, as the ASCII encoding is equivalent on the
       -- codepoints 0-127.
 
       -- *** Decimal numbers
@@ -36,8 +36,8 @@ module Data.ByteString.Builder.ASCII
     , word64Dec
     , wordDec
 
-    , floatDec
-    , doubleDec
+    , char7
+    , string7
 
       -- *** Hexadecimal numbers
 
@@ -110,11 +110,15 @@ import GHC.Integer.GMP.Internals
 #endif
 
 ------------------------------------------------------------------------------
--- Decimal Encoding
+-- ASCII encoding
 ------------------------------------------------------------------------------
 
+-- | Char7 encode a 'Char'.
+{-# INLINE char7 #-}
+char7 :: Char -> Builder
+char7 = P.primFixed P.char7
 
--- | Encode a 'String' using 'P.char7'.
+-- | Char7 encode a 'String'.
 {-# INLINE string7 #-}
 string7 :: String -> Builder
 string7 = P.primMapListFixed P.char7
@@ -185,23 +189,6 @@ word64Dec = P.primBounded P.word64Dec
 {-# INLINE wordDec #-}
 wordDec :: Word -> Builder
 wordDec = P.primBounded P.wordDec
-
-
--- Floating point numbers
--------------------------
-
--- TODO: Use Bryan O'Sullivan's double-conversion package to speed it up.
-
--- | /Currently slow./ Decimal encoding of an IEEE 'Float'.
-{-# INLINE floatDec #-}
-floatDec :: Float -> Builder
-floatDec = string7 . show
-
--- | /Currently slow./ Decimal encoding of an IEEE 'Double'.
-{-# INLINE doubleDec #-}
-doubleDec :: Double -> Builder
-doubleDec = string7 . show
-
 
 ------------------------------------------------------------------------------
 -- Hexadecimal Encoding

--- a/Data/ByteString/Builder/RealFloat.hs
+++ b/Data/ByteString/Builder/RealFloat.hs
@@ -12,8 +12,8 @@
 
 module Data.ByteString.Builder.RealFloat
     ( FFFormat(..) -- TODO: add document to GHC.Float
-    , formatRealFloat
-    , formatRealDouble
+    , formatFloat
+    , formatDouble
     , floatDec
     , doubleDec
     , grisu3_sp
@@ -46,7 +46,7 @@ import           GHC.IO (unsafeDupablePerformIO)
 --
 {-# INLINE floatDec #-}
 floatDec :: Float -> Builder
-floatDec = formatRealFloat FFGeneric Nothing
+floatDec = formatFloat FFGeneric Nothing
 
 -- | Decimal encoding of an IEEE 'Double'.
 -- Using standard decimal notation for arguments whose absolute value lies
@@ -54,16 +54,16 @@ floatDec = formatRealFloat FFGeneric Nothing
 --
 {-# INLINE doubleDec #-}
 doubleDec :: Double -> Builder
-doubleDec = formatRealDouble FFGeneric Nothing
+doubleDec = formatDouble FFGeneric Nothing
 
 -- | Format single-precision float using drisu3 with dragon4 fallback.
 --
-{-# INLINE formatRealFloat #-}
-formatRealFloat :: FFFormat
-                -> Maybe Int  -- ^ Number of decimal places to render.
-                -> Float
-                -> Builder
-formatRealFloat fmt decs x
+{-# INLINE formatFloat #-}
+formatFloat :: FFFormat
+            -> Maybe Int  -- ^ Number of decimal places to render.
+            -> Float
+            -> Builder
+formatFloat fmt decs x
     | isNaN x                   = string7 "NaN"
     | isInfinite x              = if x < 0 then string7 "-Infinity" else string7 "Infinity"
     | x < 0                     = char7 '-' `append` doFmt fmt decs (digits (-x))
@@ -76,12 +76,12 @@ formatRealFloat fmt decs x
 
 -- | Format double-precision float using drisu3 with dragon4 fallback.
 --
-{-# INLINE formatRealDouble #-}
-formatRealDouble :: FFFormat
-                 -> Maybe Int  -- ^ Number of decimal places to render.
-                 -> Double
-                 -> Builder
-formatRealDouble fmt decs x
+{-# INLINE formatDouble #-}
+formatDouble :: FFFormat
+             -> Maybe Int  -- ^ Number of decimal places to render.
+             -> Double
+             -> Builder
+formatDouble fmt decs x
     | isNaN x                   = string7 "NaN"
     | isInfinite x              = if x < 0 then string7 "-Infinity" else string7 "Infinity"
     | x < 0                     = char7 '-' `append` doFmt fmt decs (digits (-x))

--- a/Data/ByteString/Builder/RealFloat.hs
+++ b/Data/ByteString/Builder/RealFloat.hs
@@ -23,7 +23,7 @@ import GHC.Show (intToDigit)
 import Foreign.Marshal (peekArray, alloca, allocaBytes)
 import Foreign.Ptr (Ptr)
 import Foreign.Storable (peek)
-import Foreign.C.Types (CDouble(..), CFloat(..),  CInt(..))
+import Foreign.C.Types
 import Data.Word (Word8)
 import qualified Data.ByteString.Builder.Prim  as P
 import Data.ByteString.Builder.ASCII (intDec, string7, char7)

--- a/Data/ByteString/Builder/RealFloat.hs
+++ b/Data/ByteString/Builder/RealFloat.hs
@@ -159,6 +159,6 @@ grisu3 d = unsafeDupablePerformIO $ do
                     else do
                         CInt len <- peek pLen
                         CInt e <- peek pE
-                        buf <- map fromIntegral <$> peekArray (fromIntegral len) pBuf
+                        buf <- map fromIntegral `fmap` peekArray (fromIntegral len) pBuf
                         let e' = fromIntegral (e + len)
                         e `seq` return $ Just (buf, e')

--- a/Data/ByteString/Builder/RealFloat.hs
+++ b/Data/ByteString/Builder/RealFloat.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE CPP, OverloadedStrings, ForeignFunctionInterface #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- |
+-- Module:    Data.ByteString.Builder.RealFloat
+-- Copyright: (c) 2016 Winter Han
+-- License:   BSD3-style (see LICENSE)
+--
+-- Write a floating point value to a 'Builder'.
+
+module Data.ByteString.Builder.RealFloat
+    ( FFFormat(..) -- TODO: add document to GHC.Float
+    , formatRealFloat
+    , formatRealDouble
+    , floatDec
+    , doubleDec
+    ) where
+
+import GHC.Float (FFFormat(..), floatToDigits, roundTo)
+import GHC.Show (intToDigit)
+import Foreign.Marshal (peekArray, alloca, allocaBytes)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (peek)
+import Foreign.C.Types (CDouble(..), CFloat(..),  CInt(..))
+import System.IO.Unsafe (unsafeDupablePerformIO)
+import Data.Word (Word8)
+import Data.ByteString.Builder.Internal (Builder)
+import qualified Data.ByteString.Builder.Prim  as P
+import Data.ByteString.Builder.ASCII (intDec, string7, char7)
+import Data.ByteString.Builder.Internal (empty)
+import Data.Monoid ((<>))
+
+-- Floating point numbers
+-------------------------
+
+-- | Decimal encoding of an IEEE 'Float'.
+-- using standard decimal notation for arguments whose absolute value lies
+-- between @0.1@ and @9,999,999@, and scientific notation otherwise.
+--
+{-# INLINE floatDec #-}
+floatDec :: Float -> Builder
+floatDec = formatRealFloat FFGeneric Nothing
+
+-- | Decimal encoding of an IEEE 'Double'.
+-- using standard decimal notation for arguments whose absolute value lies
+-- between @0.1@ and @9,999,999@, and scientific notation otherwise.
+--
+{-# INLINE doubleDec #-}
+doubleDec :: Double -> Builder
+doubleDec = formatRealDouble FFGeneric Nothing
+
+-- | Format single-precision float using dragon4(R.G. Burger and R.K. Dybvig).
+--
+formatRealFloat :: FFFormat
+                -> Maybe Int  -- ^ Number of decimal places to render.
+                -> Float
+                -> Builder
+formatRealFloat fmt decs x
+    | isNaN x                   = string7 "NaN"
+    | isInfinite x              = if x < 0 then string7 "-Infinity" else string7 "Infinity"
+    | x < 0 || isNegativeZero x = char7 '-' <> doFmt fmt decs (digits (-x))
+    | otherwise                 = doFmt fmt decs (digits x) -- Grisu only handles strictly positive finite numbers.
+  where
+    digits y = floatToDigits 10 y
+
+-- | Format double-precision float using drisu3 with dragon4 fallback.
+--
+formatRealDouble :: FFFormat
+                 -> Maybe Int  -- ^ Number of decimal places to render.
+                 -> Double
+                 -> Builder
+formatRealDouble fmt decs x
+    | isNaN x                   = string7 "NaN"
+    | isInfinite x              = if x < 0 then string7 "-Infinity" else string7 "Infinity"
+    | x < 0                     = char7 '-' <> doFmt fmt decs (digits (-x))
+    | isNegativeZero x          = string7 "-0.0"
+    | x == 0                    = string7 "0.0"
+    | otherwise                 = doFmt fmt decs (digits x) -- Grisu only handles strictly positive finite numbers.
+  where
+    digits y = case grisu3 y of Just r  -> r
+                                Nothing -> floatToDigits 10 y
+
+{-# INLINE doFmt #-}
+doFmt :: FFFormat -> Maybe Int -> ([Int], Int) -> Builder
+doFmt format decs (is, e) =
+    let ds = map intToDigit is
+    in case format of
+        FFGeneric ->
+            doFmt (if e < 0 || e > 7 then FFExponent else FFFixed) decs (is,e)
+        FFExponent ->
+            case decs of
+                Nothing ->
+                    let show_e' = intDec (e-1)
+                    in case ds of
+                        "0"     -> string7 "0.0e0"
+                        [d]     -> char7 d <> string7 ".0e" <> show_e'
+                        (d:ds') -> char7 d <> char7 '.' <> string7 ds' <> char7 'e' <> show_e'
+                        []      -> error "doFmt/Exponent: []"
+                Just dec ->
+                    let dec' = max dec 1 in
+                    case is of
+                        [0] -> char7 '0' <> char7 '.' <>
+                                string7 (replicate dec' '0') <> char7 'e' <> char7 '0'
+                        _ ->
+                            let (ei,is') = roundTo 10 (dec'+1) is
+                                (d:ds') = map intToDigit (if ei > 0 then init is' else is')
+                            in char7 d <> char7 '.' <> string7 ds' <> char7 'e' <> intDec (e-1+ei)
+        FFFixed ->
+            let mk0 ls = case ls of { "" -> char7 '0' ; _ -> string7 ls}
+            in case decs of
+                Nothing
+                    | e <= 0    -> char7 '0' <> char7 '.' <>
+                                    string7 (replicate (-e) '0') <> string7 ds
+                    | otherwise ->
+                        let f 0 s    rs  = mk0 (reverse s) <> char7 '.' <> mk0 rs
+                            f n s    ""  = f (n-1) ('0':s) ""
+                            f n s (r:rs) = f (n-1) (r:s) rs
+                        in f e "" ds
+                Just dec ->
+                    let dec' = max dec 0
+                    in if e >= 0
+                        then
+                            let (ei,is') = roundTo 10 (dec' + e) is
+                                (ls,rs)  = splitAt (e+ei) (map intToDigit is')
+                            in mk0 ls <> (if null rs then empty else char7 '.' <> string7 rs)
+                        else
+                            let (ei,is') = roundTo 10 dec' (replicate (-e) 0 ++ is)
+                                d:ds' = map intToDigit (if ei > 0 then is' else 0:is')
+                            in char7 d <> (if null ds' then empty else char7 '.' <> string7 ds')
+
+------------------------------------------------------------------------------
+-- Conversion of 'Float's and 'Double's to ASCII in decimal using Grisu3
+------------------------------------------------------------------------
+
+#define GRISU3_BUF_LEN 18
+
+foreign import ccall unsafe "static grisu3" c_grisu3
+    :: CDouble -> Ptr Word8 -> Ptr CInt -> Ptr CInt -> IO CInt
+
+-- | Decimal encoding of a 'Double'.
+{-# INLINE grisu3 #-}
+grisu3 :: Double -> Maybe ([Int], Int)
+grisu3 d = unsafeDupablePerformIO $ do
+    allocaBytes GRISU3_BUF_LEN $ \ pBuf ->
+        alloca $ \ pLen ->
+            alloca $ \ pE -> do
+                success <- c_grisu3 (CDouble d) pBuf pLen pE
+                if success == 0 -- grisu3 fail, fall back to Dragon4
+                    then return Nothing
+                    else do
+                        CInt len <- peek pLen
+                        CInt e <- peek pE
+                        buf <- map fromIntegral <$> peekArray (fromIntegral len) pBuf
+                        let e' = fromIntegral (e + len)
+                        e `seq` return $ Just (buf, e')

--- a/Data/ByteString/Builder/RealFloat.hs
+++ b/Data/ByteString/Builder/RealFloat.hs
@@ -153,12 +153,12 @@ grisu3 d = unsafeDupablePerformIO $ do
     allocaBytes GRISU3_BUF_LEN $ \ pBuf ->
         alloca $ \ pLen ->
             alloca $ \ pE -> do
-                success <- c_grisu3 (CDouble d) pBuf pLen pE
+                success <- c_grisu3 (realToFrac d) pBuf pLen pE
                 if success == 0 -- grisu3 fail, fall back to Dragon4
                     then return Nothing
                     else do
-                        CInt len <- peek pLen
-                        CInt e <- peek pE
+                        len <- peek pLen
+                        e <- peek pE
                         buf <- map fromIntegral `fmap` peekArray (fromIntegral len) pBuf
                         let e' = fromIntegral (e + len)
-                        e `seq` return $ Just (buf, e')
+                        e' `seq` return $ Just (buf, e')

--- a/Data/ByteString/Builder/RealFloat.hs
+++ b/Data/ByteString/Builder/RealFloat.hs
@@ -56,6 +56,7 @@ doubleDec = formatRealDouble FFGeneric Nothing
 
 -- | Format single-precision float using dragon4(R.G. Burger and R.K. Dybvig).
 --
+{-# INLINE formatRealFloat #-}
 formatRealFloat :: FFFormat
                 -> Maybe Int  -- ^ Number of decimal places to render.
                 -> Float
@@ -64,12 +65,13 @@ formatRealFloat fmt decs x
     | isNaN x                   = string7 "NaN"
     | isInfinite x              = if x < 0 then string7 "-Infinity" else string7 "Infinity"
     | x < 0 || isNegativeZero x = char7 '-' `append` doFmt fmt decs (digits (-x))
-    | otherwise                 = doFmt fmt decs (digits x) -- Grisu only handles strictly positive finite numbers.
+    | otherwise                 = doFmt fmt decs (digits x)
   where
     digits y = floatToDigits 10 y
 
 -- | Format double-precision float using drisu3 with dragon4 fallback.
 --
+{-# INLINE formatRealDouble #-}
 formatRealDouble :: FFFormat
                  -> Maybe Int  -- ^ Number of decimal places to render.
                  -> Double

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -40,6 +40,7 @@ import           Foreign
 
 import System.Random
 
+import Paths_bench_bytestring
 
 ------------------------------------------------------------------------------
 -- Benchmark support
@@ -133,7 +134,7 @@ benchFE name = benchBE name . P.liftFixedToBounded
 {-# INLINE benchBE #-}
 benchBE :: String -> BoundedPrim Int -> Benchmark
 benchBE name e =
-  bench (name ++" (" ++ show nRepl ++ ")") $ benchIntEncodingB nRepl e
+  bench (name ++" (" ++ show nRepl ++ ")") $ whnfIO $ benchIntEncodingB nRepl e
 
 -- We use this construction of just looping through @n,n-1,..,1@ to ensure that
 -- we measure the speed of the encoding and not the speed of generating the
@@ -166,7 +167,7 @@ w :: Int -> Word8
 w = fromIntegral
 
 hashWord8 :: Word8 -> Word8
-hashWord8 = fromIntegral . hashInt . w
+hashWord8 = fromIntegral . hashInt . fromIntegral
 
 partitionStrict p = nf (S.partition p) . randomStrict $ mkStdGen 98423098
   where randomStrict = fst . S.unfoldrN 10000 (Just . random)
@@ -269,7 +270,9 @@ main = do
         [ benchB "byteStringHex"           byteStringData     $ byteStringHex
         , benchB "lazyByteStringHex"       lazyByteStringData $ lazyByteStringHex
         , benchB "foldMap floatDec"        floatData          $ foldMap floatDec
+        , benchB "foldMap show float"      floatData          $ foldMap (string7 . show)
         , benchB "foldMap doubleDec"       doubleData         $ foldMap doubleDec
+        , benchB "foldMap show double"     doubleData         $ foldMap (string7 . show)
           -- Note that the small data corresponds to the intData pre-converted
           -- to Integer.
         , benchB "foldMap integerDec (small)"                     smallIntegerData        $ foldMap integerDec

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -38,7 +38,7 @@ executable bench-bytestring-builder
   build-depends:     base >= 4 && < 5
                    , ghc-prim
                    , deepseq       >= 1.2
-                   , criterion     >= 0.5
+                   , criterion     >= 1.0
                    , blaze-textual == 0.2.*
                    , blaze-builder == 0.3.*
                    -- we require bytestring due to benchmarking against

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -50,6 +50,7 @@ executable bench-bytestring-builder
   -- which probably don't work on windows.
   c-sources:         ../cbits/fpstring.c
                      ../cbits/itoa.c
+                     ../cbits/dtoa.c
   include-dirs:      ../include
   includes:          fpstring.h
   install-includes:  fpstring.h
@@ -124,6 +125,7 @@ executable bench-builder-boundscheck
                     criterion
   c-sources:        ../cbits/fpstring.c
                     ../cbits/itoa.c
+                    ../cbits/dtoa.c
   include-dirs:     ../include
   ghc-options:      -O2
                     -fmax-simplifier-iterations=10

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -95,6 +95,7 @@ library
                      Data.ByteString.Lazy.Builder.ASCII
   other-modules:
                      Data.ByteString.Builder.ASCII
+                     Data.ByteString.Builder.RealFloat
                      Data.ByteString.Builder.Prim.Binary
                      Data.ByteString.Builder.Prim.ASCII
                      Data.ByteString.Builder.Prim.Internal.Floating
@@ -128,6 +129,7 @@ library
 
   c-sources:         cbits/fpstring.c
                      cbits/itoa.c
+                     cbits/dtoa.c
   include-dirs:      include
   includes:          fpstring.h
   install-includes:  fpstring.h
@@ -220,6 +222,7 @@ test-suite test-builder
 
   c-sources:        cbits/fpstring.c
                     cbits/itoa.c
+                    cbits/dtoa.c
   include-dirs:     include
   includes:         fpstring.h
   install-includes: fpstring.h

--- a/cbits/dtoa.c
+++ b/cbits/dtoa.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright Winterland1989
  * Copyright author of MathGeoLib (https://github.com/juj)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -345,7 +346,7 @@ int grisu3_sp(float v, char *buffer, int *length, int *d_exp)
     diy_fp b_minus;
     diy_fp c_mk; // Cached power of ten: 10^-k
     uint64_t u32 = CAST_U32(v);
-    assert(v > 0 && v <= 3.40282e38); // Grisu only handles strictly positive finite numbers.
+    assert(v > 0 && v <= 3.4028235e38); // Grisu only handles strictly positive finite numbers.
     if (!(u32 & D32_FRACT_MASK) && (u32 & D32_EXP_MASK) != 0) {
         b_minus.f = (dfp.f << 2) - 1; b_minus.e =  dfp.e - 2;
     } // lower boundary is closer?

--- a/cbits/dtoa.c
+++ b/cbits/dtoa.c
@@ -1,0 +1,304 @@
+/*
+ * Copyright author of MathGeoLib (https://github.com/juj)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/*
+ * Extracted from MathGeoLib, modified by Winterland1989.
+ *
+ * MatGeoLib grisu3.c comment:
+ *
+ *     This file is part of an implementation of the "grisu3" double to string
+ *     conversion algorithm described in the research paper
+ *
+ *     "Printing Floating-Point Numbers Quickly And Accurately with Integers"
+ *     by Florian Loitsch, available at
+ *     http://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf
+ */
+
+#include <stdint.h> // uint64_t etc.
+#include <assert.h> // assert
+#include <math.h> // ceil
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4204) // nonstandard extension used : non-constant aggregate initializer
+#endif
+
+#define D64_SIGN         0x8000000000000000ULL
+#define D64_EXP_MASK     0x7FF0000000000000ULL
+#define D64_FRACT_MASK   0x000FFFFFFFFFFFFFULL
+#define D64_IMPLICIT_ONE 0x0010000000000000ULL
+#define D64_EXP_POS      52
+#define D64_EXP_BIAS     1075
+#define DIYFP_FRACT_SIZE 64
+#define D_1_LOG2_10      0.30102999566398114 // 1 / lg(10)
+#define MIN_TARGET_EXP   -60
+#define MASK32           0xFFFFFFFFULL
+
+#define CAST_U64(d) (*(uint64_t*)&d)
+#define MIN(x,y) ((x) <= (y) ? (x) : (y))
+#define MAX(x,y) ((x) >= (y) ? (x) : (y))
+
+#define MIN_CACHED_EXP -348
+#define CACHED_EXP_STEP 8
+
+typedef struct diy_fp
+{
+    uint64_t f;
+    int e;
+} diy_fp;
+
+typedef struct power
+{
+    uint64_t fract;
+    int16_t b_exp, d_exp;
+} power;
+
+static const power pow_cache[] =
+{
+    { 0xfa8fd5a0081c0288ULL, -1220, -348 },
+    { 0xbaaee17fa23ebf76ULL, -1193, -340 },
+    { 0x8b16fb203055ac76ULL, -1166, -332 },
+    { 0xcf42894a5dce35eaULL, -1140, -324 },
+    { 0x9a6bb0aa55653b2dULL, -1113, -316 },
+    { 0xe61acf033d1a45dfULL, -1087, -308 },
+    { 0xab70fe17c79ac6caULL, -1060, -300 },
+    { 0xff77b1fcbebcdc4fULL, -1034, -292 },
+    { 0xbe5691ef416bd60cULL, -1007, -284 },
+    { 0x8dd01fad907ffc3cULL,  -980, -276 },
+    { 0xd3515c2831559a83ULL,  -954, -268 },
+    { 0x9d71ac8fada6c9b5ULL,  -927, -260 },
+    { 0xea9c227723ee8bcbULL,  -901, -252 },
+    { 0xaecc49914078536dULL,  -874, -244 },
+    { 0x823c12795db6ce57ULL,  -847, -236 },
+    { 0xc21094364dfb5637ULL,  -821, -228 },
+    { 0x9096ea6f3848984fULL,  -794, -220 },
+    { 0xd77485cb25823ac7ULL,  -768, -212 },
+    { 0xa086cfcd97bf97f4ULL,  -741, -204 },
+    { 0xef340a98172aace5ULL,  -715, -196 },
+    { 0xb23867fb2a35b28eULL,  -688, -188 },
+    { 0x84c8d4dfd2c63f3bULL,  -661, -180 },
+    { 0xc5dd44271ad3cdbaULL,  -635, -172 },
+    { 0x936b9fcebb25c996ULL,  -608, -164 },
+    { 0xdbac6c247d62a584ULL,  -582, -156 },
+    { 0xa3ab66580d5fdaf6ULL,  -555, -148 },
+    { 0xf3e2f893dec3f126ULL,  -529, -140 },
+    { 0xb5b5ada8aaff80b8ULL,  -502, -132 },
+    { 0x87625f056c7c4a8bULL,  -475, -124 },
+    { 0xc9bcff6034c13053ULL,  -449, -116 },
+    { 0x964e858c91ba2655ULL,  -422, -108 },
+    { 0xdff9772470297ebdULL,  -396, -100 },
+    { 0xa6dfbd9fb8e5b88fULL,  -369,  -92 },
+    { 0xf8a95fcf88747d94ULL,  -343,  -84 },
+    { 0xb94470938fa89bcfULL,  -316,  -76 },
+    { 0x8a08f0f8bf0f156bULL,  -289,  -68 },
+    { 0xcdb02555653131b6ULL,  -263,  -60 },
+    { 0x993fe2c6d07b7facULL,  -236,  -52 },
+    { 0xe45c10c42a2b3b06ULL,  -210,  -44 },
+    { 0xaa242499697392d3ULL,  -183,  -36 },
+    { 0xfd87b5f28300ca0eULL,  -157,  -28 },
+    { 0xbce5086492111aebULL,  -130,  -20 },
+    { 0x8cbccc096f5088ccULL,  -103,  -12 },
+    { 0xd1b71758e219652cULL,   -77,   -4 },
+    { 0x9c40000000000000ULL,   -50,    4 },
+    { 0xe8d4a51000000000ULL,   -24,   12 },
+    { 0xad78ebc5ac620000ULL,     3,   20 },
+    { 0x813f3978f8940984ULL,    30,   28 },
+    { 0xc097ce7bc90715b3ULL,    56,   36 },
+    { 0x8f7e32ce7bea5c70ULL,    83,   44 },
+    { 0xd5d238a4abe98068ULL,   109,   52 },
+    { 0x9f4f2726179a2245ULL,   136,   60 },
+    { 0xed63a231d4c4fb27ULL,   162,   68 },
+    { 0xb0de65388cc8ada8ULL,   189,   76 },
+    { 0x83c7088e1aab65dbULL,   216,   84 },
+    { 0xc45d1df942711d9aULL,   242,   92 },
+    { 0x924d692ca61be758ULL,   269,  100 },
+    { 0xda01ee641a708deaULL,   295,  108 },
+    { 0xa26da3999aef774aULL,   322,  116 },
+    { 0xf209787bb47d6b85ULL,   348,  124 },
+    { 0xb454e4a179dd1877ULL,   375,  132 },
+    { 0x865b86925b9bc5c2ULL,   402,  140 },
+    { 0xc83553c5c8965d3dULL,   428,  148 },
+    { 0x952ab45cfa97a0b3ULL,   455,  156 },
+    { 0xde469fbd99a05fe3ULL,   481,  164 },
+    { 0xa59bc234db398c25ULL,   508,  172 },
+    { 0xf6c69a72a3989f5cULL,   534,  180 },
+    { 0xb7dcbf5354e9beceULL,   561,  188 },
+    { 0x88fcf317f22241e2ULL,   588,  196 },
+    { 0xcc20ce9bd35c78a5ULL,   614,  204 },
+    { 0x98165af37b2153dfULL,   641,  212 },
+    { 0xe2a0b5dc971f303aULL,   667,  220 },
+    { 0xa8d9d1535ce3b396ULL,   694,  228 },
+    { 0xfb9b7cd9a4a7443cULL,   720,  236 },
+    { 0xbb764c4ca7a44410ULL,   747,  244 },
+    { 0x8bab8eefb6409c1aULL,   774,  252 },
+    { 0xd01fef10a657842cULL,   800,  260 },
+    { 0x9b10a4e5e9913129ULL,   827,  268 },
+    { 0xe7109bfba19c0c9dULL,   853,  276 },
+    { 0xac2820d9623bf429ULL,   880,  284 },
+    { 0x80444b5e7aa7cf85ULL,   907,  292 },
+    { 0xbf21e44003acdd2dULL,   933,  300 },
+    { 0x8e679c2f5e44ff8fULL,   960,  308 },
+    { 0xd433179d9c8cb841ULL,   986,  316 },
+    { 0x9e19db92b4e31ba9ULL,  1013,  324 },
+    { 0xeb96bf6ebadf77d9ULL,  1039,  332 },
+    { 0xaf87023b9bf0ee6bULL,  1066,  340 }
+};
+
+static int cached_pow(int exp, diy_fp *p)
+{
+    int k = (int)ceil((exp+DIYFP_FRACT_SIZE-1) * D_1_LOG2_10);
+    int i = (k-MIN_CACHED_EXP-1) / CACHED_EXP_STEP + 1;
+    p->f = pow_cache[i].fract;
+    p->e = pow_cache[i].b_exp;
+    return pow_cache[i].d_exp;
+}
+
+static diy_fp minus(diy_fp x, diy_fp y)
+{
+    diy_fp d; d.f = x.f - y.f; d.e = x.e;
+    assert(x.e == y.e && x.f >= y.f);
+    return d;
+}
+
+static diy_fp multiply(diy_fp x, diy_fp y)
+{
+    uint64_t a, b, c, d, ac, bc, ad, bd, tmp;
+    diy_fp r;
+    a = x.f >> 32; b = x.f & MASK32;
+    c = y.f >> 32; d = y.f & MASK32;
+    ac = a*c; bc = b*c;
+    ad = a*d; bd = b*d;
+    tmp = (bd >> 32) + (ad & MASK32) + (bc & MASK32);
+    tmp += 1U << 31; // round
+    r.f = ac + (ad >> 32) + (bc >> 32) + (tmp >> 32);
+    r.e = x.e + y.e + 64;
+    return r;
+}
+
+static diy_fp normalize_diy_fp(diy_fp n)
+{
+    assert(n.f != 0);
+    while(!(n.f & 0xFFC0000000000000ULL)) { n.f <<= 10; n.e -= 10; }
+    while(!(n.f & D64_SIGN)) { n.f <<= 1; --n.e; }
+    return n;
+}
+
+static diy_fp double2diy_fp(double d)
+{
+    diy_fp fp;
+    uint64_t u64 = CAST_U64(d);
+    if (!(u64 & D64_EXP_MASK)) { fp.f = u64 & D64_FRACT_MASK; fp.e = 1 - D64_EXP_BIAS; }
+    else { fp.f = (u64 & D64_FRACT_MASK) + D64_IMPLICIT_ONE; fp.e = (int)((u64 & D64_EXP_MASK) >> D64_EXP_POS) - D64_EXP_BIAS; }
+    return fp;
+}
+
+// pow10_cache[i] = 10^(i-1)
+static const unsigned int pow10_cache[] = { 0, 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
+
+static int largest_pow10(uint32_t n, int n_bits, uint32_t *power)
+{
+    int guess = ((n_bits + 1) * 1233 >> 12) + 1/*skip first entry*/;
+    if (n < pow10_cache[guess]) --guess; // We don't have any guarantees that 2^n_bits <= n.
+    *power = pow10_cache[guess];
+    return guess;
+}
+
+static int round_weed(char *buffer, int len, uint64_t wp_W, uint64_t delta, uint64_t rest, uint64_t ten_kappa, uint64_t ulp)
+{
+    uint64_t wp_Wup = wp_W - ulp;
+    uint64_t wp_Wdown = wp_W + ulp;
+    while(rest < wp_Wup && delta - rest >= ten_kappa
+            && (rest + ten_kappa < wp_Wup || wp_Wup - rest >= rest + ten_kappa - wp_Wup))
+    {
+        --buffer[len-1];
+        rest += ten_kappa;
+    }
+    if (rest < wp_Wdown && delta - rest >= ten_kappa
+            && (rest + ten_kappa < wp_Wdown || wp_Wdown - rest > rest + ten_kappa - wp_Wdown))
+        return 0;
+
+    return 2*ulp <= rest && rest <= delta - 4*ulp;
+}
+
+static int digit_gen(diy_fp low, diy_fp w, diy_fp high, char *buffer, int *length, int *kappa)
+{
+    uint64_t unit = 1;
+    diy_fp too_low = { low.f - unit, low.e };
+    diy_fp too_high = { high.f + unit, high.e };
+    diy_fp unsafe_interval = minus(too_high, too_low);
+    diy_fp one = { 1ULL << -w.e, w.e };
+    uint32_t p1 = (uint32_t)(too_high.f >> -one.e);
+    uint64_t p2 = too_high.f & (one.f - 1);
+    uint32_t div;
+    *kappa = largest_pow10(p1, DIYFP_FRACT_SIZE + one.e, &div);
+    *length = 0;
+
+    while(*kappa > 0)
+    {
+        uint64_t rest;
+        int digit = p1 / div;
+        buffer[*length] = (char)(digit);
+        ++*length;
+        p1 %= div;
+        --*kappa;
+        rest = ((uint64_t)p1 << -one.e) + p2;
+        if (rest < unsafe_interval.f) return round_weed(buffer, *length, minus(too_high, w).f, unsafe_interval.f, rest, (uint64_t)div << -one.e, unit);
+        div /= 10;
+    }
+
+    for(;;)
+    {
+        int digit;
+        p2 *= 10;
+        unit *= 10;
+        unsafe_interval.f *= 10;
+        // Integer division by one.
+        digit = (int)(p2 >> -one.e);
+        buffer[*length] = (char)(digit);
+        ++*length;
+        p2 &= one.f - 1;  // Modulo by one.
+        --*kappa;
+        if (p2 < unsafe_interval.f) return round_weed(buffer, *length, minus(too_high, w).f * unit, unsafe_interval.f, p2, one.f, unit);
+    }
+}
+
+int grisu3(double v, char *buffer, int *length, int *d_exp)
+{
+    int mk, kappa, success;
+    diy_fp dfp = double2diy_fp(v);
+    diy_fp w = normalize_diy_fp(dfp);
+
+    // normalize boundaries
+    diy_fp t = { (dfp.f << 1) + 1, dfp.e - 1 };
+    diy_fp b_plus = normalize_diy_fp(t);
+    diy_fp b_minus;
+    diy_fp c_mk; // Cached power of ten: 10^-k
+    uint64_t u64 = CAST_U64(v);
+    assert(v > 0 && v <= 1.7976931348623157e308); // Grisu only handles strictly positive finite numbers.
+    if (!(u64 & D64_FRACT_MASK) && (u64 & D64_EXP_MASK) != 0) { b_minus.f = (dfp.f << 2) - 1; b_minus.e =  dfp.e - 2;} // lower boundary is closer?
+    else { b_minus.f = (dfp.f << 1) - 1; b_minus.e = dfp.e - 1; }
+    b_minus.f = b_minus.f << (b_minus.e - b_plus.e);
+    b_minus.e = b_plus.e;
+
+    mk = cached_pow(MIN_TARGET_EXP - DIYFP_FRACT_SIZE - w.e, &c_mk);
+
+    w = multiply(w, c_mk);
+    b_minus = multiply(b_minus, c_mk);
+    b_plus  = multiply(b_plus,  c_mk);
+
+    success = digit_gen(b_minus, w, b_plus, buffer, length, &kappa);
+    *d_exp = kappa - mk;
+    return success;
+}

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -95,6 +95,7 @@ executable test-builder
 
   c-sources:        ../cbits/fpstring.c
                     ../cbits/itoa.c
+                    ../cbits/dtoa.c
   include-dirs:     ../include
   includes:         fpstring.h
   install-includes: fpstring.h


### PR DESCRIPTION
Sorry for the delay, the floating format problem is definitely not as simple as i thought, but i finally made it forward somehow, in short this patch:

+ Implement `doubleDec/floatDec` using grisu3 with dragon4 fallback with reference [here](https://github.com/juj/MathGeoLib/blob/master/src/Math/grisu3.c).

+ ~~Implement `floatDec` using dragon4 with `floatToDigits` in `GHC.Float`.~~

Benchmarks are uploaded, please give a review any time you want.