### PR TITLE
Update for QuickCheck >= 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,12 @@ before_install:
 install:
  - travis_retry cabal update
  # can't use "cabal install --only-dependencies --enable-tests" due to dep-cycle
- - cabal install "QuickCheck >=2.4 && <2.10" "byteorder ==1.0.*" "dlist >=0.5 && <0.8" "mtl >=2.0 && <2.3" deepseq test-framework-hunit test-framework-quickcheck2
+ - cabal install \
+      "QuickCheck >=2.10 && <2.14" \
+      "byteorder ==1.0.*"
+      "dlist >=0.5 && <0.9"
+      "mtl >=2.0 && <2.3"
+      deepseq test-framework-hunit test-framework-quickcheck2
 
 script:
  - cabal configure --enable-tests -v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ env:
  - GHCVER=7.10.3 CABALVER=1.22
  - GHCVER=8.0.2 CABALVER=1.24
  - GHCVER=8.2.2 CABALVER=2.0
- - GHCVER=head  CABALVER=2.0
+ - GHCVER=8.4.4 CABALVER=2.2
+ - GHCVER=8.6.3 CABALVER=2.4
+ - GHCVER=head  CABALVER=2.4
 
 matrix:
   allow_failures:
-   - env: GHCVER=head  CABALVER=2.0
+   - env: GHCVER=head  CABALVER=2.4
 
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -40,7 +40,7 @@ executable bench-bytestring-builder
                    , deepseq       >= 1.2
                    , criterion     >= 0.5
                    , blaze-textual == 0.2.*
-                   , blaze-builder == 0.3.*
+                   , blaze-builder >= 0.3 && < 0.5
                    -- we require bytestring due to benchmarking against
                    -- blaze-textual, which uses blaze-builder
                    , bytestring    >= 0.9

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -153,7 +153,7 @@ test-suite prop-compiled
   hs-source-dirs:   . tests
   build-depends:    base, ghc-prim, deepseq, random, directory,
                     test-framework, test-framework-quickcheck2,
-                    QuickCheck >= 2.3 && < 2.10
+                    QuickCheck >= 2.10 && < 2.14
   c-sources:        cbits/fpstring.c
   include-dirs:     include
   ghc-options:      -fwarn-unused-binds
@@ -198,7 +198,7 @@ test-suite test-builder
 
   build-depends:    base, ghc-prim,
                     deepseq,
-                    QuickCheck                 >= 2.4 && < 2.10,
+                    QuickCheck                 >= 2.10 && < 2.14,
                     byteorder                  == 1.0.*,
                     dlist                      >= 0.5 && < 0.9,
                     directory,

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1701,18 +1701,18 @@ io_tests =
     ]
 
 misc_tests =
-    [ testProperty "packunpack"             prop_packunpack_s
-    , testProperty "unpackpack"             prop_unpackpack_s
-    , testProperty "packunpack"             prop_packunpack_c
-    , testProperty "unpackpack"             prop_unpackpack_c
-    , testProperty "packunpack"             prop_packunpack_l
-    , testProperty "unpackpack"             prop_unpackpack_l
-    , testProperty "packunpack"             prop_packunpack_lc
-    , testProperty "unpackpack"             prop_unpackpack_lc
-    , testProperty "unpack"                 prop_unpack_s
-    , testProperty "unpack"                 prop_unpack_c
-    , testProperty "unpack"                 prop_unpack_l
-    , testProperty "unpack"                 prop_unpack_lc
+    [ testProperty "packunpack (bytes)"     prop_packunpack_s
+    , testProperty "unpackpack (bytes)"     prop_unpackpack_s
+    , testProperty "packunpack (chars)"     prop_packunpack_c
+    , testProperty "unpackpack (chars)"     prop_unpackpack_c
+    , testProperty "packunpack (lazy bytes)" prop_packunpack_l
+    , testProperty "unpackpack (lazy bytes)" prop_unpackpack_l
+    , testProperty "packunpack (lazy chars)" prop_packunpack_lc
+    , testProperty "unpackpack (lazy chars)" prop_unpackpack_lc
+    , testProperty "unpack (bytes)"         prop_unpack_s
+    , testProperty "unpack (chars)"         prop_unpack_c
+    , testProperty "unpack (lazy bytes)"    prop_unpack_l
+    , testProperty "unpack (lazy chars)"    prop_unpack_lc
     , testProperty "packUptoLenBytes"       prop_packUptoLenBytes
     , testProperty "packUptoLenChars"       prop_packUptoLenChars
     , testProperty "unpackBytes"            prop_unpackBytes

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -51,7 +51,7 @@ import           TestFramework
 #endif
 
 import           Test.QuickCheck
-                   ( Arbitrary(..), oneof, choose, listOf, elements )
+                   ( Arbitrary(..), oneof, choose, listOf, elements, getUnicodeString )
 import           Test.QuickCheck.Property
                    ( printTestCase, morallyDubiousIOProperty )
 
@@ -299,7 +299,7 @@ instance Arbitrary Action where
       , W8  <$> arbitrary
       , W8S <$> listOf arbitrary
         -- ensure that larger character codes are also tested
-      , String <$> listOf ((\c -> chr (ord c * ord c)) <$> arbitrary)
+      , String . getUnicodeString <$> arbitrary
       , pure Flush
         -- never request more than 64kb free space
       , (EnsureFree . (`mod` 0xffff)) <$> arbitrary

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -72,7 +72,7 @@ executable test-builder
                     deepseq,
                     QuickCheck                 >= 2.4 && < 3,
                     byteorder                  == 1.0.*,
-                    dlist                      >= 0.5 && < 0.8,
+                    dlist                      >= 0.5 && < 0.9,
                     directory,
                     mtl                        >= 2.0 && < 2.3,
                     HUnit,


### PR DESCRIPTION
This fixes nearly all of the tests for compatibility with QuickCheck 2.10, allowing the testsuite to be run with GHC 8.6. The tests still failing are the following in the `P:
 * `compare 7`
 * `scanl1`
 * `scanr`
 * `scanr1`

Fixing these should merely involve adapting them to use `ASCIIChar` and `ASCIIString` instead of `Char` and `String`.