### PR TITLE
[master] Don't fill ForeignPtrContents field with bottom

### DIFF
--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -166,7 +166,6 @@ import GHC.Prim                 (plusAddr#)
 import GHC.CString              (cstringLength#)
 import GHC.ForeignPtr           (ForeignPtrContents(FinalPtr))
 #endif
-
 import GHC.Ptr                  (Ptr(..), castPtr)
 
 -- CFILES stuff is Hugs only
@@ -437,7 +436,11 @@ unpackAppendCharsStrict (BS fp len) xs =
 
 -- | The 0 pointer. Used to indicate the empty Bytestring.
 nullForeignPtr :: ForeignPtr Word8
-nullForeignPtr = ForeignPtr nullAddr# (error "nullForeignPtr") --TODO: should ForeignPtrContents be strict?
+#if __GLASGOW_HASKELL__ >= 811
+nullForeignPtr = ForeignPtr nullAddr# FinalPtr
+#else
+nullForeignPtr = ForeignPtr nullAddr# (error "nullForeignPtr")
+#endif
 
 -- ---------------------------------------------------------------------
 -- Low level constructors


### PR DESCRIPTION
As noted in GHC #17290, ForeignPtrContents really should be strict.
With the addition of the FinalPtr constructor we now have a
sensible value to use in nullForeignPtr other than bottom.

Moreover, another unrelated GHC change (#17760) recently forced
the application of strictness for ForeignPtr's ForeignPtrContents
field. Consequently, we are making this change now. Unfortunately this
means that all earlier versions of bytestring will be unbuilable with
GHC >=9.0.