### PR TITLE
Replace flag 'integer-simple' with flag 'integer-gmp'

### DIFF
--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -105,7 +105,7 @@ import           GHC.Types   (Int(..))
 # if __GLASGOW_HASKELL__ < 611
 import GHC.Integer.Internals
 # else
-import GHC.Integer.GMP.Internals
+import GHC.Integer.GMP.Internals -- for S# constructor
 # endif
 #endif
 

--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -105,7 +105,7 @@ import           GHC.Types   (Int(..))
 # if __GLASGOW_HASKELL__ < 611
 import GHC.Integer.Internals
 # else
-import GHC.Integer.GMP.Internals -- for S# constructor
+import GHC.Integer.GMP.Internals (Integer(S#))
 # endif
 #endif
 

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -63,9 +63,9 @@ source-repository head
   type:     git
   location: https://github.com/haskell/bytestring
 
-flag integer-simple
-  description: Use the simple integer library instead of GMP
-  default: False
+flag integer-gmp
+  description: Use GMP specific optimizations.
+  default: True
 
 library
   build-depends:     base >= 4.2 && < 5, ghc-prim, deepseq
@@ -134,7 +134,7 @@ library
 
    -- flags for the decimal integer serialization code
   if impl(ghc >= 6.11)
-    if !flag(integer-simple)
+    if flag(integer-gmp)
       cpp-options: -DINTEGER_GMP
       build-depends: integer-gmp >= 0.2
 


### PR DESCRIPTION
The code is using internals of integer-gmp and CPP switches do not relate to
integer-simple at all.