### PR TITLE
Simpler, cleaner faster `elemIndices`

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1148,14 +1148,12 @@ elemIndexEnd = findIndexEnd . (==)
 elemIndices :: Word8 -> ByteString -> [Int]
 elemIndices w (BS x l) = loop 0
     where
-        loop !n = let q = accursedUnutterablePerformIO $ withForeignPtr x $ \p ->
-                           memchr (p `plusPtr` n)
-                                                w (fromIntegral (l - n))
-                  in if q == nullPtr
-                        then []
-                        else let i = accursedUnutterablePerformIO $ withForeignPtr x $ \p ->
-                                       return (q `minusPtr` p)
-                             in i : loop (i+1)
+        loop !n = accursedUnutterablePerformIO $ withForeignPtr x $ \p -> do
+            q <- memchr (p `plusPtr` n) w (fromIntegral (l - n))
+            if q == nullPtr
+                then return []
+                else let !i = q `minusPtr` p
+                      in return $ i : loop (i + 1)
 {-# INLINE elemIndices #-}
 
 -- | count returns the number of times its argument appears in the ByteString


### PR DESCRIPTION
There's no need for a separate `withForeignPointer` call to subtract the
pointers after `memchr`.  The entire loop is a closure around a fixed
foreign pointer which can safely be reused with just a *single*
`withForeignPointer` in each loop iteration.

In informal measurements, this yields non-trivial performance
improvements, but even without these, the code is simply better.