### PR TITLE
[RFC] Builder: Efficiently handle literal strings

### DIFF
--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, BangPatterns, ScopedTypeVariables #-}
+{-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 #if __GLASGOW_HASKELL__ == 700
 -- This is needed as a workaround for an old bug in GHC 7.0.1 (Trac #4498)
@@ -437,6 +438,9 @@ module Data.ByteString.Builder.Prim (
   -- a decimal number with UTF-8 encoded characters.
   , charUtf8
 
+  , cstring
+  , cstringUtf8
+
 {-
   -- * Testing support
   -- | The following four functions are intended for testing use
@@ -472,6 +476,7 @@ import           Data.ByteString.Builder.Prim.ASCII
 #if MIN_VERSION_base(4,4,0)
 #if MIN_VERSION_base(4,7,0)
 import           Foreign
+import           Foreign.C.Types
 #else
 import           Foreign hiding (unsafeForeignPtrToPtr)
 #endif
@@ -479,6 +484,8 @@ import           Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 #else
 import           Foreign
 #endif
+import           GHC.Exts
+import           GHC.IO
 
 ------------------------------------------------------------------------------
 -- Creating Builders from bounded primitives
@@ -678,6 +685,60 @@ primMapLazyByteStringBounded w =
 
 
 ------------------------------------------------------------------------------
+-- Raw CString encoding
+------------------------------------------------------------------------------
+
+#if !MIN_VERSION_base(4,7,0)
+-- eqWord# et al. return Bools prior to GHC 7.6
+isTrue# :: Bool -> Bool
+isTrue# x = x
+#endif
+
+-- | A null-terminated ASCII encoded 'CString'. Null characters are not representable.
+cstring :: Addr# -> Builder
+cstring =
+    \addr0 -> builder $ step addr0
+  where
+    step :: Addr# -> BuildStep r -> BuildStep r
+    step !addr !k !br@(BufferRange op0@(Ptr op0#) ope)
+      | isTrue# (ch `eqWord#` 0##) = k br
+      | op0 == ope =
+          return $ bufferFull defaultChunkSize op0 (step addr k)
+      | otherwise = do
+          IO $ \s -> case writeWord8OffAddr# op0# 0# ch s of
+                       s' -> (# s', () #)
+          let br' = BufferRange (op0 `plusPtr` 1) ope
+          step (addr `plusAddr#` 1#) k br'
+      where
+        !ch = indexWord8OffAddr# addr 0#
+
+-- | A null-terminated UTF-8 encoded 'CString'. Null characters can be encoded as
+-- @0xc0 0x80@.
+cstringUtf8 :: Addr# -> Builder
+cstringUtf8 =
+    \addr0 -> builder $ step addr0
+  where
+    step :: Addr# -> BuildStep r -> BuildStep r
+    step !addr !k !br@(BufferRange op0@(Ptr op0#) ope)
+      | isTrue# (ch `eqWord#` 0##) = k br
+      | op0 == ope =
+          return $ bufferFull defaultChunkSize op0 (step addr k)
+        -- NULL is encoded as 0xc0 0x80
+      | isTrue# (ch `eqWord#` 0xc0##)
+      , isTrue# (indexWord8OffAddr# addr 1# `eqWord#` 0x80##) = do
+          IO $ \s -> case writeWord8OffAddr# op0# 0# 0## s of
+                       s' -> (# s', () #)
+          let br' = BufferRange (op0 `plusPtr` 1) ope
+          step (addr `plusAddr#` 1#) k br'
+      | otherwise = do
+          IO $ \s -> case writeWord8OffAddr# op0# 0# ch s of
+                       s' -> (# s', () #)
+          let br' = BufferRange (op0 `plusPtr` 1) ope
+          step (addr `plusAddr#` 1#) k br'
+      where
+        !ch = indexWord8OffAddr# addr 0#
+
+------------------------------------------------------------------------------
 -- Char8 encoding
 ------------------------------------------------------------------------------
 
@@ -741,5 +802,3 @@ encodeCharUtf8 f1 f2 f3 f4 c = case ord c of
                x3 = fromIntegral $ ((x `shiftR` 6) .&. 0x3F) + 0x80
                x4 = fromIntegral $ (x .&. 0x3F) + 0x80
            in f4 x1 x2 x3 x4
-
-

--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -724,7 +724,7 @@ cstringUtf8 =
           IO $ \s -> case writeWord8OffAddr# op0# 0# 0## s of
                        s' -> (# s', () #)
           let br' = BufferRange (op0 `plusPtr` 1) ope
-          step (addr `plusAddr#` 1#) k br'
+          step (addr `plusAddr#` 2#) k br'
       | otherwise = do
           IO $ \s -> case writeWord8OffAddr# op0# 0# ch s of
                        s' -> (# s', () #)

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MagicHash           #-}
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -239,6 +240,7 @@ main = do
         , benchB' "ensureFree 8"  ()  (const (ensureFree 8))
         , benchB' "intHost 1"     1   intHost
         , benchB' "String (naive)" "hello world!" fromString
+        , benchB' "String"        () $ \() -> P.cstring "hello world!"#
         ]
 
       , bgroup "Encoding wrappers"

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -239,6 +239,8 @@ main = do
         [ benchB' "mempty"        ()  (const mempty)
         , benchB' "ensureFree 8"  ()  (const (ensureFree 8))
         , benchB' "intHost 1"     1   intHost
+        , benchB' "UTF-8 String (naive)" "hello world\0" fromString
+        , benchB' "UTF-8 String"  () $ \() -> P.cstringUtf8 "hello world\0"#
         , benchB' "String (naive)" "hello world!" fromString
         , benchB' "String"        () $ \() -> P.cstring "hello world!"#
         ]

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -34,6 +34,7 @@ flag integer-simple
 executable bench-bytestring-builder
   hs-source-dirs:    . ..
   main-is:           BenchAll.hs
+  other-modules:     Paths_bench_bytestring
 
   build-depends:     base >= 4 && < 5
                    , ghc-prim

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -33,12 +33,13 @@ tests = concat [ testsBinary, testsASCII, testsChar8, testsUtf8
 
 testCString :: Test
 testCString = testProperty "cstring" $
-    toLazyByteString (BP.cstring "hello world!"#) == LC.pack "hello world!"
+    toLazyByteString (BP.cstring "hello world!"#) ==
+      LC.pack "hello" <> L.singleton 0x20 <> LC.pack "world!"
 
 testCStringUtf8 :: Test
 testCStringUtf8 = testProperty "cstringUtf8" $
-    toLazyByteString (BP.cstringUtf8 "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82\x2c\x20\xc0\x80\xd0\xbc\xd0\xb8\xd1\x80\x21"#) ==
-      toLazyByteString (stringUtf8 "Привет, \0мир!")
+    toLazyByteString (BP.cstringUtf8 "hello\xc0\x80world!"#) ==
+      LC.pack "hello" <> L.singleton 0x00 <> LC.pack "world!"
 
 ------------------------------------------------------------------------------
 -- Binary

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -34,12 +34,12 @@ tests = concat [ testsBinary, testsASCII, testsChar8, testsUtf8
 testCString :: Test
 testCString = testProperty "cstring" $
     toLazyByteString (BP.cstring "hello world!"#) ==
-      LC.pack "hello" <> L.singleton 0x20 <> LC.pack "world!"
+      LC.pack "hello" `L.append` L.singleton 0x20 `L.append` LC.pack "world!"
 
 testCStringUtf8 :: Test
 testCStringUtf8 = testProperty "cstringUtf8" $
     toLazyByteString (BP.cstringUtf8 "hello\xc0\x80world!"#) ==
-      LC.pack "hello" <> L.singleton 0x00 <> LC.pack "world!"
+      LC.pack "hello" `L.append` L.singleton 0x00 `L.append` LC.pack "world!"
 
 ------------------------------------------------------------------------------
 -- Binary

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -29,11 +29,16 @@ import           TestFramework
 
 tests :: [Test]
 tests = concat [ testsBinary, testsASCII, testsChar8, testsUtf8
-               , testsCombinatorsB, [testCString] ]
+               , testsCombinatorsB, [testCString, testCStringUtf8] ]
 
 testCString :: Test
 testCString = testProperty "cstring" $
     toLazyByteString (BP.cstring "hello world!"#) == LC.pack "hello world!"
+
+testCStringUtf8 :: Test
+testCStringUtf8 = testProperty "cstringUtf8" $
+    toLazyByteString (BP.cstringUtf8 "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82\x2c\x20\xc0\x80\xd0\xbc\xd0\xb8\xd1\x80\x21"#) ==
+      toLazyByteString (stringUtf8 "Привет, \0мир!")
 
 ------------------------------------------------------------------------------
 -- Binary

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, ScopedTypeVariables #-}
+{-# LANGUAGE CPP, ScopedTypeVariables, MagicHash #-}
 
 -- |
 -- Copyright   : (c) 2011 Simon Meier
@@ -14,12 +14,14 @@ module Data.ByteString.Builder.Prim.Tests (tests) where
 
 import           Data.Char  (ord)
 import qualified Data.ByteString.Lazy                  as L
+import qualified Data.ByteString.Lazy.Char8            as LC
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Builder.Prim          as BP
 import           Data.ByteString.Builder.Prim.TestUtils
 
 #if defined(HAVE_TEST_FRAMEWORK)
 import           Test.Framework
+import           Test.Framework.Providers.QuickCheck2
 #else
 import           TestFramework
 #endif
@@ -27,8 +29,11 @@ import           TestFramework
 
 tests :: [Test]
 tests = concat [ testsBinary, testsASCII, testsChar8, testsUtf8
-               , testsCombinatorsB ]
+               , testsCombinatorsB, [testCString] ]
 
+testCString :: Test
+testCString = testProperty "cstring" $
+    toLazyByteString (BP.cstring "hello world!"#) == LC.pack "hello world!"
 
 ------------------------------------------------------------------------------
 -- Binary


### PR DESCRIPTION
Previously `String`s would be handled with `P.primMapListBounded P.charUtf8`. In the case that the `String` was a literal, we would decode UTF-8 from the primitive string and then reencode each character as we wrote it to the target buffer. Not only was this inefficient to run, it was also inefficient to compile as we would be forced to inline and simplify large swathes of the builder machinery (see [GHC #13960](https://ghc.haskell.org/trac/ghc/ticket/13960)).

The obvious solution here is to do what we should have done all along: `strcpy` directly out of the primitive string into the target buffer. In the case of UTF-8 things are slightly trickier as we must recognize NULL characters, which GHC encodes as `0xc0 0x80`.

Fixing this is a win in several respects: code size of a trivial `main = print $ BSL.length $ B.toLazyByteString $ B.string "hello world"` program is roughly cut in half. Moreover, the new approach is about twice as fast as the previous according to the provided benchmarks.
