### PR TITLE
Use qsort to sort short ByteString

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1514,7 +1514,12 @@ tails p | null p    = [empty]
 
 -- | /O(n)/ Sort a ByteString efficiently, using counting sort.
 sort :: ByteString -> ByteString
-sort (BS input l) = unsafeCreate l $ \p -> allocaArray 256 $ \arr -> do
+sort (BS input l)
+  -- qsort outperforms counting sort for small arrays
+  | l <= 20 = unsafeCreate l $ \ptr -> withForeignPtr input $ \inp -> do
+    memcpy ptr inp (fromIntegral l)
+    c_sort ptr (fromIntegral l)
+  | otherwise = unsafeCreate l $ \p -> allocaArray 256 $ \arr -> do
 
     _ <- memset (castPtr arr) 0 (256 * fromIntegral (sizeOf (undefined :: CSize)))
     withForeignPtr input (\x -> countOccurrences arr x l)

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -79,7 +79,7 @@ module Data.ByteString.Internal (
         c_intersperse,          -- :: Ptr Word8 -> Ptr Word8 -> CSize -> Word8 -> IO ()
         c_maximum,              -- :: Ptr Word8 -> CSize -> IO Word8
         c_minimum,              -- :: Ptr Word8 -> CSize -> IO Word8
-        c_count,                -- :: Ptr Word8 -> CSize -> Word8 -> IO CInt
+        c_count,                -- :: Ptr Word8 -> CSize -> Word8 -> IO CSize
         c_sort,                 -- :: Ptr Word8 -> CSize -> IO ()
 
         -- * Chars
@@ -758,7 +758,7 @@ foreign import ccall unsafe "static fpstring.h fps_minimum" c_minimum
     :: Ptr Word8 -> CSize -> IO Word8
 
 foreign import ccall unsafe "static fpstring.h fps_count" c_count
-    :: Ptr Word8 -> CSize -> Word8 -> IO CULong
+    :: Ptr Word8 -> CSize -> Word8 -> IO CSize
 
 foreign import ccall unsafe "static fpstring.h fps_sort" c_sort
     :: Ptr Word8 -> CSize -> IO ()

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -80,6 +80,7 @@ module Data.ByteString.Internal (
         c_maximum,              -- :: Ptr Word8 -> CInt -> IO Word8
         c_minimum,              -- :: Ptr Word8 -> CInt -> IO Word8
         c_count,                -- :: Ptr Word8 -> CInt -> Word8 -> IO CInt
+        c_sort,                 -- :: Ptr Word8 -> CInt -> IO ()
 
         -- * Chars
         w2c, c2w, isSpaceWord8, isSpaceChar8,
@@ -758,3 +759,6 @@ foreign import ccall unsafe "static fpstring.h fps_minimum" c_minimum
 
 foreign import ccall unsafe "static fpstring.h fps_count" c_count
     :: Ptr Word8 -> CULong -> Word8 -> IO CULong
+
+foreign import ccall unsafe "static fpstring.h fps_sort" c_sort
+    :: Ptr Word8 -> CULong -> IO ()

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -75,12 +75,12 @@ module Data.ByteString.Internal (
         memset,                 -- :: Ptr Word8 -> Word8 -> CSize -> IO (Ptr Word8)
 
         -- * cbits functions
-        c_reverse,              -- :: Ptr Word8 -> Ptr Word8 -> CInt -> IO ()
-        c_intersperse,          -- :: Ptr Word8 -> Ptr Word8 -> CInt -> Word8 -> IO ()
-        c_maximum,              -- :: Ptr Word8 -> CInt -> IO Word8
-        c_minimum,              -- :: Ptr Word8 -> CInt -> IO Word8
-        c_count,                -- :: Ptr Word8 -> CInt -> Word8 -> IO CInt
-        c_sort,                 -- :: Ptr Word8 -> CInt -> IO ()
+        c_reverse,              -- :: Ptr Word8 -> Ptr Word8 -> CSize -> IO ()
+        c_intersperse,          -- :: Ptr Word8 -> Ptr Word8 -> CSize -> Word8 -> IO ()
+        c_maximum,              -- :: Ptr Word8 -> CSize -> IO Word8
+        c_minimum,              -- :: Ptr Word8 -> CSize -> IO Word8
+        c_count,                -- :: Ptr Word8 -> CSize -> Word8 -> IO CInt
+        c_sort,                 -- :: Ptr Word8 -> CSize -> IO ()
 
         -- * Chars
         w2c, c2w, isSpaceWord8, isSpaceChar8,
@@ -746,19 +746,19 @@ memset p w s = c_memset p (fromIntegral w) s
 --
 
 foreign import ccall unsafe "static fpstring.h fps_reverse" c_reverse
-    :: Ptr Word8 -> Ptr Word8 -> CULong -> IO ()
+    :: Ptr Word8 -> Ptr Word8 -> CSize -> IO ()
 
 foreign import ccall unsafe "static fpstring.h fps_intersperse" c_intersperse
-    :: Ptr Word8 -> Ptr Word8 -> CULong -> Word8 -> IO ()
+    :: Ptr Word8 -> Ptr Word8 -> CSize -> Word8 -> IO ()
 
 foreign import ccall unsafe "static fpstring.h fps_maximum" c_maximum
-    :: Ptr Word8 -> CULong -> IO Word8
+    :: Ptr Word8 -> CSize -> IO Word8
 
 foreign import ccall unsafe "static fpstring.h fps_minimum" c_minimum
-    :: Ptr Word8 -> CULong -> IO Word8
+    :: Ptr Word8 -> CSize -> IO Word8
 
 foreign import ccall unsafe "static fpstring.h fps_count" c_count
-    :: Ptr Word8 -> CULong -> Word8 -> IO CULong
+    :: Ptr Word8 -> CSize -> Word8 -> IO CULong
 
 foreign import ccall unsafe "static fpstring.h fps_sort" c_sort
-    :: Ptr Word8 -> CULong -> IO ()
+    :: Ptr Word8 -> CSize -> IO ()

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -101,9 +101,9 @@ import Foreign.Ptr              (Ptr, FunPtr, plusPtr)
 import Foreign.Storable         (Storable(..))
 
 #if MIN_VERSION_base(4,5,0) || __GLASGOW_HASKELL__ >= 703
-import Foreign.C.Types          (CInt(..), CSize(..), CULong(..))
+import Foreign.C.Types          (CInt(..), CSize(..))
 #else
-import Foreign.C.Types          (CInt, CSize, CULong)
+import Foreign.C.Types          (CInt, CSize)
 #endif
 
 import Foreign.C.String         (CString)

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -587,7 +587,7 @@ copyAddrToByteArray0 src dst len s =
         = copyAddrToByteArray0 src dst    len s  #-}
 
 foreign import ccall unsafe "fpstring.h fps_memcpy_offsets"
-  memcpy_AddrToByteArray :: MutableByteArray# s -> CLong -> Addr# -> CLong -> CSize -> IO ()
+  memcpy_AddrToByteArray :: MutableByteArray# s -> CSize -> Addr# -> CSize -> CSize -> IO ()
 
 foreign import ccall unsafe "string.h memcpy"
   memcpy_AddrToByteArray0 :: MutableByteArray# s -> Addr# -> CSize -> IO ()
@@ -608,7 +608,7 @@ copyByteArrayToAddr0 src dst len s =
         = copyByteArrayToAddr0 src    dst len s  #-}
 
 foreign import ccall unsafe "fpstring.h fps_memcpy_offsets"
-  memcpy_ByteArrayToAddr :: Addr# -> CLong -> ByteArray# -> CLong -> CSize -> IO ()
+  memcpy_ByteArrayToAddr :: Addr# -> CSize -> ByteArray# -> CSize -> CSize -> IO ()
 
 foreign import ccall unsafe "string.h memcpy"
   memcpy_ByteArrayToAddr0 :: Addr# -> ByteArray# -> CSize -> IO ()
@@ -635,8 +635,7 @@ copyByteArray# src src_off dst dst_off len s =
     unST_ st s = case unST st s of (# s, _ #) -> s
 
 foreign import ccall unsafe "fpstring.h fps_memcpy_offsets"
-  memcpy_ByteArray :: MutableByteArray# s -> CLong
-                   -> ByteArray# -> CLong -> CSize -> IO ()
+  memcpy_ByteArray :: MutableByteArray# s -> CSize -> ByteArray# -> CSize -> CSize -> IO ()
 #endif
 
 -- | /O(n)./ Construct a new @ShortByteString@ from a @CString@. The

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -573,7 +573,7 @@ copyByteArrayToAddr# = GHC.Exts.copyByteArrayToAddr#
 #else
 
 copyAddrToByteArray# src dst dst_off len s =
-  unIO_ (memcpy_AddrToByteArray dst (clong dst_off) src 0 (csize len)) s
+  unIO_ (memcpy_AddrToByteArray dst (csize dst_off) src 0 (csize len)) s
 
 copyAddrToByteArray0 :: Addr# -> MutableByteArray# s -> Int#
                      -> State# RealWorld -> State# RealWorld
@@ -594,7 +594,7 @@ foreign import ccall unsafe "string.h memcpy"
 
 
 copyByteArrayToAddr# src src_off dst len s =
-  unIO_ (memcpy_ByteArrayToAddr dst 0 src (clong src_off) (csize len)) s
+  unIO_ (memcpy_ByteArrayToAddr dst 0 src (csize src_off) (csize len)) s
 
 copyByteArrayToAddr0 :: ByteArray# -> Addr# -> Int#
                      -> State# RealWorld -> State# RealWorld
@@ -617,9 +617,6 @@ foreign import ccall unsafe "string.h memcpy"
 unIO_ :: IO () -> State# RealWorld -> State# RealWorld
 unIO_ io s = case unIO io s of (# s, _ #) -> s
 
-clong :: Int# -> CLong
-clong i# = fromIntegral (I# i#)
-
 csize :: Int# -> CSize
 csize i# = fromIntegral (I# i#)
 #endif
@@ -629,7 +626,7 @@ copyByteArray# = GHC.Exts.copyByteArray#
 #else
 copyByteArray# src src_off dst dst_off len s =
     unST_ (unsafeIOToST
-      (memcpy_ByteArray dst (clong dst_off) src (clong src_off) (csize len))) s
+      (memcpy_ByteArray dst (csize dst_off) src (csize src_off) (csize len))) s
   where
     unST (ST st) = st
     unST_ st s = case unST st s of (# s, _ #) -> s

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -18,6 +18,7 @@ import           Gauge
 import           Prelude                               hiding (words)
 
 import qualified Data.ByteString                       as S
+import qualified Data.ByteString.Char8                 as S8
 import qualified Data.ByteString.Lazy                  as L
 
 import           Data.ByteString.Builder
@@ -225,6 +226,9 @@ sanityCheckInfo =
       ]
   ]
 
+sortInputs :: [S.ByteString]
+sortInputs = map (`S.take` S.pack [122, 121 .. 32]) [10..25]
+
 main :: IO ()
 main = do
   mapM_ putStrLn sanityCheckInfo
@@ -387,4 +391,5 @@ main = do
         , bench "balancedSlow"    $ partitionLazy (\x -> hashWord8 x < w 128)
         ]
       ]
+    , bgroup "sort" $ map (\s -> bench (S8.unpack s) $ nf S.sort s) sortInputs
     ]

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -88,3 +88,11 @@ void * fps_memcpy_offsets(void       *dst, unsigned long dst_off,
                           const void *src, unsigned long src_off, size_t n) {
     return memcpy(dst + dst_off, src + src_off, n);
 }
+
+int fps_compare(const void *a, const void *b) {
+  return *(unsigned char*)a - *(unsigned char*)b;
+}
+
+void fps_sort(unsigned char *p, unsigned long len) {
+  return qsort(p, len, 1, fps_compare);
+}

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -84,8 +84,7 @@ size_t fps_count(unsigned char *p, size_t len, unsigned char w) {
 /* This wrapper is here so that we can copy a sub-range of a ByteArray#.
    We cannot construct a pointer to the interior of an unpinned ByteArray#,
    except by doing an unsafe ffi call, and adjusting the pointer C-side. */
-void * fps_memcpy_offsets(void       *dst, unsigned long dst_off,
-                          const void *src, unsigned long src_off, size_t n) {
+void * fps_memcpy_offsets(void *dst, size_t dst_off, const void *src, size_t src_off, size_t n) {
     return memcpy(dst + dst_off, src + src_off, n);
 }
 

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -32,7 +32,7 @@
 #include "fpstring.h"
 
 /* copy a string in reverse */
-void fps_reverse(unsigned char *q, unsigned char *p, unsigned long n) {
+void fps_reverse(unsigned char *q, unsigned char *p, size_t n) {
     p += n-1;
     while (n-- != 0)
         *q++ = *p--;
@@ -42,7 +42,7 @@ void fps_reverse(unsigned char *q, unsigned char *p, unsigned long n) {
    of the duplicated string */
 void fps_intersperse(unsigned char *q,
                      unsigned char *p,
-                     unsigned long n,
+                     size_t n,
                      unsigned char c) {
 
     while (n > 1) {
@@ -55,7 +55,7 @@ void fps_intersperse(unsigned char *q,
 }
 
 /* find maximum char in a packed string */
-unsigned char fps_maximum(unsigned char *p, unsigned long len) {
+unsigned char fps_maximum(unsigned char *p, size_t len) {
     unsigned char *q, c = *p;
     for (q = p; q < p + len; q++)
         if (*q > c)
@@ -64,7 +64,7 @@ unsigned char fps_maximum(unsigned char *p, unsigned long len) {
 }
 
 /* find minimum char in a packed string */
-unsigned char fps_minimum(unsigned char *p, unsigned long  len) {
+unsigned char fps_minimum(unsigned char *p, size_t len) {
     unsigned char *q, c = *p;
     for (q = p; q < p + len; q++)
         if (*q < c)
@@ -73,7 +73,7 @@ unsigned char fps_minimum(unsigned char *p, unsigned long  len) {
 }
 
 /* count the number of occurences of a char in a string */
-unsigned long fps_count(unsigned char *p, unsigned long len, unsigned char w) {
+unsigned long fps_count(unsigned char *p, size_t len, unsigned char w) {
     unsigned long c;
     for (c = 0; len-- != 0; ++p)
         if (*p == w)
@@ -93,6 +93,6 @@ int fps_compare(const void *a, const void *b) {
   return (int)*(unsigned char*)a - (int)*(unsigned char*)b;
 }
 
-void fps_sort(unsigned char *p, unsigned long len) {
+void fps_sort(unsigned char *p, size_t len) {
   return qsort(p, len, 1, fps_compare);
 }

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -73,7 +73,7 @@ unsigned char fps_minimum(unsigned char *p, size_t len) {
 }
 
 /* count the number of occurences of a char in a string */
-unsigned long fps_count(unsigned char *p, size_t len, unsigned char w) {
+size_t fps_count(unsigned char *p, size_t len, unsigned char w) {
     unsigned long c;
     for (c = 0; len-- != 0; ++p)
         if (*p == w)

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -90,7 +90,7 @@ void * fps_memcpy_offsets(void       *dst, unsigned long dst_off,
 }
 
 int fps_compare(const void *a, const void *b) {
-  return *(unsigned char*)a - *(unsigned char*)b;
+  return (int)*(unsigned char*)a - (int)*(unsigned char*)b;
 }
 
 void fps_sort(unsigned char *p, unsigned long len) {

--- a/include/fpstring.h
+++ b/include/fpstring.h
@@ -1,11 +1,9 @@
-
 #include <string.h>
 #include <stdlib.h>
 
-void fps_reverse(unsigned char *dest, unsigned char *from, unsigned long  len);
-void fps_intersperse(unsigned char *dest, unsigned char *from, unsigned long  len, unsigned char c);
-unsigned char fps_maximum(unsigned char *p, unsigned long  len);
-unsigned char fps_minimum(unsigned char *p, unsigned long  len);
-unsigned long fps_count(unsigned char *p, unsigned long  len, unsigned char w);
-void fps_sort(unsigned char *p, unsigned long  len);
-
+void fps_reverse(unsigned char *dest, unsigned char *from, size_t len);
+void fps_intersperse(unsigned char *dest, unsigned char *from, size_t len, unsigned char c);
+unsigned char fps_maximum(unsigned char *p, size_t len);
+unsigned char fps_minimum(unsigned char *p, size_t len);
+unsigned long fps_count(unsigned char *p, size_t len, unsigned char w);
+void fps_sort(unsigned char *p, size_t len);

--- a/include/fpstring.h
+++ b/include/fpstring.h
@@ -5,5 +5,5 @@ void fps_reverse(unsigned char *dest, unsigned char *from, size_t len);
 void fps_intersperse(unsigned char *dest, unsigned char *from, size_t len, unsigned char c);
 unsigned char fps_maximum(unsigned char *p, size_t len);
 unsigned char fps_minimum(unsigned char *p, size_t len);
-unsigned long fps_count(unsigned char *p, size_t len, unsigned char w);
+size_t fps_count(unsigned char *p, size_t len, unsigned char w);
 void fps_sort(unsigned char *p, size_t len);

--- a/include/fpstring.h
+++ b/include/fpstring.h
@@ -1,9 +1,11 @@
 
 #include <string.h>
+#include <stdlib.h>
 
 void fps_reverse(unsigned char *dest, unsigned char *from, unsigned long  len);
 void fps_intersperse(unsigned char *dest, unsigned char *from, unsigned long  len, unsigned char c);
 unsigned char fps_maximum(unsigned char *p, unsigned long  len);
 unsigned char fps_minimum(unsigned char *p, unsigned long  len);
 unsigned long fps_count(unsigned char *p, unsigned long  len, unsigned char w);
+void fps_sort(unsigned char *p, unsigned long  len);
 


### PR DESCRIPTION
This is similar in spirit to #123, but includes benchmarks to reproduce results. I also decided to use `qsort` from `stdlib` instead of implementing insertion sort manually, just to minimise changes.
(I have no idea about C, suggestions would be highly appreciated, CC @vdukhovni)

```
countsort

sort/zyxwvutsrq                          mean 299.7 ns  ( +- 19.84 ns  )
sort/zyxwvutsrqp                         mean 320.1 ns  ( +- 23.39 ns  )
sort/zyxwvutsrqpo                        mean 302.7 ns  ( +- 19.03 ns  )
sort/zyxwvutsrqpon                       mean 323.6 ns  ( +- 27.07 ns  )
sort/zyxwvutsrqponm                      mean 336.2 ns  ( +- 39.73 ns  )
sort/zyxwvutsrqponml                     mean 324.9 ns  ( +- 17.24 ns  )
sort/zyxwvutsrqponmlk                    mean 400.2 ns  ( +- 47.64 ns  )
sort/zyxwvutsrqponmlkj                   mean 377.8 ns  ( +- 49.46 ns  )
sort/zyxwvutsrqponmlkji                  mean 390.3 ns  ( +- 49.52 ns  )
sort/zyxwvutsrqponmlkjih                 mean 431.4 ns  ( +- 88.87 ns  )
sort/zyxwvutsrqponmlkjihg                mean 461.8 ns  ( +- 84.46 ns  )
sort/zyxwvutsrqponmlkjihgf               mean 382.9 ns  ( +- 59.26 ns  )
sort/zyxwvutsrqponmlkjihgfe              mean 363.3 ns  ( +- 30.18 ns  )
sort/zyxwvutsrqponmlkjihgfed             mean 370.6 ns  ( +- 48.68 ns  )
sort/zyxwvutsrqponmlkjihgfedc            mean 356.5 ns  ( +- 19.49 ns  )
sort/zyxwvutsrqponmlkjihgfedcb           mean 365.8 ns  ( +- 23.33 ns  )

qsort

sort/zyxwvutsrq                          mean 114.1 ns  ( +- 4.661 ns  )
sort/zyxwvutsrqp                         mean 122.7 ns  ( +- 4.730 ns  )
sort/zyxwvutsrqpo                        mean 136.0 ns  ( +- 5.738 ns  )
sort/zyxwvutsrqpon                       mean 147.4 ns  ( +- 10.86 ns  )
sort/zyxwvutsrqponm                      mean 158.3 ns  ( +- 8.222 ns  )
sort/zyxwvutsrqponml                     mean 168.8 ns  ( +- 13.26 ns  )
sort/zyxwvutsrqponmlk                    mean 216.3 ns  ( +- 11.70 ns  )
sort/zyxwvutsrqponmlkj                   mean 256.4 ns  ( +- 15.16 ns  )
sort/zyxwvutsrqponmlkji                  mean 276.9 ns  ( +- 20.38 ns  )
sort/zyxwvutsrqponmlkjih                 mean 285.3 ns  ( +- 12.04 ns  )
sort/zyxwvutsrqponmlkjihg                mean 342.3 ns  ( +- 17.22 ns  )
sort/zyxwvutsrqponmlkjihgf               mean 405.4 ns  ( +- 25.62 ns  )
sort/zyxwvutsrqponmlkjihgfe              mean 419.0 ns  ( +- 30.76 ns  )
sort/zyxwvutsrqponmlkjihgfed             mean 428.7 ns  ( +- 19.61 ns  )
sort/zyxwvutsrqponmlkjihgfedc            mean 491.1 ns  ( +- 22.98 ns  )
sort/zyxwvutsrqponmlkjihgfedcb           mean 552.5 ns  ( +- 27.65 ns  )
```