### PR TITLE
FindIndices optimized using findIndex and inlining

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1178,7 +1178,7 @@ findIndex k (BS x l) = accursedUnutterablePerformIO $ withForeignPtr x $ \f -> g
                                 if k w
                                   then return (Just n)
                                   else go (ptr `plusPtr` 1) (n+1)
-{-# INLINE findIndex #-}
+{-# INLINE [1] findIndex #-}
 
 -- | /O(n)/ The 'findIndexEnd' function takes a predicate and a 'ByteString' and
 -- returns the index of the last element in the ByteString
@@ -1200,9 +1200,29 @@ findIndexEnd k (BS x l) = accursedUnutterablePerformIO $ withForeignPtr x $ \ f 
 findIndices :: (Word8 -> Bool) -> ByteString -> [Int]
 findIndices p ps = loop 0 ps
    where
-     loop !n !qs | null qs           = []
-                 | p (unsafeHead qs) = n : loop (n+1) (unsafeTail qs)
-                 | otherwise         =     loop (n+1) (unsafeTail qs)
+     loop !n !qs = case findIndex p qs of
+                     Just !i -> 
+                        let !j = n+i
+                         in j : loop (j+1) (unsafeDrop (i+1) qs)
+                     Nothing -> []
+{-# INLINE [1] findIndices #-}
+
+
+#if MIN_VERSION_base(4,9,0)
+{-# RULES
+"ByteString specialise findIndex (x ==)" forall x. findIndex (x`eqWord8`) = elemIndex x
+"ByteString specialise findIndex (== x)" forall x. findIndex (`eqWord8`x) = elemIndex x
+"ByteString specialise findIndices (x ==)" forall x. findIndices (x`eqWord8`) = elemIndices x
+"ByteString specialise findIndices (== x)" forall x. findIndices (`eqWord8`x) = elemIndices x
+  #-}
+#else
+{-# RULES
+"ByteString specialise findIndex (x ==)" forall x. findIndex (x==) = elemIndex x
+"ByteString specialise findIndex (== x)" forall x. findIndex (==x) = elemIndex x
+"ByteString specialise findIndices (x ==)" forall x. findIndices (x==) = elemIndices x
+"ByteString specialise findIndices (== x)" forall x. findIndices (==x) = elemIndices x
+  #-}
+#endif
 
 -- ---------------------------------------------------------------------
 -- Searching ByteStrings

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -693,12 +693,38 @@ elemIndices = B.elemIndices . c2w
 -- returns the index of the first element in the ByteString satisfying the predicate.
 findIndex :: (Char -> Bool) -> ByteString -> Maybe Int
 findIndex f = B.findIndex (f . w2c)
-{-# INLINE findIndex #-}
+{-# INLINE [1] findIndex #-}
 
 -- | The 'findIndices' function extends 'findIndex', by returning the
 -- indices of all elements satisfying the predicate, in ascending order.
 findIndices :: (Char -> Bool) -> ByteString -> [Int]
 findIndices f = B.findIndices (f . w2c)
+{-# INLINE [1] findIndices #-}
+
+#if MIN_VERSION_base(4,9,0)
+{-# RULES
+"ByteString specialise findIndex (x==)" forall x.
+    findIndex (x `eqChar`) = elemIndex x
+"ByteString specialise findIndex (==x)" forall x.
+    findIndex (`eqChar` x) = elemIndex x
+"ByteString specialise findIndices (x==)" forall x.
+    findIndices (x `eqChar`) = elemIndices x
+"ByteString specialise findIndices (==x)" forall x.
+    findIndices (`eqChar` x) = elemIndices x
+  #-}
+#else
+{-# RULES
+"ByteString specialise findIndex (x==)" forall x.
+    findIndex (x==) = elemIndex x
+"ByteString specialise findIndex (==x)" forall x.
+    findIndex (==x) = elemIndex x
+"ByteString specialise findIndices (x==)" forall x.
+    findIndices (x==) = elemIndices x
+"ByteString specialise findIndices (==x)" forall x.
+    findIndices (==x) = elemIndices x
+  #-}
+#endif
+
 
 -- | count returns the number of times its argument appears in the ByteString
 --

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1009,6 +1009,7 @@ findIndices k cs0 = findIndices' 0 cs0
   where findIndices' _ Empty        = []
         findIndices' n (Chunk c cs) = L.map ((+n).fromIntegral) (S.findIndices k c)
                              ++ findIndices' (n + fromIntegral (S.length c)) cs
+{-# INLINE findIndices #-}
 
 -- ---------------------------------------------------------------------
 -- Searching ByteStrings

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -572,6 +572,7 @@ findIndex f = L.findIndex (f . w2c)
 -- indices of all elements satisfying the predicate, in ascending order.
 findIndices :: (Char -> Bool) -> ByteString -> [Int64]
 findIndices f = L.findIndices (f . w2c)
+{-# INLINE findIndices #-}
 
 -- | count returns the number of times its argument appears in the ByteString
 --


### PR DESCRIPTION
Reimplements findIndices to iteratively call findIndex, which
yields an approximate 2x improvement over original implementation
for a simple equality predicate

Adds inline pragma for findIndices, which yields an approximate 10x
improvement for a simple equality predicate

Additionally inlines findIndices functions in
Data.ByteString{.Lazy,}{.Char8,}

resolves #269 