### PR TITLE
Fix build failure under GHC-9.0

### DIFF
--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -153,20 +153,27 @@ import GHC.IOBase               (IO(IO),RawBuffer,unsafeDupablePerformIO)
 #endif
 
 import GHC.ForeignPtr           (ForeignPtr(ForeignPtr)
-                                ,newForeignPtr_, mallocPlainForeignPtrBytes)
+#if __GLASGOW_HASKELL__ < 900
+                                , newForeignPtr_
+#endif
+                                , mallocPlainForeignPtrBytes)
+
 #if MIN_VERSION_base(4,10,0)
 import GHC.ForeignPtr           (plusForeignPtr)
 #else
 import GHC.Prim                 (plusAddr#)
 #endif
 
-import GHC.Types                (Int (..))
-
 #if __GLASGOW_HASKELL__ >= 811
 import GHC.CString              (cstringLength#)
 import GHC.ForeignPtr           (ForeignPtrContents(FinalPtr))
-#endif
+#else
 import GHC.Ptr                  (Ptr(..), castPtr)
+#endif
+
+#if (__GLASGOW_HASKELL__ < 802) || (__GLASGOW_HASKELL__ >= 811)
+import GHC.Types                (Int (..))
+#endif
 
 -- CFILES stuff is Hugs only
 {-# CFILES cbits/fpstring.c #-}

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -157,9 +157,10 @@ import GHC.ForeignPtr           (ForeignPtr(ForeignPtr)
 #if MIN_VERSION_base(4,10,0)
 import GHC.ForeignPtr           (plusForeignPtr)
 #else
-import GHC.Types                (Int (..))
 import GHC.Prim                 (plusAddr#)
 #endif
+
+import GHC.Types                (Int (..))
 
 #if __GLASGOW_HASKELL__ >= 811
 import GHC.CString              (cstringLength#)


### PR DESCRIPTION
After installing GHC 9.0 alpha via ```ghcup set ghc 9.0.0.20200925``` the build failure was:

```
Data/ByteString/Internal.hs:331:45: error:
    • Data constructor not in scope: I# :: GHC.Prim.Int# -> Int
    • Perhaps you meant ‘IO’ (imported from GHC.IO)
      Perhaps you want to add ‘I#’ to one of these import lists:
        ‘GHC.Base’ (Data/ByteString/Internal.hs:135:1-64)
        ‘GHC.Exts’ (Data/ByteString/Internal.hs:138:1-44)
    |
331 |     return (BS (ForeignPtr addr# FinalPtr) (I# (cstringLength# addr#)))
    |                                             ^^

Data/ByteString/Internal.hs:350:35: error:
    • Data constructor not in scope: I# :: GHC.Prim.Int# -> Int
    • Perhaps you meant ‘IO’ (imported from GHC.IO)
      Perhaps you want to add ‘I#’ to one of these import lists:
        ‘GHC.Base’ (Data/ByteString/Internal.hs:135:1-64)
        ‘GHC.Exts’ (Data/ByteString/Internal.hs:138:1-44)
    |
350 |   BS (ForeignPtr addr# FinalPtr) (I# (cstringLength# addr#))

```