### PR TITLE
Expose fromStrict/toStrict directly from Data.ByteString

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -50,6 +50,8 @@ module Data.ByteString (
         singleton,              -- :: Word8   -> ByteString
         pack,                   -- :: [Word8] -> ByteString
         unpack,                 -- :: ByteString -> [Word8]
+        fromStrict,             -- :: ByteString -> Lazy.ByteString
+        toStrict,               -- :: Lazy.ByteString -> ByteString
 
         -- * Basic interface
         cons,                   -- :: Word8 -> ByteString -> ByteString
@@ -233,6 +235,7 @@ import Data.Bits                (bitSize, shiftL, (.|.), (.&.))
 #endif
 
 import Data.ByteString.Internal
+import Data.ByteString.Lazy.Internal (fromStrict, toStrict)
 import Data.ByteString.Unsafe
 
 import qualified Data.List as List

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -52,6 +52,8 @@ module Data.ByteString.Char8 (
         singleton,              -- :: Char   -> ByteString
         pack,                   -- :: String -> ByteString
         unpack,                 -- :: ByteString -> String
+        B.fromStrict,           -- :: ByteString -> Lazy.ByteString
+        B.toStrict,             -- :: Lazy.ByteString -> ByteString
 
         -- * Basic interface
         cons,                   -- :: Char -> ByteString -> ByteString

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -199,7 +199,7 @@ module Data.ByteString.Lazy.Char8 (
 
 -- Functions transparently exported
 import Data.ByteString.Lazy
-        (fromChunks, toChunks, fromStrict, toStrict
+        (fromChunks, toChunks
         ,empty,null,length,tail,init,append,reverse,transpose,cycle
         ,concat,take,drop,splitAt,intercalate
         ,isPrefixOf,isSuffixOf,group,inits,tails,copy


### PR DESCRIPTION
Closes #279. 

Basically I just moved `fromStrict` / `toStrict` from `Data.ByteString.Lazy` to `Data.ByteString.Lazy.Internal`. The difficulty is that their implementation depends on `Data.ByteString.{length,null,take,drop}`. I could potentially move these four functions to `Data.ByteString.Internal`, but I decided just to operate on fields of `BS` directly. IMHO it is a better option, because it moves less stuff between modules and also shaves off a couple of picoseconds, avoiding conditional branches in `take` / `drop`.