### PR TITLE
Avoid copying in 'append' if the strings are adjacent in memory

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -433,7 +433,11 @@ unsnoc (PS x s l)
                           withForeignPtr x $ \p -> peekByteOff p (s+l-1))
 {-# INLINE unsnoc #-}
 
--- | /O(n)/ Append two ByteStrings
+-- | /O(n)/ Append two ByteStrings.
+--
+-- Note: 'append' is /O(1)/ if the ByteStrings are slices of a bigger
+-- ByteString and are adjacent in memory (e.g. if they were obtained by doing
+-- 'splitAt').
 append :: ByteString -> ByteString -> ByteString
 append = mappend
 {-# INLINE append #-}

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -454,11 +454,14 @@ compareBytes (PS fp1 off1 len1) (PS fp2 off2 len2) =
 append :: ByteString -> ByteString -> ByteString
 append (PS _   _    0)    b                  = b
 append a                  (PS _   _    0)    = a
-append (PS fp1 off1 len1) (PS fp2 off2 len2) =
-    unsafeCreate (len1+len2) $ \destptr1 -> do
-      let destptr2 = destptr1 `plusPtr` len1
-      withForeignPtr fp1 $ \p1 -> memcpy destptr1 (p1 `plusPtr` off1) len1
-      withForeignPtr fp2 $ \p2 -> memcpy destptr2 (p2 `plusPtr` off2) len2
+append (PS fp1 off1 len1) (PS fp2 off2 len2)
+    | fp1 == fp2 && off1 + len1 == off2      =
+        PS fp1 off1 (len1+len2)
+    | otherwise                              =
+        unsafeCreate (len1+len2) $ \destptr1 -> do
+          let destptr2 = destptr1 `plusPtr` len1
+          withForeignPtr fp1 $ \p1 -> memcpy destptr1 (p1 `plusPtr` off1) len1
+          withForeignPtr fp2 $ \p2 -> memcpy destptr2 (p2 `plusPtr` off2) len2
 
 concat :: [ByteString] -> ByteString
 concat = \bss0 -> goLen0 bss0 bss0


### PR DESCRIPTION
See #124. [This benchmark](http://lpaste.net/1708203944972386304) demonstrates that there is almost no slowdown compared to the previous implementation (+1 ns, while creating a new bytestring takes 30 ns). The results of benchmarks are [here](http://lpaste.net/1946810621173432320). The non-copying path always takes ~15 ns, which seems pretty weird to me (I expected less), but I don't know why it happens.

I have to say that I'm not _quite_ sure it's a good idea. The 1 ns slowdown is probably not important (if you are concatenating lots of small bytestrings you should probably be using a builder anyway), but it might worsen behavior of code that (perhaps accidentally) relied on `append` always making a copy.