### PR TITLE
Final touches for 0.11.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 [0.11.0.0] — September 2020
  * [Change internal representation of `ByteString`, removing offset](https://github.com/haskell/bytestring/pull/175)
-   * The old `PS` constructor has been turned into a pattern synonym that is available with GHC >= 8.0 for backwards compatibility.
+   * The old `PS` constructor has been turned into a pattern synonym that is available with GHC >= 8.0 for backwards compatibility. Consider adding `if !impl(ghc >=8.0) { build-depends: bytestring < 0.11 }` to packages, which use `PS` and still support GHC < 8.0.
  * [Fill `ForeignPtrContents` of `nullForeignPtr` with `FinalPtr` instead of a bottom](https://github.com/haskell/bytestring/pull/284)
-   * Note that `bytestring < 0.11` will be unbuildable with GHC >= 9.0.
+   * While `bytestring-0.11` is compatible with GHC >= 7.0, note that `bytestring < 0.11` will be unbuildable with GHC >= 9.0.
  * [Remove deprecated functions `findSubstring` and `findSubstrings`](https://github.com/haskell/bytestring/pull/181)
  * [Speed up sorting of short strings](https://github.com/haskell/bytestring/pull/267)
  * [Improve handling of literal strings in `Data.ByteString.Builder`](https://github.com/haskell/bytestring/pull/132)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Requirements:
 
   * Cabal 1.10 or greater
   * cabal-install
-  * GHC 6.12 or greater
+  * GHC 7.0 or greater
 
 Building:
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-## ByteString: Fast, Packed Strings of Bytes
+# ByteString: Fast, Packed Strings of Bytes
 
-[![Build Status](https://secure.travis-ci.org/haskell/bytestring.png?branch=master)](http://travis-ci.org/haskell/bytestring)
+[![Build Status](https://secure.travis-ci.org/haskell/bytestring.svg?branch=master)](http://travis-ci.org/haskell/bytestring) [![Hackage](http://img.shields.io/hackage/v/bytestring.svg)](https://hackage.haskell.org/package/bytestring) [![Hackage CI](https://matrix.hackage.haskell.org/api/v2/packages/bytestring/badge)](https://matrix.hackage.haskell.org/package/bytestring) [![Stackage LTS](http://stackage.org/package/bytestring/badge/lts)](http://stackage.org/lts/package/bytestring) [![Stackage Nightly](http://stackage.org/package/bytestring/badge/nightly)](http://stackage.org/nightly/package/bytestring)
 
 This library provides the `Data.ByteString` module -- strict and lazy
-byte arrays manipulable as strings -- providing very time/space-efficient 
+byte arrays manipulable as strings -- providing very time/space-efficient
 string and IO operations.
 
 For very large data requirements, or constraints on heap size,
@@ -16,20 +16,10 @@ of `ByteString` values from smaller pieces during binary serialization.
 Requirements:
 
   * Cabal 1.10 or greater
-  * cabal-install
   * GHC 7.0 or greater
 
-Building:
-```
-cabal install
-```
-
-You can run the testsuite as follows:
-```    
-cabal test
-```
-
 ### Authors
+
 `ByteString` was derived from the GHC `PackedString` library,
 originally written by Bryan O'Sullivan, and then by Simon Marlow.
 It was adapted and greatly extended for darcs by David Roundy and

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -70,7 +70,7 @@ flag integer-simple
   default: False
 
 library
-  build-depends:     base >= 4.2 && < 5, ghc-prim, deepseq
+  build-depends:     base >= 4.3 && < 5, ghc-prim, deepseq
 
   exposed-modules:   Data.ByteString
                      Data.ByteString.Char8


### PR DESCRIPTION
1. Since we do not test against GHC 6.12, it is better to stop listing it as a supported platform (cf. discussion in #285). Thus, I changed GHC 6.12 to 7.0 in `README.md` and bumped the lower bound for base from 4.2 to 4.3. However, I decided to retain `if impl(ghc < 7)` section still - it has a chance to appear useful for a daring soul. Dunno, maybe it is better to strip it as well.

2. Following discussions elsewhere, I clarified statements about compatibility issues in `Changelog.md`. 

3. I removed `cabal-install` from build requirements: `stack` or whatever can be used as well. I also removed paragraphs about building and testing: we certainly do not want people to use `cabal install` (at the very least it should be `cabal build`), and `cabal test` does not run any tests, because they are in a separate package. I'd appreciate if someone invest time into writing a proper modern contributors guide, but at least we should avoid misleading instructions.

4. I added badges to track versions of `bytestring` available from Hackage and Stackage (LTS and nightly). Given that currently they point to three different versions, I find it very useful to have this information at hand.