### PR TITLE
Changelog: Warn about upcoming breaking changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 0.10.10.1 <ietf-dane@dukhovni.org> May 2020
 
+ * **Note:** There are several breaking changes planned to be included in v0.11.
+   Please ensure that your package has appropriate upper bounds on bytestring,
+   to minimize avoidable breakage.
  * Fix off-by-one infinite loop in primMapByteStringBounded.
  * Document inadvertent 0.10.6.0 behaviour change in findSubstrings
  * Fix findSubString and findSubstrings tests

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
  * **Note:** There are several breaking changes planned to be included in v0.11.
    Please ensure that your package has appropriate upper bounds on bytestring,
-   to minimize avoidable breakage.
+   in order to minimize avoidable breakage.
  * Add `takeWhileEnd`, `dropWhileEnd` and `strip`  for strict bytestrings
 
 0.10.10.1 – June 2020


### PR DESCRIPTION
One concern that frequently came up in discussions over breaking changes is that many packages currently don't specify an upper bound on `bytestring`. The note I'm adding here is meant to help remediate that situation.

The planned breaking changes I'm currently aware of are:

* #174 
* #180 

and potentially the result of #140.

