### PR TITLE
Add D.BS.B.P.I.boundedPrim to fix typo in "boudedPrim"

### DIFF
--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -694,7 +694,7 @@ char8 = (fromIntegral . ord) >$< word8
 -- | UTF-8 encode a 'Char'.
 {-# INLINE charUtf8 #-}
 charUtf8 :: BoundedPrim Char
-charUtf8 = boudedPrim 4 (encodeCharUtf8 f1 f2 f3 f4)
+charUtf8 = boundedPrim 4 (encodeCharUtf8 f1 f2 f3 f4)
   where
     pokeN n io op  = io op >> return (op `plusPtr` n)
 

--- a/Data/ByteString/Builder/Prim/ASCII.hs
+++ b/Data/ByteString/Builder/Prim/ASCII.hs
@@ -112,7 +112,7 @@ foreign import ccall unsafe "static _hs_bytestring_long_long_int_dec" c_long_lon
 
 {-# INLINE encodeIntDecimal #-}
 encodeIntDecimal :: Integral a => Int -> BoundedPrim a
-encodeIntDecimal bound = boudedPrim bound $ c_int_dec . fromIntegral
+encodeIntDecimal bound = boundedPrim bound $ c_int_dec . fromIntegral
 
 -- | Decimal encoding of an 'Int8'.
 {-# INLINE int8Dec #-}
@@ -133,7 +133,7 @@ int32Dec = encodeIntDecimal 11
 -- | Decimal encoding of an 'Int64'.
 {-# INLINE int64Dec #-}
 int64Dec :: BoundedPrim Int64
-int64Dec = boudedPrim 20 $ c_long_long_int_dec . fromIntegral
+int64Dec = boundedPrim 20 $ c_long_long_int_dec . fromIntegral
 
 -- | Decimal encoding of an 'Int'.
 {-# INLINE intDec #-}
@@ -154,7 +154,7 @@ foreign import ccall unsafe "static _hs_bytestring_long_long_uint_dec" c_long_lo
 
 {-# INLINE encodeWordDecimal #-}
 encodeWordDecimal :: Integral a => Int -> BoundedPrim a
-encodeWordDecimal bound = boudedPrim bound $ c_uint_dec . fromIntegral
+encodeWordDecimal bound = boundedPrim bound $ c_uint_dec . fromIntegral
 
 -- | Decimal encoding of a 'Word8'.
 {-# INLINE word8Dec #-}
@@ -174,7 +174,7 @@ word32Dec = encodeWordDecimal 10
 -- | Decimal encoding of a 'Word64'.
 {-# INLINE word64Dec #-}
 word64Dec :: BoundedPrim Word64
-word64Dec = boudedPrim 20 $ c_long_long_uint_dec . fromIntegral
+word64Dec = boundedPrim 20 $ c_long_long_uint_dec . fromIntegral
 
 -- | Decimal encoding of a 'Word'.
 {-# INLINE wordDec #-}
@@ -199,7 +199,7 @@ foreign import ccall unsafe "static _hs_bytestring_long_long_uint_hex" c_long_lo
 {-# INLINE encodeWordHex #-}
 encodeWordHex :: forall a. (Storable a, Integral a) => BoundedPrim a
 encodeWordHex =
-    boudedPrim (2 * sizeOf (undefined :: a)) $ c_uint_hex  . fromIntegral
+    boundedPrim (2 * sizeOf (undefined :: a)) $ c_uint_hex  . fromIntegral
 
 -- | Hexadecimal encoding of a 'Word8'.
 {-# INLINE word8Hex #-}
@@ -219,7 +219,7 @@ word32Hex = encodeWordHex
 -- | Hexadecimal encoding of a 'Word64'.
 {-# INLINE word64Hex #-}
 word64Hex :: BoundedPrim Word64
-word64Hex = boudedPrim 16 $ c_long_long_uint_hex . fromIntegral
+word64Hex = boundedPrim 16 $ c_long_long_uint_hex . fromIntegral
 
 -- | Hexadecimal encoding of a 'Word'.
 {-# INLINE wordHex #-}

--- a/Data/ByteString/Builder/Prim/Internal.hs
+++ b/Data/ByteString/Builder/Prim/Internal.hs
@@ -20,7 +20,7 @@
 -- standard encodings of standard Haskell values.
 --
 -- If you need to write your own builder primitives, then be aware that you are
--- writing code with /all saftey belts off/; i.e.,
+-- writing code with /all safety belts off/; i.e.,
 -- *this is the code that might make your application vulnerable to buffer-overflow attacks!*
 -- The "Data.ByteString.Builder.Prim.Tests" module provides you with
 -- utilities for testing your encodings thoroughly.
@@ -42,7 +42,7 @@ module Data.ByteString.Builder.Prim.Internal (
 
   -- * Bounded-size builder primitives
   , BoundedPrim
-  , boudedPrim
+  , boundedPrim
   , sizeBound
   , runB
 
@@ -64,6 +64,8 @@ module Data.ByteString.Builder.Prim.Internal (
   , (>$<)
   , (>*<)
 
+  -- * Deprecated
+  , boudedPrim
   ) where
 
 import Foreign
@@ -231,6 +233,10 @@ data BoundedPrim a = BP {-# UNPACK #-} !Int (a -> Ptr Word8 -> IO (Ptr Word8))
 sizeBound :: BoundedPrim a -> Int
 sizeBound (BP b _) = b
 
+boundedPrim :: Int -> (a -> Ptr Word8 -> IO (Ptr Word8)) -> BoundedPrim a
+boundedPrim = BP
+
+{-# DEPRECATED boudedPrim "Use 'boundedPrim' instead" #-}
 boudedPrim :: Int -> (a -> Ptr Word8 -> IO (Ptr Word8)) -> BoundedPrim a
 boudedPrim = BP
 


### PR DESCRIPTION
`boudedPrim` is deprecated.

Fixes #48.