### PR TITLE
Fix Haddock quote

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -548,7 +548,7 @@ foldl1 f ps
     | otherwise = foldl f (unsafeHead ps) (unsafeTail ps)
 {-# INLINE foldl1 #-}
 
--- | 'foldl1\'' is like 'foldl1', but strict in the accumulator.
+-- | 'foldl1'' is like 'foldl1', but strict in the accumulator.
 -- An exception will be thrown in the case of an empty ByteString.
 foldl1' :: (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 foldl1' f ps

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -348,7 +348,7 @@ foldl :: (a -> Char -> a) -> a -> ByteString -> a
 foldl f = B.foldl (\a c -> f a (w2c c))
 {-# INLINE foldl #-}
 
--- | 'foldl\'' is like foldl, but strict in the accumulator.
+-- | 'foldl'' is like foldl, but strict in the accumulator.
 foldl' :: (a -> Char -> a) -> a -> ByteString -> a
 foldl' f = B.foldl' (\a c -> f a (w2c c))
 {-# INLINE foldl' #-}
@@ -360,7 +360,7 @@ foldr :: (Char -> a -> a) -> a -> ByteString -> a
 foldr f = B.foldr (\c a -> f (w2c c) a)
 {-# INLINE foldr #-}
 
--- | 'foldr\'' is a strict variant of foldr
+-- | 'foldr'' is a strict variant of foldr
 foldr' :: (Char -> a -> a) -> a -> ByteString -> a
 foldr' f = B.foldr' (\c a -> f (w2c c) a)
 {-# INLINE foldr' #-}

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -488,7 +488,7 @@ foldl f z = go z
         go a (Chunk c cs) = go (S.foldl f a c) cs
 {-# INLINE foldl #-}
 
--- | 'foldl\'' is like 'foldl', but strict in the accumulator.
+-- | 'foldl'' is like 'foldl', but strict in the accumulator.
 foldl' :: (a -> Word8 -> a) -> a -> ByteString -> a
 foldl' f z = go z
   where go !a Empty        = a
@@ -508,7 +508,7 @@ foldl1 :: (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 foldl1 _ Empty        = errorEmptyList "foldl1"
 foldl1 f (Chunk c cs) = foldl f (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
 
--- | 'foldl1\'' is like 'foldl1', but strict in the accumulator.
+-- | 'foldl1'' is like 'foldl1', but strict in the accumulator.
 foldl1' :: (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 foldl1' _ Empty        = errorEmptyList "foldl1'"
 foldl1' f (Chunk c cs) = foldl' f (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -357,7 +357,7 @@ cons :: Word8 -> ByteString -> ByteString
 cons c cs = Chunk (S.singleton c) cs
 {-# INLINE cons #-}
 
--- | /O(1)/ Unlike 'cons', 'cons\'' is
+-- | /O(1)/ Unlike 'cons', 'cons'' is
 -- strict in the ByteString that we are consing onto. More precisely, it forces
 -- the head and the first chunk. It does this because, for space efficiency, it
 -- may coalesce the new byte onto the first \'chunk\' rather than starting a
@@ -365,7 +365,7 @@ cons c cs = Chunk (S.singleton c) cs
 --
 -- So that means you can't use a lazy recursive contruction like this:
 --
--- > let xs = cons\' c xs in xs
+-- > let xs = cons' c xs in xs
 --
 -- You can however use 'cons', as well as 'repeat' and 'cycle', to build
 -- infinite lazy ByteStrings.

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -251,7 +251,7 @@ cons :: Char -> ByteString -> ByteString
 cons = L.cons . c2w
 {-# INLINE cons #-}
 
--- | /O(1)/ Unlike 'cons', 'cons\'' is
+-- | /O(1)/ Unlike 'cons', 'cons'' is
 -- strict in the ByteString that we are consing onto. More precisely, it forces
 -- the head and the first chunk. It does this because, for space efficiency, it
 -- may coalesce the new byte onto the first \'chunk\' rather than starting a
@@ -259,7 +259,7 @@ cons = L.cons . c2w
 --
 -- So that means you can't use a lazy recursive contruction like this:
 --
--- > let xs = cons\' c xs in xs
+-- > let xs = cons' c xs in xs
 --
 -- You can however use 'cons', as well as 'repeat' and 'cycle', to build
 -- infinite lazy ByteStrings.
@@ -319,7 +319,7 @@ foldl :: (a -> Char -> a) -> a -> ByteString -> a
 foldl f = L.foldl (\a c -> f a (w2c c))
 {-# INLINE foldl #-}
 
--- | 'foldl\'' is like foldl, but strict in the accumulator.
+-- | 'foldl'' is like foldl, but strict in the accumulator.
 foldl' :: (a -> Char -> a) -> a -> ByteString -> a
 foldl' f = L.foldl' (\a c -> f a (w2c c))
 {-# INLINE foldl' #-}
@@ -337,7 +337,7 @@ foldl1 :: (Char -> Char -> Char) -> ByteString -> Char
 foldl1 f ps = w2c (L.foldl1 (\x y -> c2w (f (w2c x) (w2c y))) ps)
 {-# INLINE foldl1 #-}
 
--- | 'foldl1\'' is like 'foldl1', but strict in the accumulator.
+-- | 'foldl1'' is like 'foldl1', but strict in the accumulator.
 foldl1' :: (Char -> Char -> Char) -> ByteString -> Char
 foldl1' f ps = w2c (L.foldl1' (\x y -> c2w (f (w2c x) (w2c y))) ps)
 


### PR DESCRIPTION
Noticed this while hacking on Haddock on HEAD. The existing docs render as

<img width="798" alt="screen shot 2018-02-09 at 4 55 28 pm" src="https://user-images.githubusercontent.com/10766081/36056556-24301e5e-0dba-11e8-8d5e-bac975cc64db.png">

Now they render as

<img width="798" alt="screen shot 2018-02-09 at 4 55 02 pm" src="https://user-images.githubusercontent.com/10766081/36056559-2ace9eac-0dba-11e8-8552-ea06d48334cf.png">

(Note that the actual docs do hyperlink `cons`, `repeat`, and `cycle` - the images above are taken of a module with just the `cons'` function in it)