### PR TITLE
Really no offset

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1539,7 +1539,7 @@ tails :: ByteString -> [ByteString]
 tails p | null p    = [empty]
         | otherwise = p : tails (unsafeTail p)
 
--- less efficent spacewise: tails (PS x s l) = [PS x (s+n) (l-n) | n <- [0..l]]
+-- less efficent spacewise: tails (BS x l) = [BS (plusForeignPtr x n) (l-n) | n <- [0..l]]
 
 -- ---------------------------------------------------------------------
 -- ** Ordered 'ByteString's

--- a/tests/Hash.hs
+++ b/tests/Hash.hs
@@ -64,16 +64,15 @@ mulHi a b = fromIntegral (r `shiftR` 32)
 newtype OrdString = OrdString S.ByteString
      deriving Show
 
-eq a@(S.PS p s l) b@(S.PS p' s' l')
-         | l /= l'            = False    -- short cut on length
-         | p == p' && s == s' = True     -- short cut for the same string
-         | otherwise          = compare a b == EQ
+eq a@(S.BS p l) b@(S.BS p' l')
+         | l /= l'   = False    -- short cut on length
+         | p == p'   = True     -- short cut for the same string
+         | otherwise = compare a b == EQ
   where
-    compare (S.PS fp1 off1 len1) (S.PS fp2 off2 len2) = S.inlinePerformIO $
+    compare (S.BS fp1 len1) (S.BS fp2 len2) = S.inlinePerformIO $
         withForeignPtr fp1 $ \p1 ->
             withForeignPtr fp2 $ \p2 ->
-                cmp (p1 `plusPtr` off1)
-                    (p2 `plusPtr` off2) 0 len1 len2
+                cmp p1 p2 0 len1 len2
 
 cmp :: Ptr Word8 -> Ptr Word8 -> Int -> Int -> Int-> IO Ordering
 cmp !p1 !p2 !n len1 len2

--- a/tests/Words.hs
+++ b/tests/Words.hs
@@ -35,14 +35,14 @@ instance Ord OrdString where
     compare (OrdString p) (OrdString q) = compareBytes p q
 
 compareBytes :: ByteString -> ByteString -> Ordering
-compareBytes (PS fp1 off1 len1) (PS fp2 off2 len2)
-    | len1 == 0  && len2 == 0                     = EQ  -- short cut for empty strings
-    | fp1 == fp2 && off1 == off2 && len1 == len2  = EQ  -- short cut for the same string
+compareBytes (BS fp1 len1) (BS fp2 len2)
+    | len1 == 0  && len2 == 0     = EQ  -- short cut for empty strings
+    | fp1 == fp2 && len1 == len2  = EQ  -- short cut for the same string
 --  | max len1 len2 > 1                           = inlinePerformIO $
     | otherwise                                   = inlinePerformIO $
     withForeignPtr fp1 $ \p1 ->
     withForeignPtr fp2 $ \p2 -> do
-        i <- memcmp (p1 `plusPtr` off1) (p2 `plusPtr` off2) (fromIntegral $ min len1 len2)
+        i <- memcmp p1 p2 (fromIntegral $ min len1 len2)
         return $! case i `compare` 0 of
                     EQ  -> len1 `compare` len2
                     x   -> x

--- a/tests/test-compare.hs
+++ b/tests/test-compare.hs
@@ -37,14 +37,13 @@ main = do
 ------------------------------------------------------------------------
 
 compareBytes :: ByteString -> ByteString -> Ordering
-compareBytes (PS fp1 off1 len1) (PS fp2 off2 len2)
---    | len1 == 0  && len2 == 0                     = EQ  -- short cut for empty strings
---    | fp1 == fp2 && off1 == off2 && len1 == len2  = EQ  -- short cut for the same string
+compareBytes (BS fp1 len1) (BS fp2 len2)
+--    | len1 == 0  && len2 == 0     = EQ  -- short cut for empty strings
+--    | fp1 == fp2 && len1 == len2  = EQ  -- short cut for the same string
     | otherwise                                   = inlinePerformIO $
     withForeignPtr fp1 $ \p1 ->
         withForeignPtr fp2 $ \p2 ->
-            cmp (p1 `plusPtr` off1)
-                (p2 `plusPtr` off2) 0 len1 len2
+            cmp p1 p2 0 len1 len2
  
 cmp :: Ptr Word8 -> Ptr Word8 -> Int -> Int -> Int-> IO Ordering
 cmp p1 p2 n len1 len2
@@ -58,13 +57,13 @@ cmp p1 p2 n len1 len2
                 LT -> return LT
                 GT -> return GT
  
-compareBytesC (PS x1 s1 l1) (PS x2 s2 l2)
-    | l1 == 0  && l2 == 0               = EQ  -- short cut for empty strings
-    | x1 == x2 && s1 == s2 && l1 == l2  = EQ  -- short cut for the same string
+compareBytesC (BS x1 l1) (BS x2 l2)
+    | l1 == 0  && l2 == 0   = EQ  -- short cut for empty strings
+    | x1 == x2 && l1 == l2  = EQ  -- short cut for the same string
     | otherwise                         = inlinePerformIO $
         withForeignPtr x1 $ \p1 ->
         withForeignPtr x2 $ \p2 -> do
-            i <- memcmp (p1 `plusPtr` s1) (p2 `plusPtr` s2) (fromIntegral $ min l1 l2)
+            i <- memcmp p1 p2 (fromIntegral $ min l1 l2)
             return $! case i `compare` 0 of
                         EQ  -> l1 `compare` l2
                         x   -> x

--- a/tests/unpack.hs
+++ b/tests/unpack.hs
@@ -26,11 +26,11 @@ my_unpack ps = build (unpackFoldr ps)
 {-# INLINE my_unpack #-}
 
 unpackFoldr :: ByteString -> (Word8 -> a -> a) -> a -> a
-unpackFoldr (PS fp off len) f ch =
+unpackFoldr (BS fp len) f ch =
     unsafePerformIO $ withForeignPtr fp $ \p -> do
         let loop a b c | a `seq` b `seq` False = undefined -- needs the strictness
             loop _ (-1) acc = return acc
             loop q n    acc = do
                a <- peekByteOff q n
                loop q (n-1) (a `f` acc)
-        loop (p `plusPtr` off) (len-1) ch
+        loop p (len-1) ch


### PR DESCRIPTION
This removes all vestiges of the `PS` constructor, other than the backwards-compatibility pattern definition.
Also fixes the commented out alternative implementation of `Data.ByteString.Char8.lines`. Perhaps worth
using instead of the current one???