### PR TITLE
Fix a reference to unsafePackAddress

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -322,8 +322,8 @@ singleton c = unsafeCreate 1 $ \p -> poke p c
 
 -- | /O(n)/ Convert a @['Word8']@ into a 'ByteString'.
 --
--- For applications with large numbers of string literals, pack can be a
--- bottleneck. In such cases, consider using packAddress (GHC only).
+-- For applications with large numbers of string literals, 'pack' can be a
+-- bottleneck. In such cases, consider using 'unsafePackAddress' (GHC only).
 pack :: [Word8] -> ByteString
 pack = packBytes
 


### PR DESCRIPTION
Also, a few ~~comments~~ questions:

* How do I replace  `pack`  with `unsafePackAddress`? Does this look right?

```
b, b' :: ByteString
b = pack [0x01, 0x02]
b' = unsafeDupablePerformIO (unsafePackAddress "\x01\x02"#)
```
If that's right, how about adding the following convenience function?

```
unsafeLiteral :: Addr# -> ByteString
unsafeLiteral = unsafeDupablePerformIO . unsafePackAddress
```