### PR TITLE
Optimize folds

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1521,9 +1521,8 @@ sort (PS input s l) = unsafeCreate l $ \p -> allocaArray 256 $ \arr -> do
                          go (i + 1) (ptr `plusPtr` fromIntegral n)
     go 0 p
   where
-    -- | Count the number of occurrences of each byte.
+    -- Count the number of occurrences of each byte.
     -- Used by 'sort'
-    --
     countOccurrences :: Ptr CSize -> Ptr Word8 -> Int -> IO ()
     countOccurrences !counts !str !len = go 0
      where

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -207,6 +207,25 @@ test-suite test-builder
                     Data.ByteString.Builder.Prim.TestUtils
                     TestFramework
 
+                    Data.ByteString
+                    Data.ByteString.Builder
+                    Data.ByteString.Builder.ASCII
+                    Data.ByteString.Builder.Extra
+                    Data.ByteString.Builder.Internal
+                    Data.ByteString.Builder.Prim
+                    Data.ByteString.Builder.Prim.ASCII
+                    Data.ByteString.Builder.Prim.Binary
+                    Data.ByteString.Builder.Prim.Internal
+                    Data.ByteString.Builder.Prim.Internal.Base16
+                    Data.ByteString.Builder.Prim.Internal.Floating
+                    Data.ByteString.Builder.Prim.Internal.UncheckedShifts
+                    Data.ByteString.Internal
+                    Data.ByteString.Lazy
+                    Data.ByteString.Lazy.Internal
+                    Data.ByteString.Short
+                    Data.ByteString.Short.Internal
+                    Data.ByteString.Unsafe
+
   build-depends:    base, ghc-prim,
                     deepseq,
                     QuickCheck                 >= 2.4 && < 2.10,

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -150,6 +150,17 @@ test-suite prop-compiled
   other-modules:    Rules
                     QuickCheckUtils
                     TestFramework
+
+                    Data.ByteString
+                    Data.ByteString.Char8
+                    Data.ByteString.Internal
+                    Data.ByteString.Lazy
+                    Data.ByteString.Lazy.Char8
+                    Data.ByteString.Lazy.Internal
+                    Data.ByteString.Short
+                    Data.ByteString.Short.Internal
+                    Data.ByteString.Unsafe
+
   hs-source-dirs:   . tests
   build-depends:    base, ghc-prim, deepseq, random, directory,
                     test-framework, test-framework-quickcheck2,


### PR DESCRIPTION
The idea is to manually remove arguments that do not change between invocations from worker functions in folds. Ideally, ghc should do this and this PR will not be needed, but 8.2.2 currently doesn't seem to do that. I'll try to provide more research there, but in the meantime it seems worthwhile to optimize `bytestring` package manually. Thanks to it's backwards compatibility with previous versions of GHC, benefits of optimization will become available there as well.

The speedup is not eye-widening for foldls like `foldl'`, but is pretty good for `mapAccumR` (around 75%, which could make a good candidate for Haskell performane attack if it wasn't cancelled already). Please find benchmarks at https://gist.github.com/sergv/b4642943db3f59293531c5291e3e3af7.