### PR TITLE
Drop 7x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,32 +11,7 @@ defaults:
     shell: bash
 
 jobs:
-  ghcprep:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
-    steps:
-    - uses: actions/checkout@v2
-    - name: Update cabal package database
-      run: cabal update
-    - uses: actions/cache@v2.1.4
-      name: Cache cabal stuff
-      with:
-        path: |
-          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
-          dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}
-    - name: Install GHC
-      run: |
-        sudo add-apt-repository ppa:hvr/ghc -y
-        sudo apt-get update
-        sudo apt-get install ghc-${{ matrix.ghc }}
-
   build:
-    needs: ghcprep
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -80,7 +55,6 @@ jobs:
       run: cabal haddock
 
   build-freebsd:
-    needs: build
     # This job intentionally is using macOS because at the time of the writing
     # Linux and Windows environments don't have the necessary virtualization features.
     # See https://github.com/vmactions/freebsd-vm#under-the-hood.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ defaults:
     shell: bash
 
 jobs:
-  build-old:
+  ghcprep:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['7.0.4', '7.2.2', '7.4.2', '7.6.3', '7.8.4']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
     steps:
     - uses: actions/checkout@v2
     - name: Update cabal package database
@@ -34,24 +34,15 @@ jobs:
         sudo add-apt-repository ppa:hvr/ghc -y
         sudo apt-get update
         sudo apt-get install ghc-${{ matrix.ghc }}
-    - name: Test
-      run: |
-        cabal sdist -z -o .
-        cabal get bytestring-*.tar.gz
-        cd bytestring-*/
-        cp ../cabal.project .
-        cabal test -w /opt/ghc/bin/ghc-${{ matrix.ghc }} --test-show-details=direct
-    - name: Haddock
-      run: cabal haddock -w /opt/ghc/bin/ghc-${{ matrix.ghc }}
 
   build:
-    needs: build-old
+    needs: ghcprep
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['7.10', '8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
         include:
         - os: windows-latest
           ghc: 'latest'

--- a/Data/ByteString/Builder.hs
+++ b/Data/ByteString/Builder.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE CPP, MagicHash #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports -fno-warn-orphans #-}
-#if __GLASGOW_HASKELL__ >= 701
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Trustworthy #-}
-#endif
+{-# OPTIONS_GHC -fno-warn-unused-imports -fno-warn-orphans #-}
 {- | Copyright   : (c) 2010 Jasper Van der Jeugt
                    (c) 2010 - 2011 Simon Meier
 License     : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables, CPP, ForeignFunctionInterface,
              MagicHash, UnboxedTuples #-}
 {-# OPTIONS_HADDOCK not-home #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- | Copyright : (c) 2010 - 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
 --
@@ -95,14 +93,6 @@ import GHC.Num.Integer
 
 #define HAS_INTEGER_CONSTR 1
 #define IS S#
-
-# if !(MIN_VERSION_base(4,8,0))
-import           Data.Monoid (mappend)
-# endif
-
-# if __GLASGOW_HASKELL__ < 710
-import           GHC.Num     (quotRemInteger)
-# endif
 
 import GHC.Integer.GMP.Internals
 #endif

--- a/Data/ByteString/Builder/Extra.hs
+++ b/Data/ByteString/Builder/Extra.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP          #-}
 {-# LANGUAGE BangPatterns #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -----------------------------------------------------------------------------
 -- | Copyright : (c) 2010      Jasper Van der Jeugt
 --               (c) 2010-2011 Simon Meier

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -1,11 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, CPP, BangPatterns, RankNTypes, TupleSections #-}
-#if __GLASGOW_HASKELL__ == 700
--- This is needed as a workaround for an old bug in GHC 7.0.1 (Trac #4498)
-{-# LANGUAGE MonoPatBinds #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 {-# OPTIONS_HADDOCK not-home #-}
 -- | Copyright : (c) 2010 - 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -134,12 +128,8 @@ module Data.ByteString.Builder.Internal (
 
 import           Control.Arrow (second)
 
-#if !(MIN_VERSION_base(4,11,0)) && MIN_VERSION_base(4,9,0)
+#if !(MIN_VERSION_base(4,11,0))
 import           Data.Semigroup (Semigroup((<>)))
-#endif
-#if !(MIN_VERSION_base(4,8,0))
-import           Data.Monoid
-import           Control.Applicative (Applicative(..),(<$>))
 #endif
 
 import qualified Data.ByteString               as S
@@ -153,18 +143,9 @@ import           GHC.IO.Handle.Types (Handle__, haByteBuffer, haBufferMode)
 import           System.IO (hFlush, BufferMode(..), Handle)
 import           Data.IORef
 
-#if MIN_VERSION_base(4,4,0)
-#if MIN_VERSION_base(4,7,0)
 import           Foreign
-#else
-import           Foreign hiding (unsafeForeignPtrToPtr)
-#endif
 import           Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import           System.IO.Unsafe (unsafeDupablePerformIO)
-#else
-import           Foreign
-import           GHC.IO (unsafeDupablePerformIO)
-#endif
 
 ------------------------------------------------------------------------------
 -- Buffers
@@ -401,21 +382,15 @@ empty = Builder ($)
 append :: Builder -> Builder -> Builder
 append (Builder b1) (Builder b2) = Builder $ b1 . b2
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup Builder where
   {-# INLINE (<>) #-}
   (<>) = append
-#endif
 
 instance Monoid Builder where
   {-# INLINE mempty #-}
   mempty = empty
   {-# INLINE mappend #-}
-#if MIN_VERSION_base(4,9,0)
   mappend = (<>)
-#else
-  mappend = append
-#endif
   {-# INLINE mconcat #-}
   mconcat = foldr mappend mempty
 

--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -1,13 +1,7 @@
-{-# LANGUAGE CPP, BangPatterns, ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns, ScopedTypeVariables #-}
 {-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
-#if __GLASGOW_HASKELL__ == 700
--- This is needed as a workaround for an old bug in GHC 7.0.1 (Trac #4498)
-{-# LANGUAGE MonoPatBinds #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 {- | Copyright : (c) 2010-2011 Simon Meier
                  (c) 2010      Jasper van der Jeugt
 License        : BSD3-style (see LICENSE)
@@ -472,17 +466,9 @@ import qualified Data.ByteString.Builder.Prim.Internal as I (size, sizeBound)
 import           Data.ByteString.Builder.Prim.Binary
 import           Data.ByteString.Builder.Prim.ASCII
 
-#if MIN_VERSION_base(4,4,0)
-#if MIN_VERSION_base(4,7,0)
 import           Foreign
 import           Foreign.C.Types
-#else
-import           Foreign hiding (unsafeForeignPtrToPtr)
-#endif
 import           Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
-#else
-import           Foreign
-#endif
 import           GHC.Word (Word8 (..))
 import           GHC.Exts
 import           GHC.IO
@@ -680,12 +666,6 @@ primMapLazyByteStringBounded w =
 ------------------------------------------------------------------------------
 -- Raw CString encoding
 ------------------------------------------------------------------------------
-
-#if !MIN_VERSION_base(4,7,0)
--- eqWord# et al. return Bools prior to GHC 7.6
-isTrue# :: Bool -> Bool
-isTrue# x = x
-#endif
 
 -- | A null-terminated ASCII encoded 'CString'. Null characters are not representable.
 --

--- a/Data/ByteString/Builder/Prim/ASCII.hs
+++ b/Data/ByteString/Builder/Prim/ASCII.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables, ForeignFunctionInterface #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- | Copyright   : (c) 2010 Jasper Van der Jeugt
 --                 (c) 2010 - 2011 Simon Meier
 -- License       : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/Prim/Binary.hs
+++ b/Data/ByteString/Builder/Prim/Binary.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- | Copyright   : (c) 2010-2011 Simon Meier
 -- License       : BSD3-style (see LICENSE)
 --

--- a/Data/ByteString/Builder/Prim/Internal.hs
+++ b/Data/ByteString/Builder/Prim/Internal.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables, CPP #-}
-#if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 {-# OPTIONS_HADDOCK not-home #-}
 -- |
 -- Copyright   : 2010-2011 Simon Meier, 2010 Jasper van der Jeugt

--- a/Data/ByteString/Builder/Prim/Internal/Base16.hs
+++ b/Data/ByteString/Builder/Prim/Internal/Base16.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -27,17 +24,9 @@ module Data.ByteString.Builder.Prim.Internal.Base16 (
 import qualified Data.ByteString          as S
 import qualified Data.ByteString.Internal as S
 
-#if MIN_VERSION_base(4,4,0)
-#if MIN_VERSION_base(4,7,0)
 import           Foreign
-#else
-import           Foreign hiding (unsafePerformIO, unsafeForeignPtrToPtr)
-#endif
 import           Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import           System.IO.Unsafe (unsafePerformIO)
-#else
-import           Foreign
-#endif
 
 -- Creating the encoding table
 ------------------------------

--- a/Data/ByteString/Builder/Prim/Internal/Floating.hs
+++ b/Data/ByteString/Builder/Prim/Internal/Floating.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 -- |
 -- Copyright   : (c) 2010 Simon Meier
 --

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -1,8 +1,7 @@
-{-# LANGUAGE CPP, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
 {-# OPTIONS_HADDOCK prune #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module      : Data.ByteString.Char8
@@ -266,16 +265,9 @@ import Data.ByteString (empty,null,length,tail,init,append
 
 import Data.ByteString.Internal
 
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative ((<$>))
-#endif
-
 import Data.Char    ( isSpace )
-import Data.Word
-#if MIN_VERSION_base(4,9,0)
 -- See bytestring #70
 import GHC.Char (eqChar)
-#endif
 import qualified Data.List as List (intersperse)
 
 import System.IO    (Handle,stdout)
@@ -544,21 +536,12 @@ break f = B.break (f . w2c)
 {-# INLINE [1] break #-}
 
 -- See bytestring #70
-#if MIN_VERSION_base(4,9,0)
 {-# RULES
 "ByteString specialise break (x==)" forall x.
     break (x `eqChar`) = breakChar x
 "ByteString specialise break (==x)" forall x.
     break (`eqChar` x) = breakChar x
   #-}
-#else
-{-# RULES
-"ByteString specialise break (x==)" forall x.
-    break (x ==) = breakChar x
-"ByteString specialise break (==x)" forall x.
-    break (== x) = breakChar x
-  #-}
-#endif
 
 -- INTERNAL:
 
@@ -721,7 +704,6 @@ findIndices :: (Char -> Bool) -> ByteString -> [Int]
 findIndices f = B.findIndices (f . w2c)
 {-# INLINE [1] findIndices #-}
 
-#if MIN_VERSION_base(4,9,0)
 {-# RULES
 "ByteString specialise findIndex (x==)" forall x.
     findIndex (x `eqChar`) = elemIndex x
@@ -732,18 +714,6 @@ findIndices f = B.findIndices (f . w2c)
 "ByteString specialise findIndices (==x)" forall x.
     findIndices (`eqChar` x) = elemIndices x
   #-}
-#else
-{-# RULES
-"ByteString specialise findIndex (x==)" forall x.
-    findIndex (x==) = elemIndex x
-"ByteString specialise findIndex (==x)" forall x.
-    findIndex (==x) = elemIndex x
-"ByteString specialise findIndices (x==)" forall x.
-    findIndices (x==) = elemIndices x
-"ByteString specialise findIndices (==x)" forall x.
-    findIndices (==x) = elemIndices x
-  #-}
-#endif
 
 
 -- | count returns the number of times its argument appears in the ByteString

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -3,12 +3,8 @@
             UnboxedTuples, DeriveDataTypeable #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
-#endif
-#if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- |
@@ -33,9 +29,7 @@ module Data.ByteString.Internal (
         -- * The @ByteString@ type and representation
         ByteString
         ( BS
-#if __GLASGOW_HASKELL__ >= 800
         , PS -- backwards compatibility shim
-#endif
         ), -- instances: Eq, Ord, Show, Read, Data, Typeable
 
         -- * Internal indexing
@@ -111,27 +105,15 @@ import Control.Monad            (void)
 import Foreign.ForeignPtr       (ForeignPtr, withForeignPtr)
 import Foreign.Ptr              (Ptr, FunPtr, plusPtr, minusPtr)
 import Foreign.Storable         (Storable(..))
-
-#if MIN_VERSION_base(4,5,0) || __GLASGOW_HASKELL__ >= 703
 import Foreign.C.Types          (CInt(..), CSize(..))
-#else
-import Foreign.C.Types          (CInt, CSize)
-#endif
-
 import Foreign.C.String         (CString)
 
 #if MIN_VERSION_base(4,13,0)
 import Data.Semigroup           (Semigroup (sconcat, stimes))
-import Data.List.NonEmpty       (NonEmpty ((:|)))
-#elif MIN_VERSION_base(4,9,0)
+#else
 import Data.Semigroup           (Semigroup ((<>), sconcat, stimes))
+#endif
 import Data.List.NonEmpty       (NonEmpty ((:|)))
-#endif
-
-#if !(MIN_VERSION_base(4,8,0))
-import Data.Monoid              (Monoid(..))
-#endif
-
 
 import Control.DeepSeq          (NFData(rnf))
 
@@ -147,21 +129,10 @@ import Data.Typeable            (Typeable)
 import Data.Data                (Data(..), mkNoRepType)
 
 import GHC.Base                 (nullAddr#,realWorld#,unsafeChr)
-
-#if MIN_VERSION_base(4,7,0)
 import GHC.Exts                 (IsList(..))
-#endif
-
-#if MIN_VERSION_base(4,4,0)
 import GHC.CString              (unpackCString#)
-#else
-import GHC.Base                 (unpackCString#)
-#endif
-
 import GHC.Prim                 (Addr#)
-
 import GHC.IO                   (IO(IO),unsafeDupablePerformIO)
-
 import GHC.ForeignPtr           (ForeignPtr(ForeignPtr)
 #if __GLASGOW_HASKELL__ < 900
                                 , newForeignPtr_
@@ -231,7 +202,6 @@ data ByteString = BS {-# UNPACK #-} !(ForeignPtr Word8) -- payload
     deriving (Typeable)
 
 
-#if __GLASGOW_HASKELL__ >= 800
 -- |
 -- @'PS' foreignPtr offset length@ represents a 'ByteString' with data
 -- backed by a given @foreignPtr@, starting at a given @offset@ in bytes
@@ -251,7 +221,6 @@ pattern PS fp zero len <- BS fp ((0,) -> (zero, len)) where
 #if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE PS #-}
 #endif
-#endif
 
 instance Eq  ByteString where
     (==)    = eq
@@ -259,20 +228,14 @@ instance Eq  ByteString where
 instance Ord ByteString where
     compare = compareBytes
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup ByteString where
     (<>)    = append
     sconcat (b:|bs) = concat (b:bs)
-    stimes = times
-#endif
+    stimes  = times
 
 instance Monoid ByteString where
     mempty  = BS nullForeignPtr 0
-#if MIN_VERSION_base(4,9,0)
     mappend = (<>)
-#else
-    mappend = append
-#endif
     mconcat = concat
 
 instance NFData ByteString where
@@ -284,13 +247,11 @@ instance Show ByteString where
 instance Read ByteString where
     readsPrec p str = [ (packChars x, y) | (x, y) <- readsPrec p str ]
 
-#if MIN_VERSION_base(4,7,0)
 -- | @since 0.10.12.0
 instance IsList ByteString where
   type Item ByteString = Word8
   fromList = packBytes
   toList   = unpackBytes
-#endif
 
 -- | Beware: 'fromString' truncates multi-byte characters to octets.
 -- e.g. "枯朶に烏のとまりけり秋の暮" becomes �6k�nh~�Q��n�
@@ -694,7 +655,6 @@ concat = \bss0 -> goLen0 bss0 bss0
    concat [x] = x
  #-}
 
-#if MIN_VERSION_base(4,9,0)
 -- | /O(log n)/ Repeats the given ByteString n times.
 times :: Integral a => a -> ByteString -> ByteString
 times n (BS fp len)
@@ -719,7 +679,6 @@ times n (BS fp len)
         memcpy (destptr `plusPtr` copied) destptr copied
         fillFrom destptr (copied * 2)
       | otherwise = memcpy (destptr `plusPtr` copied) destptr (size - copied)
-#endif
 
 -- | Add two non-negative numbers. Errors out on overflow.
 checkedAdd :: String -> Int -> Int -> Int

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE CPP, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}
 {-# OPTIONS_HADDOCK prune #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module      : Data.ByteString.Lazy
@@ -227,10 +225,6 @@ import qualified Data.ByteString.Internal as S
 import qualified Data.ByteString.Unsafe as S
 import Data.ByteString.Lazy.Internal
 
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative      ((<$>))
-import Data.Monoid              (Monoid(..))
-#endif
 import Control.Monad            (mplus)
 import Data.Word                (Word8)
 import Data.Int                 (Int64)

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE CPP, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_HADDOCK prune #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module      : Data.ByteString.Lazy.Char8
@@ -224,10 +222,6 @@ import Data.ByteString.Lazy.Internal
 import Data.ByteString.Internal (c2w,w2c,isSpaceWord8
                                 ,intmaxQuot10,intmaxRem10
                                 ,intminQuot10,intminRem10)
-
-#if !(MIN_VERSION_base(4,8,0))
-import Control.Applicative ((<$>))
-#endif
 
 import Data.Int (Int64)
 import Data.Word

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -2,9 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
-#if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- |
@@ -58,14 +56,10 @@ import Foreign.Storable (Storable(sizeOf))
 
 #if MIN_VERSION_base(4,13,0)
 import Data.Semigroup   (Semigroup (sconcat, stimes))
-import Data.List.NonEmpty (NonEmpty ((:|)))
-#elif MIN_VERSION_base(4,9,0)
+#else
 import Data.Semigroup   (Semigroup ((<>), sconcat, stimes))
+#endif
 import Data.List.NonEmpty (NonEmpty ((:|)))
-#endif
-#if !(MIN_VERSION_base(4,8,0))
-import Data.Monoid      (Monoid(..))
-#endif
 import Control.DeepSeq  (NFData, rnf)
 
 import Data.String      (IsString(..))
@@ -73,9 +67,7 @@ import Data.String      (IsString(..))
 import Data.Typeable            (Typeable)
 import Data.Data                (Data(..), mkNoRepType)
 
-#if MIN_VERSION_base(4,7,0)
 import GHC.Exts                 (IsList(..))
-#endif
 
 -- | A space-efficient representation of a 'Word8' vector, supporting many
 -- efficient operations.
@@ -94,20 +86,14 @@ instance Eq  ByteString where
 instance Ord ByteString where
     compare = cmp
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup ByteString where
     (<>)    = append
     sconcat (b:|bs) = concat (b:bs)
-    stimes = times
-#endif
+    stimes  = times
 
 instance Monoid ByteString where
     mempty  = Empty
-#if MIN_VERSION_base(4,9,0)
     mappend = (<>)
-#else
-    mappend = append
-#endif
     mconcat = concat
 
 instance NFData ByteString where
@@ -120,13 +106,11 @@ instance Show ByteString where
 instance Read ByteString where
     readsPrec p str = [ (packChars x, y) | (x, y) <- readsPrec p str ]
 
-#if MIN_VERSION_base(4,7,0)
 -- | @since 0.10.12.0
 instance IsList ByteString where
   type Item ByteString = Word8
   fromList = packBytes
   toList   = unpackBytes
-#endif
 
 -- | Beware: 'fromString' truncates multi-byte characters to octets.
 -- e.g. "枯朶に烏のとまりけり秋の暮" becomes �6k�nh~�Q��n�
@@ -275,7 +259,6 @@ concat = to
     to []               = Empty
     to (cs:css)         = go cs css
 
-#if MIN_VERSION_base(4,9,0)
 -- | Repeats the given ByteString n times.
 times :: Integral a => a -> ByteString -> ByteString
 times 0 _ = Empty
@@ -287,7 +270,6 @@ times n lbs0
   where
     go Empty = times (n-1) lbs0
     go (Chunk c cs) = Chunk c (go cs)
-#endif
 
 ------------------------------------------------------------------------
 -- Conversions

--- a/Data/ByteString/Short.hs
+++ b/Data/ByteString/Short.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
-#endif
 
 -- |
 -- Module      : Data.ByteString.Short

--- a/Data/ByteString/Unsafe.hs
+++ b/Data/ByteString/Unsafe.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
-#if __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Unsafe #-}
-#endif
 
 -- |
 -- Module      : Data.ByteString.Unsafe

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -54,9 +54,13 @@ Author:              Don Stewart,
 Maintainer:          Haskell Bytestring Team <andrew.lelechenko@gmail.com>, Core Libraries Committee
 Homepage:            https://github.com/haskell/bytestring
 Bug-reports:         https://github.com/haskell/bytestring/issues
-Tested-With:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2,
-                     GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2,
-                     GHC==7.2.2, GHC==7.0.4
+Tested-With:         GHC==9.0.1,
+                     GHC==8.10.4,
+                     GHC==8.8.4,
+                     GHC==8.6.5,
+                     GHC==8.4.4,
+                     GHC==8.2.2,
+                     GHC==8.0.2
 Build-Type:          Simple
 Cabal-Version:       >= 1.10
 extra-source-files:  README.md Changelog.md
@@ -70,7 +74,7 @@ flag integer-simple
   default: False
 
 library
-  build-depends:     base >= 4.3 && < 5, ghc-prim, deepseq
+  build-depends:     base >= 4.9 && < 5, ghc-prim, deepseq
 
   exposed-modules:   Data.ByteString
                      Data.ByteString.Char8
@@ -89,12 +93,11 @@ library
                      -- perhaps only exposed temporarily
                      Data.ByteString.Builder.Internal
                      Data.ByteString.Builder.Prim.Internal
-  other-modules:
-                     Data.ByteString.Builder.ASCII
-                     Data.ByteString.Builder.Prim.Binary
+  other-modules:     Data.ByteString.Builder.ASCII
                      Data.ByteString.Builder.Prim.ASCII
-                     Data.ByteString.Builder.Prim.Internal.Floating
+                     Data.ByteString.Builder.Prim.Binary
                      Data.ByteString.Builder.Prim.Internal.Base16
+                     Data.ByteString.Builder.Prim.Internal.Floating
 
   default-language:  Haskell2010
   other-extensions:  CPP,
@@ -143,9 +146,18 @@ library
 test-suite prop-compiled
   type:             exitcode-stdio-1.0
   main-is:          Properties.hs
-  other-modules:    Rules
+  other-modules:    Data.ByteString
+                    Data.ByteString.Char8
+                    Data.ByteString.Internal
+                    Data.ByteString.Lazy
+                    Data.ByteString.Lazy.Char8
+                    Data.ByteString.Lazy.Internal
+                    Data.ByteString.Short
+                    Data.ByteString.Short.Internal
+                    Data.ByteString.Unsafe
                     QuickCheckUtils
-  hs-source-dirs:   tests
+                    Rules
+  hs-source-dirs:   tests .
   build-depends:    base, bytestring, ghc-prim, deepseq,
                     tasty, tasty-quickcheck
   ghc-options:      -fwarn-unused-binds
@@ -155,21 +167,50 @@ test-suite prop-compiled
 test-suite lazy-hclose
   type:             exitcode-stdio-1.0
   main-is:          LazyHClose.hs
-  hs-source-dirs:   tests
+  hs-source-dirs:   tests .
   build-depends:    base, bytestring, ghc-prim, deepseq,
                     tasty, tasty-quickcheck
   ghc-options:      -fwarn-unused-binds
                     -threaded -rtsopts
   default-language: Haskell2010
+  other-modules:    Data.ByteString
+                    Data.ByteString.Char8
+                    Data.ByteString.Internal
+                    Data.ByteString.Lazy
+                    Data.ByteString.Lazy.Char8
+                    Data.ByteString.Lazy.Internal
+                    Data.ByteString.Short
+                    Data.ByteString.Short.Internal
+                    Data.ByteString.Unsafe
 
 test-suite test-builder
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   tests/builder
+  hs-source-dirs:   tests/builder .
   main-is:          TestSuite.hs
-  other-modules:    Data.ByteString.Builder.Tests
-                    Data.ByteString.Builder.Prim.Tests
+  other-modules:    Data.ByteString
+                    Data.ByteString.Builder
+                    Data.ByteString.Builder.ASCII
+                    Data.ByteString.Builder.Extra
+                    Data.ByteString.Builder.Internal
+                    Data.ByteString.Builder.Prim
+                    Data.ByteString.Builder.Prim.ASCII
+                    Data.ByteString.Builder.Prim.Binary
+                    Data.ByteString.Builder.Prim.Internal
+                    Data.ByteString.Builder.Prim.Internal.Base16
+                    Data.ByteString.Builder.Prim.Internal.Floating
                     Data.ByteString.Builder.Prim.TestUtils
+                    Data.ByteString.Builder.Prim.Tests
+                    Data.ByteString.Builder.Tests
+                    Data.ByteString.Char8
+                    Data.ByteString.Internal
+                    Data.ByteString.Lazy
+                    Data.ByteString.Lazy.Char8
+                    Data.ByteString.Lazy.Internal
+                    Data.ByteString.Short
+                    Data.ByteString.Short.Internal
+                    Data.ByteString.Unsafe
   build-depends:    base, bytestring, ghc-prim,
+                    byteorder,
                     deepseq,
                     dlist                      >= 0.5 && < 0.9,
                     transformers               >= 0.3,
@@ -183,15 +224,32 @@ test-suite test-builder
 
 benchmark bytestring-bench
   main-is:          BenchAll.hs
-  other-modules:    BenchBoundsCheckFusion
+  other-modules:    Data.ByteString
+                    Data.ByteString.Builder
+                    Data.ByteString.Builder.ASCII
+                    Data.ByteString.Builder.Extra
+                    Data.ByteString.Builder.Internal
+                    Data.ByteString.Builder.Prim
+                    Data.ByteString.Builder.Prim.ASCII
+                    Data.ByteString.Builder.Prim.Binary
+                    Data.ByteString.Builder.Prim.Internal
+                    Data.ByteString.Builder.Prim.Internal.Base16
+                    Data.ByteString.Builder.Prim.Internal.Floating
+                    Data.ByteString.Char8
+                    Data.ByteString.Internal
+                    Data.ByteString.Lazy
+                    Data.ByteString.Lazy.Internal
+                    Data.ByteString.Short
+                    Data.ByteString.Short.Internal
+                    Data.ByteString.Unsafe
+                    BenchBoundsCheckFusion
                     BenchCSV
                     BenchIndices
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   bench
+  hs-source-dirs:   bench .
   default-language: Haskell2010
   ghc-options:      -O2
-  build-depends:    base,
-                    bytestring,
+  build-depends:    base, bytestring, ghc-prim,
                     deepseq,
                     dlist,
                     tasty-bench,

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -110,13 +110,6 @@ library
                      ScopedTypeVariables
                      RankNTypes
                      NamedFieldPuns
---  if impl(ghc >= 7.2)
---    other-extensions: Trustworthy, Unsafe
-  -- older ghc had issues with language pragmas guarded by cpp
-  if impl(ghc < 7)
-    default-extensions: CPP, MagicHash, UnboxedTuples,
-                        DeriveDataTypeable, BangPatterns,
-                        NamedFieldPuns
 
   ghc-options:      -Wall -fwarn-tabs
                     -O2
@@ -133,31 +126,17 @@ library
    -- flags for the decimal integer serialization code
   if impl(ghc >= 8.11)
     build-depends: ghc-bignum >= 1.0
-
-  if impl(ghc >= 6.11) && impl(ghc < 8.11)
+  else
     if !flag(integer-simple)
       cpp-options: -DINTEGER_GMP
       build-depends: integer-gmp >= 0.2
 
-  if impl(ghc >= 6.9) && impl(ghc < 6.11)
-    cpp-options: -DINTEGER_GMP
-    build-depends: integer >= 0.1 && < 0.2
-
 test-suite prop-compiled
   type:             exitcode-stdio-1.0
   main-is:          Properties.hs
-  other-modules:    Data.ByteString
-                    Data.ByteString.Char8
-                    Data.ByteString.Internal
-                    Data.ByteString.Lazy
-                    Data.ByteString.Lazy.Char8
-                    Data.ByteString.Lazy.Internal
-                    Data.ByteString.Short
-                    Data.ByteString.Short.Internal
-                    Data.ByteString.Unsafe
-                    QuickCheckUtils
+  other-modules:    QuickCheckUtils
                     Rules
-  hs-source-dirs:   tests .
+  hs-source-dirs:   tests
   build-depends:    base, bytestring, ghc-prim, deepseq,
                     tasty, tasty-quickcheck
   ghc-options:      -fwarn-unused-binds
@@ -167,50 +146,21 @@ test-suite prop-compiled
 test-suite lazy-hclose
   type:             exitcode-stdio-1.0
   main-is:          LazyHClose.hs
-  hs-source-dirs:   tests .
+  hs-source-dirs:   tests
   build-depends:    base, bytestring, ghc-prim, deepseq,
                     tasty, tasty-quickcheck
   ghc-options:      -fwarn-unused-binds
                     -threaded -rtsopts
   default-language: Haskell2010
-  other-modules:    Data.ByteString
-                    Data.ByteString.Char8
-                    Data.ByteString.Internal
-                    Data.ByteString.Lazy
-                    Data.ByteString.Lazy.Char8
-                    Data.ByteString.Lazy.Internal
-                    Data.ByteString.Short
-                    Data.ByteString.Short.Internal
-                    Data.ByteString.Unsafe
 
 test-suite test-builder
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   tests/builder .
+  hs-source-dirs:   tests/builder
   main-is:          TestSuite.hs
-  other-modules:    Data.ByteString
-                    Data.ByteString.Builder
-                    Data.ByteString.Builder.ASCII
-                    Data.ByteString.Builder.Extra
-                    Data.ByteString.Builder.Internal
-                    Data.ByteString.Builder.Prim
-                    Data.ByteString.Builder.Prim.ASCII
-                    Data.ByteString.Builder.Prim.Binary
-                    Data.ByteString.Builder.Prim.Internal
-                    Data.ByteString.Builder.Prim.Internal.Base16
-                    Data.ByteString.Builder.Prim.Internal.Floating
-                    Data.ByteString.Builder.Prim.TestUtils
+  other-modules:    Data.ByteString.Builder.Prim.TestUtils
                     Data.ByteString.Builder.Prim.Tests
                     Data.ByteString.Builder.Tests
-                    Data.ByteString.Char8
-                    Data.ByteString.Internal
-                    Data.ByteString.Lazy
-                    Data.ByteString.Lazy.Char8
-                    Data.ByteString.Lazy.Internal
-                    Data.ByteString.Short
-                    Data.ByteString.Short.Internal
-                    Data.ByteString.Unsafe
   build-depends:    base, bytestring, ghc-prim,
-                    byteorder,
                     deepseq,
                     dlist                      >= 0.5 && < 0.9,
                     transformers               >= 0.3,
@@ -224,32 +174,15 @@ test-suite test-builder
 
 benchmark bytestring-bench
   main-is:          BenchAll.hs
-  other-modules:    Data.ByteString
-                    Data.ByteString.Builder
-                    Data.ByteString.Builder.ASCII
-                    Data.ByteString.Builder.Extra
-                    Data.ByteString.Builder.Internal
-                    Data.ByteString.Builder.Prim
-                    Data.ByteString.Builder.Prim.ASCII
-                    Data.ByteString.Builder.Prim.Binary
-                    Data.ByteString.Builder.Prim.Internal
-                    Data.ByteString.Builder.Prim.Internal.Base16
-                    Data.ByteString.Builder.Prim.Internal.Floating
-                    Data.ByteString.Char8
-                    Data.ByteString.Internal
-                    Data.ByteString.Lazy
-                    Data.ByteString.Lazy.Internal
-                    Data.ByteString.Short
-                    Data.ByteString.Short.Internal
-                    Data.ByteString.Unsafe
-                    BenchBoundsCheckFusion
+  other-modules:    BenchBoundsCheckFusion
                     BenchCSV
                     BenchIndices
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   bench .
+  hs-source-dirs:   bench
   default-language: Haskell2010
   ghc-options:      -O2
-  build-depends:    base, bytestring, ghc-prim,
+  build-depends:    base,
+                    bytestring,
                     deepseq,
                     dlist,
                     tasty-bench,

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -99,17 +99,10 @@ size_t fps_count(unsigned char *p, size_t len, unsigned char w) {
     return c;
 }
 
-/* This wrapper is here so that we can copy a sub-range of a ByteArray#.
-   We cannot construct a pointer to the interior of an unpinned ByteArray#,
-   except by doing an unsafe ffi call, and adjusting the pointer C-side. */
-void * fps_memcpy_offsets(void *dst, size_t dst_off, const void *src, size_t src_off, size_t n) {
-    return memcpy(dst + dst_off, src + src_off, n);
-}
-
 int fps_compare(const void *a, const void *b) {
-  return (int)*(unsigned char*)a - (int)*(unsigned char*)b;
+    return (int)*(unsigned char*)a - (int)*(unsigned char*)b;
 }
 
 void fps_sort(unsigned char *p, size_t len) {
-  return qsort(p, len, 1, fps_compare);
+    return qsort(p, len, 1, fps_compare);
 }

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
@@ -30,9 +29,7 @@ import Data.Word
 import Data.Maybe
 import Data.Int (Int64)
 import Data.Monoid
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup
-#endif
 import GHC.Exts (Int(..), newPinnedByteArray#, unsafeFreezeByteArray#)
 import GHC.ST (ST(..), runST)
 
@@ -1481,13 +1478,11 @@ prop_packZipWithLC f xs ys = LC.pack (LC.zipWith f xs ys) == LC.packZipWith f xs
 
 prop_unzipBB x = let (xs,ys) = unzip x in (P.pack xs, P.pack ys) == P.unzip x
 
-#if MIN_VERSION_base(4,9,0)
 prop_stimesBB :: NonNegative Int -> P.ByteString -> Bool
 prop_stimesBB (NonNegative i) bs = stimes i bs == mtimesDefault i bs
 
 prop_stimesLL :: NonNegative Int -> L.ByteString -> Bool
 prop_stimesLL (NonNegative i) bs = stimes i bs == mtimesDefault i bs
-#endif
 
 -- prop_zipwith_spec f p q =
 --   P.pack (P.zipWith f p q) == P.zipWith' f p q
@@ -2487,10 +2482,8 @@ bb_tests =
     , testProperty "unzip"          prop_unzipBB
     , testProperty "concatMap"      prop_concatMapBB
 --  , testProperty "join/joinByte"  prop_join_spec
-#if MIN_VERSION_base(4,9,0)
     , testProperty "stimes strict"  prop_stimesBB
     , testProperty "stimes lazy"    prop_stimesLL
-#endif
     ]
 
 

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -94,20 +94,10 @@ testHandlePutBuilder =
     testRecipe :: (UnicodeString, UnicodeString, UnicodeString, Recipe) -> Property
     testRecipe args =
       ioProperty $ do
-        let (UnicodeString a1, UnicodeString a2, UnicodeString a3, recipe) = args
-#if MIN_VERSION_base(4,5,0)
-            before  = a1
-            between = a2
-            after   = a3
-#else
-            -- See https://github.com/haskell/bytestring/issues/212
-            -- write -> read does not roundrip with GHC 7.2 and
-            -- characters in the \xEF00-\xEFFF range.
-            safeChr = \c -> c < '\xEF00' || c > '\xEFFF'
-            before  = filter safeChr a1
-            between = filter safeChr a2
-            after   = filter safeChr a3
-#endif
+        let { ( UnicodeString before
+              , UnicodeString between
+              , UnicodeString after
+              , recipe) = args }
         (tempFile, tempH) <- openTempFile "." "test-builder.tmp"
         -- switch to UTF-8 encoding
         hSetEncoding tempH utf8


### PR DESCRIPTION
With `bytestring` 0.11 no longer fully compatible with GHC prior to 8.0, drop support for GHC 7.x and older, by requiring base >= 4.9.
This also makes it possible to shed considerable CPP baggage.