### PR TITLE
Add breakSubstring function to Data.ByteString.Lazy.

### DIFF
--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -236,7 +236,7 @@ import Control.Applicative      ((<$>))
 import Data.Monoid              (Monoid(..))
 #endif
 import Control.Monad            (mplus)
-import Data.Word                (Word8,Word32)
+import Data.Word                (Word8)
 import Data.Int                 (Int64)
 import System.IO                (Handle,openBinaryFile,stdin,stdout,withBinaryFile,IOMode(..)
                                 ,hClose)
@@ -246,6 +246,8 @@ import System.IO.Unsafe
 import Foreign.ForeignPtr       (withForeignPtr)
 import Foreign.Ptr
 import Foreign.Storable
+
+import GHC.Word hiding (Word8)
 
 #if !(MIN_VERSION_base(4,7,0))
 finiteBitSize = bitSize

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1136,8 +1136,7 @@ breakSubstring pat =
              then shift
              else karpRabin
   where
-    unsafeSplitAt i s = (take i s, drop i s)
-    lp                = length pat
+    lp = length pat
     karpRabin :: ByteString -> (ByteString, ByteString)
     karpRabin src
         | length src < lp = (src,empty)


### PR DESCRIPTION
This is a copy of the version in Data.ByteString with the following changes:

- breakByte -> break
- unsafeDrop -> drop
- unsafeHead -> head
- unsafeIndex -> index
- unsafeSplitAt -> splitAt
- unsafeTake -> take