### PR TITLE
Remove unused imports.

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -134,7 +134,7 @@ module Data.ByteString.Builder.Internal (
 
 import           Control.Arrow (second)
 
-#if MIN_VERSION_base(4,9,0)
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
 import           Data.Semigroup (Semigroup((<>)))
 #endif
 #if !(MIN_VERSION_base(4,8,0))

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -91,7 +91,7 @@ import Foreign.C.Types          (CInt, CSize, CULong)
 
 import Foreign.C.String         (CString)
 
-#if MIN_VERSION_base(4,9,0)
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
 import Data.Semigroup           (Semigroup((<>)))
 #endif
 #if !(MIN_VERSION_base(4,8,0))

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -51,7 +51,7 @@ import qualified Data.ByteString          as S (length, take, drop)
 import Data.Word        (Word8)
 import Foreign.Storable (Storable(sizeOf))
 
-#if MIN_VERSION_base(4,9,0)
+#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
 import Data.Semigroup   (Semigroup((<>)))
 #endif
 #if !(MIN_VERSION_base(4,8,0))


### PR DESCRIPTION
Due to a bug in ghc, some unused imports do not yield warnings.
This commit will remove such unused imports in preparation for
the ghc bug fix (see https://ghc.haskell.org/trac/ghc/ticket/13064).