### PR TITLE
Docs: properly escape character literals

### DIFF
--- a/Data/ByteString/Builder/Prim/Internal.hs
+++ b/Data/ByteString/Builder/Prim/Internal.hs
@@ -272,7 +272,7 @@ eitherB (BP b1 io1) (BP b2 io2) =
 -- Unicode codepoints above 127 as follows.
 --
 -- @
---charASCIIDrop = 'condB' (< '\128') ('fromF' 'char7') 'emptyB'
+--charASCIIDrop = 'condB' (< \'\\128\') ('fromF' 'char7') 'emptyB'
 -- @
 {-# INLINE CONLIKE condB #-}
 condB :: (a -> Bool) -> BoundedPrim a -> BoundedPrim a -> BoundedPrim a

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -219,11 +219,11 @@ unsafePackLenChars len cs0 =
 -- | /O(n)/ Pack a null-terminated sequence of bytes, pointed to by an
 -- Addr\# (an arbitrary machine address assumed to point outside the
 -- garbage-collected heap) into a @ByteString@. A much faster way to
--- create an Addr\# is with an unboxed string literal, than to pack a
+-- create an 'Addr#' is with an unboxed string literal, than to pack a
 -- boxed string. A unboxed string literal is compiled to a static @char
 -- []@ by GHC. Establishing the length of the string requires a call to
--- @strlen(3)@, so the Addr# must point to a null-terminated buffer (as
--- is the case with "string"# literals in GHC). Use 'unsafePackAddressLen'
+-- @strlen(3)@, so the 'Addr#' must point to a null-terminated buffer (as
+-- is the case with @\"string\"\#@ literals in GHC). Use 'unsafePackAddressLen'
 -- if you know the length of the string statically.
 --
 -- An example:
@@ -231,10 +231,10 @@ unsafePackLenChars len cs0 =
 -- > literalFS = unsafePackAddress "literal"#
 --
 -- This function is /unsafe/. If you modify the buffer pointed to by the
--- original Addr# this modification will be reflected in the resulting
+-- original 'Addr#' this modification will be reflected in the resulting
 -- @ByteString@, breaking referential transparency.
 --
--- Note this also won't work if your Addr# has embedded '\0' characters in
+-- Note this also won't work if your 'Addr#' has embedded @\'\\0\'@ characters in
 -- the string, as @strlen@ will return too short a length.
 --
 unsafePackAddress :: Addr# -> IO ByteString


### PR DESCRIPTION
Single quotes in Haddock are used for references to other identifiers.
Character literals should have both the single quote and possible backslash
escaped with extra backslahes.

Ex: `@\'\\0\'@`, not `'\0'`