### PR TITLE
tests: Make orphan CChar instance conditional

### DIFF
--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -67,9 +67,11 @@ instance Arbitrary CByteString where
       fromCChar :: CChar -> Word8
       fromCChar = fromIntegral
 
+#if !MIN_VERSION_QuickCheck(2,10,0) && __GLASGOW_HASKELL__ > 704
 instance Arbitrary CChar where
   arbitrary = fmap (fromIntegral :: Int -> CChar)
             $ oneof [choose (-128,-1), choose (1,127)]
+#endif
 
 ------------------------------------------------------------------------
 --


### PR DESCRIPTION
Some versions of `QuickCheck` now provide this instance.