### PR TITLE
Deprecate Data.ByteString.Lazy.Builder.*

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
  * Add `takeWhileEnd`, `dropWhileEnd` and `strip`  for strict bytestrings
  * Add `IsList` instances
+ * Deprecate `Data.ByteString.Lazy.Builder`
 
 0.10.10.1 – June 2020
 

--- a/Data/ByteString/Lazy/Builder.hs
+++ b/Data/ByteString/Lazy/Builder.hs
@@ -1,10 +1,10 @@
 
 -- | We decided to rename the Builder modules. Sorry about that.
 --
--- The old names will hang about for at least once release cycle before we
--- deprecate them and then later remove them.
+-- The old names will hang about for at least once release cycle and then later remove them.
 --
-module Data.ByteString.Lazy.Builder (
+module Data.ByteString.Lazy.Builder
+  {-# DEPRECATED "Use Data.ByteString.Builder instead" #-} (
   module Data.ByteString.Builder
 ) where
 

--- a/Data/ByteString/Lazy/Builder/ASCII.hs
+++ b/Data/ByteString/Lazy/Builder/ASCII.hs
@@ -4,10 +4,10 @@
 -- In additon, the ASCII module has been merged into the main
 -- "Data.ByteString.Builder" module.
 --
--- The old names will hang about for at least once release cycle before we
--- deprecate them and then later remove them.
+-- The old names will hang about for at least once release cycle and then later remove them.
 --
-module Data.ByteString.Lazy.Builder.ASCII (
+module Data.ByteString.Lazy.Builder.ASCII
+  {-# DEPRECATED "Use Data.ByteString.Builder instead" #-} (
   module Data.ByteString.Builder
 , byteStringHexFixed
 , lazyByteStringHexFixed
@@ -19,6 +19,8 @@ import qualified Data.ByteString.Lazy as L
 
 byteStringHexFixed :: S.ByteString -> Builder
 byteStringHexFixed = byteStringHex
+{-# DEPRECATED byteStringHexFixed "Use byteStringHex instead" #-}
 
 lazyByteStringHexFixed :: L.ByteString -> Builder
 lazyByteStringHexFixed = lazyByteStringHex
+{-# DEPRECATED lazyByteStringHexFixed "Use lazyByteStringHex instead" #-}

--- a/Data/ByteString/Lazy/Builder/Extras.hs
+++ b/Data/ByteString/Lazy/Builder/Extras.hs
@@ -1,10 +1,10 @@
 
 -- | We decided to rename the Builder modules. Sorry about that.
 --
--- The old names will hang about for at least once release cycle before we
--- deprecate them and then later remove them.
+-- The old names will hang about for at least once release cycle and then later remove them.
 --
-module Data.ByteString.Lazy.Builder.Extras (
+module Data.ByteString.Lazy.Builder.Extras
+  {-# DEPRECATED "Use Data.ByteString.Builder.Extra instead" #-} (
   module Data.ByteString.Builder.Extra
 ) where
 


### PR DESCRIPTION
It's been planned to deprecate for 8 years, so let's do this.