### PR TITLE
Document behaviour of split and splitWith on empty input

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -973,7 +973,7 @@ spanEnd  p ps = splitAt (findFromEndUntil (not.p) ps) ps
 -- separators result in an empty component in the output.  eg.
 --
 -- > splitWith (==97) "aabbaca" == ["","","bb","c",""] -- fromEnum 'a' == 97
--- > splitWith (==97) []        == []
+-- > splitWith undefined ""     == []                  -- and not [""]
 --
 splitWith :: (Word8 -> Bool) -> ByteString -> [ByteString]
 splitWith _pred (PS _  _   0) = []
@@ -1007,6 +1007,7 @@ splitWith pred_ (PS fp off len) = splitWith0 pred# off len fp
 -- > split 10  "a\nb\nd\ne" == ["a","b","d","e"]   -- fromEnum '\n' == 10
 -- > split 97  "aXaXaXa"    == ["","X","X","X",""] -- fromEnum 'a' == 97
 -- > split 120 "x"          == ["",""]             -- fromEnum 'x' == 120
+-- > split undefined ""     == []                  -- and not [""]
 --
 -- and
 --

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -598,6 +598,7 @@ breakEnd f = B.breakEnd (f . w2c)
 -- > split '\n' "a\nb\nd\ne" == ["a","b","d","e"]
 -- > split 'a'  "aXaXaXa"    == ["","X","X","X",""]
 -- > split 'x'  "x"          == ["",""]
+-- > split undefined ""      == []  -- and not [""]
 --
 -- and
 --
@@ -618,6 +619,7 @@ split = B.split . c2w
 -- separators result in an empty component in the output.  eg.
 --
 -- > splitWith (=='a') "aabbaca" == ["","","bb","c",""]
+-- > splitWith undefined ""      == []  -- and not [""]
 --
 splitWith :: (Char -> Bool) -> ByteString -> [ByteString]
 splitWith f = B.splitWith (f . w2c)

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -793,7 +793,7 @@ span p = break (not . p)
 -- separators result in an empty component in the output.  eg.
 --
 -- > splitWith (==97) "aabbaca" == ["","","bb","c",""] -- fromEnum 'a' == 97
--- > splitWith (==97) []        == []
+-- > splitWith undefined ""     == []                  -- and not [""]
 --
 splitWith :: (Word8 -> Bool) -> ByteString -> [ByteString]
 splitWith _ Empty          = []
@@ -811,6 +811,7 @@ splitWith p (Chunk c0 cs0) = comb [] (S.splitWith p c0) cs0
 -- > split 10  "a\nb\nd\ne" == ["a","b","d","e"]   -- fromEnum '\n' == 10
 -- > split 97  "aXaXaXa"    == ["","X","X","X",""] -- fromEnum 'a' == 97
 -- > split 120 "x"          == ["",""]             -- fromEnum 'x' == 120
+-- > split undefined ""     == []                  -- and not [""]
 --
 -- and
 --

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -493,6 +493,7 @@ spanChar = L.spanByte . c2w
 -- > split '\n' "a\nb\nd\ne" == ["a","b","d","e"]
 -- > split 'a'  "aXaXaXa"    == ["","X","X","X"]
 -- > split 'x'  "x"          == ["",""]
+-- > split undefined ""      == []  -- and not [""]
 --
 -- and
 --
@@ -513,6 +514,7 @@ split = L.split . c2w
 -- separators result in an empty component in the output.  eg.
 --
 -- > splitWith (=='a') "aabbaca" == ["","","bb","c",""]
+-- > splitWith undefined ""      == []  -- and not [""]
 --
 splitWith :: (Char -> Bool) -> ByteString -> [ByteString]
 splitWith f = L.splitWith (f . w2c)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -741,11 +741,15 @@ prop_span xs a = (span (/=a) xs) == (let (x,y) = L.span (/=a) (pack xs) in (unpa
 prop_split c xs = (map L.unpack . map checkInvariant . L.split c $ xs)
                == (map P.unpack . P.split c . P.pack . L.unpack $ xs)
 
+prop_splitWith_empty f = L.splitWith f mempty == []
+
 prop_splitWith f xs = (l1 == l2 || l1 == l2+1) &&
         sum (map L.length splits) == L.length xs - l2
   where splits = L.splitWith f xs
         l1 = fromIntegral (length splits)
         l2 = L.length (L.filter f xs)
+
+prop_splitWith_D_empty f = D.splitWith f mempty == []
 
 prop_splitWith_D f xs = (l1 == l2 || l1 == l2+1) &&
         sum (map D.length splits) == D.length xs - l2
@@ -753,11 +757,15 @@ prop_splitWith_D f xs = (l1 == l2 || l1 == l2+1) &&
         l1 = fromIntegral (length splits)
         l2 = D.length (D.filter f xs)
 
+prop_splitWith_C_empty f = C.splitWith f mempty == []
+
 prop_splitWith_C f xs = (l1 == l2 || l1 == l2+1) &&
         sum (map C.length splits) == C.length xs - l2
   where splits = C.splitWith f xs
         l1 = fromIntegral (length splits)
         l2 = C.length (C.filter f xs)
+
+prop_split_empty c = L.split c mempty == []
 
 prop_joinsplit c xs = L.intercalate (pack [c]) (L.split c xs) == id xs
 
@@ -921,11 +929,15 @@ prop_wordsLC (String8 xs) =
 prop_unwordsSBB xss = C.unwords (map C.pack xss) == C.pack (unwords xss)
 prop_unwordsSLC xss = LC.unwords (map LC.pack xss) == LC.pack (unwords xss)
 
+prop_splitWithBB_empty f = P.splitWith f mempty == []
+
 prop_splitWithBB f xs = (l1 == l2 || l1 == l2+1) &&
         sum (map P.length splits) == P.length xs - l2
   where splits = P.splitWith f xs
         l1 = length splits
         l2 = P.length (P.filter f xs)
+
+prop_splitBB_empty c = P.split c mempty == []
 
 prop_joinsplitBB c xs = P.intercalate (P.pack [c]) (P.split c xs) == xs
 
@@ -2325,7 +2337,9 @@ bb_tests =
     , testProperty "unwords "       prop_unwordsSBB
     , testProperty "unwords "       prop_unwordsSLC
 --     , testProperty "wordstokens"    prop_wordstokensBB
+    , testProperty "splitWith_empty" prop_splitWithBB_empty
     , testProperty "splitWith"      prop_splitWithBB
+    , testProperty "split_empty"    prop_splitBB_empty
     , testProperty "joinsplit"      prop_joinsplitBB
     , testProperty "intercalate"    prop_intercalatePL
 --     , testProperty "lineIndices"    prop_lineIndices1BB
@@ -2428,9 +2442,13 @@ ll_tests =
 --  , testProperty "break/breakByte"    prop_breakByte
 --  , testProperty "span/spanByte"      prop_spanByte
     , testProperty "split"              prop_split
+    , testProperty "splitWith_empty"    prop_splitWith_empty
     , testProperty "splitWith"          prop_splitWith
+    , testProperty "splitWith_empty"    prop_splitWith_D_empty
     , testProperty "splitWith"          prop_splitWith_D
+    , testProperty "splitWith_empty"    prop_splitWith_C_empty
     , testProperty "splitWith"          prop_splitWith_C
+    , testProperty "split_empty"        prop_split_empty
     , testProperty "join.split/id"      prop_joinsplit
 --  , testProperty "join/joinByte"      prop_joinjoinByte
     , testProperty "group"              prop_group


### PR DESCRIPTION
Fixes #56 by clarifying and documenting existing behaviour. Supersedes #94.