### PR TITLE
Remove trailing whitespace

### DIFF
--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -73,7 +73,7 @@ executable bench-bytestring-builder
 -- executable bench-float-decimal
 --   hs-source-dirs:    . ..
 --   main-is:           BenchFloatDec.hs
--- 
+--
 --   build-depends:     base >= 4 && < 5
 --                    , ghc-prim
 --                    , deepseq       == 1.2.*
@@ -83,7 +83,7 @@ executable bench-bytestring-builder
 --                    -- we require bytestring due to benchmarking against
 --                    -- blaze-textual, which uses blaze-builder
 --                    , bytestring    == 0.9.*
--- 
+--
 --   -- cabal complains about ../ dirs. However, this is better than symlinks,
 --   -- which probably don't work on windows.
 --   c-sources:         ../cbits/fpstring.c
@@ -92,20 +92,20 @@ executable bench-bytestring-builder
 --   include-dirs:      ../include
 --   includes:          fpstring.h
 --   install-includes:  fpstring.h
--- 
+--
 --   ghc-options:      -O2
 --                     -fmax-simplifier-iterations=10
 --                     -fdicts-cheap
 --                     -fspec-constr-count=6
--- 
+--
 --   if impl(ghc >= 6.11)
 --     cpp-options: -DINTEGER_GMP
 --     build-depends: integer-gmp >= 0.2 && < 0.4
--- 
+--
 --   if impl(ghc >= 6.9) && impl(ghc < 6.11)
 --     cpp-options: -DINTEGER_GMP
 --     build-depends: integer >= 0.1 && < 0.2
--- 
+--
 --   if impl(ghc)
 --     extensions:   UnliftedFFITypes,
 --                   MagicHash,

--- a/bench/wiki-haskell.html
+++ b/bench/wiki-haskell.html
@@ -498,7 +498,7 @@ mw.config.set({"wgCanonicalNamespace":"","wgCanonicalSpecialPageName":!1,"wgName
 </ul>
 
 
-<!-- 
+<!--
 NewPP limit report
 Parsed by mw1089
 Cached time: 20150926205232
@@ -516,7 +516,7 @@ Lua time usage: 0.380/10.000 seconds
 Lua memory usage: 5.51 MB/50 MB
 Number of Wikibase entities loaded: 1-->
 
-<!-- 
+<!--
 Transclusion expansion time report (%,ms,calls,template)
 100.00%  866.995      1 - -total
  35.62%  308.834      1 - Template:Reflist


### PR DESCRIPTION
Nearly all the changes in #43 have since been made in other commits. These are the only instances of trailing whitespace that remain. This change is probably a bit superfluous; I'm really only submitting it so that we can decisively close the other PR.