### PR TITLE
`zipWith'` to `packZipWith` as per #208

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1623,7 +1623,6 @@ zipWith f ps qs
     | otherwise = f (unsafeHead ps) (unsafeHead qs) : zipWith f (unsafeTail ps) (unsafeTail qs)
 {-# NOINLINE [1] zipWith #-}
 
---
 -- | A specialised version of `zipWith` for the common case of a
 -- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -167,6 +167,7 @@ module Data.ByteString (
         -- * Zipping and unzipping ByteStrings
         zip,                    -- :: ByteString -> ByteString -> [(Word8,Word8)]
         zipWith,                -- :: (Word8 -> Word8 -> c) -> ByteString -> ByteString -> [c]
+        packZipWith,            -- :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString
         unzip,                  -- :: [(Word8,Word8)] -> (ByteString,ByteString)
 
         -- * Ordered ByteStrings
@@ -1625,11 +1626,11 @@ zipWith f ps qs
 --
 -- | A specialised version of zipWith for the common case of a
 -- simultaneous map over two bytestrings, to build a 3rd. Rewrite rules
--- are used to automatically covert zipWith into zipWith' when a pack is
+-- are used to automatically covert zipWith into packZipWith when a pack is
 -- performed on the result of zipWith.
 --
-zipWith' :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString
-zipWith' f (BS fp l) (BS fq m) = unsafeDupablePerformIO $
+packZipWith :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString
+packZipWith f (BS fp l) (BS fq m) = unsafeDupablePerformIO $
     withForeignPtr fp $ \a ->
     withForeignPtr fq $ \b ->
     create len $ go a b
@@ -1646,11 +1647,11 @@ zipWith' f (BS fp l) (BS fq m) = unsafeDupablePerformIO $
                 zipWith_ (n+1) r
 
     len = min l m
-{-# INLINE zipWith' #-}
+{-# INLINE packZipWith #-}
 
 {-# RULES
 "ByteString specialise zipWith" forall (f :: Word8 -> Word8 -> Word8) p q .
-    zipWith f p q = unpack (zipWith' f p q)
+    zipWith f p q = unpack (packZipWith f p q)
   #-}
 
 -- | /O(n)/ 'unzip' transforms a list of pairs of bytes into a pair of

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1624,11 +1624,8 @@ zipWith f ps qs
 {-# NOINLINE [1] zipWith #-}
 
 --
--- | A specialised version of zipWith for the common case of a
--- simultaneous map over two bytestrings, to build a 3rd. Rewrite rules
--- are used to automatically covert zipWith into packZipWith when a pack is
--- performed on the result of zipWith.
---
+-- | A specialised version of `zipWith` for the common case of a
+-- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString
 packZipWith f (BS fp l) (BS fq m) = unsafeDupablePerformIO $
     withForeignPtr fp $ \a ->

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -838,7 +838,6 @@ zip ps qs
 zipWith :: (Char -> Char -> a) -> ByteString -> ByteString -> [a]
 zipWith f = B.zipWith ((. w2c) . f . w2c)
 
---
 -- | A specialised version of `zipWith` for the common case of a
 -- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -843,23 +843,7 @@ zipWith f = B.zipWith ((. w2c) . f . w2c)
 -- | A specialised version of `zipWith` for the common case of a
 -- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString
-packZipWith f (BS fp l) (BS fq m) = unsafeDupablePerformIO $
-    withForeignPtr fp $ \a ->
-    withForeignPtr fq $ \b ->
-    create len $ go a b
-  where
-    go p1 p2 = zipWith_ 0
-      where
-        zipWith_ :: Int -> Ptr Word8 -> IO ()
-        zipWith_ !n !r
-           | n >= len = return ()
-           | otherwise = do
-                x <- peekByteOff p1 n
-                y <- peekByteOff p2 n
-                pokeByteOff r n (f x y)
-                zipWith_ (n+1) r
-
-    len = min l m
+packZipWith f bs bt = B.packZipWith (c2w . f . w2c) bs bt
 {-# INLINE packZipWith #-}
 
 -- | 'unzip' transforms a list of pairs of Chars into a pair of

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -272,7 +272,6 @@ import GHC.Char (eqChar)
 import qualified Data.List as List (intersperse)
 
 import System.IO    (Handle,stdout)
-import GHC.IO       (unsafeDupablePerformIO)
 import Foreign
 
 
@@ -843,7 +842,9 @@ zipWith f = B.zipWith ((. w2c) . f . w2c)
 -- | A specialised version of `zipWith` for the common case of a
 -- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString
-packZipWith f bs bt = B.packZipWith (c2w . f . w2c) bs bt
+packZipWith f = B.packZipWith f'
+    where
+        f' c1 c2 = c2w $ f (w2c c1) (w2c c2)
 {-# INLINE packZipWith #-}
 
 -- | 'unzip' transforms a list of pairs of Chars into a pair of

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1132,7 +1132,6 @@ zipWith f (Chunk a as) (Chunk b bs) = go a as b bs
     to _ (Chunk x' xs) y ys            | not (S.null y) = go x' xs y  ys
     to _ (Chunk x' xs) _ (Chunk y' ys)                  = go x' xs y' ys
 
---
 -- | A specialised version of `zipWith` for the common case of a
 -- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1140,9 +1140,9 @@ packZipWith _ Empty _ = Empty
 packZipWith _ _ Empty = Empty
 packZipWith f (Chunk a@(S.BS _ al) as) (Chunk b@(S.BS _ bl) bs) = Chunk (S.packZipWith f a b) $
     case compare al bl of
-        LT -> packZipWith f as $ Chunk (S.drop (bl - al) b) bs
+        LT -> packZipWith f as $ Chunk (S.drop al b) bs
         EQ -> packZipWith f as bs
-        GT -> packZipWith f (Chunk (S.drop (al - bl) a) as) bs
+        GT -> packZipWith f (Chunk (S.drop bl a) as) bs
 {-# INLINE packZipWith #-}
 
 -- | /O(n)/ 'unzip' transforms a list of pairs of bytes into a pair of

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -178,6 +178,7 @@ module Data.ByteString.Lazy (
         -- * Zipping and unzipping ByteStrings
         zip,                    -- :: ByteString -> ByteString -> [(Word8,Word8)]
         zipWith,                -- :: (Word8 -> Word8 -> c) -> ByteString -> ByteString -> [c]
+        packZipWith,            -- :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString
         unzip,                  -- :: [(Word8,Word8)] -> (ByteString,ByteString)
 
         -- * Ordered ByteStrings
@@ -1130,6 +1131,19 @@ zipWith f (Chunk a as) (Chunk b bs) = go a as b bs
     to x xs            _ (Chunk y' ys) | not (S.null x) = go x  xs y' ys
     to _ (Chunk x' xs) y ys            | not (S.null y) = go x' xs y  ys
     to _ (Chunk x' xs) _ (Chunk y' ys)                  = go x' xs y' ys
+
+--
+-- | A specialised version of `zipWith` for the common case of a
+-- simultaneous map over two ByteStrings, to build a 3rd.
+packZipWith :: (Word8 -> Word8 -> Word8) -> ByteString -> ByteString -> ByteString
+packZipWith _ Empty _ = Empty
+packZipWith _ _ Empty = Empty
+packZipWith f (Chunk a@(S.BS _ al) as) (Chunk b@(S.BS _ bl) bs) = Chunk (S.packZipWith f a b) $
+    case compare al bl of
+        LT -> packZipWith f as $ Chunk (S.drop (bl - al) b) bs
+        EQ -> packZipWith f as bs
+        GT -> packZipWith f (Chunk (S.drop (al - bl) a) as) bs
+{-# INLINE packZipWith #-}
 
 -- | /O(n)/ 'unzip' transforms a list of pairs of bytes into a pair of
 -- ByteStrings. Note that this performs two 'pack' operations.

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -684,7 +684,6 @@ zip ps qs
 zipWith :: (Char -> Char -> a) -> ByteString -> ByteString -> [a]
 zipWith f = L.zipWith ((. w2c) . f . w2c)
 
---
 -- | A specialised version of `zipWith` for the common case of a
 -- simultaneous map over two ByteStrings, to build a 3rd.
 packZipWith :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -157,6 +157,7 @@ module Data.ByteString.Lazy.Char8 (
         -- * Zipping and unzipping ByteStrings
         zip,                    -- :: ByteString -> ByteString -> [(Char,Char)]
         zipWith,                -- :: (Char -> Char -> c) -> ByteString -> ByteString -> [c]
+        packZipWith,            -- :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString
 --      unzip,                  -- :: [(Char,Char)] -> (ByteString,ByteString)
 
         -- * Ordered ByteStrings
@@ -682,6 +683,15 @@ zip ps qs
 -- of corresponding sums.
 zipWith :: (Char -> Char -> a) -> ByteString -> ByteString -> [a]
 zipWith f = L.zipWith ((. w2c) . f . w2c)
+
+--
+-- | A specialised version of `zipWith` for the common case of a
+-- simultaneous map over two ByteStrings, to build a 3rd.
+packZipWith :: (Char -> Char -> Char) -> ByteString -> ByteString -> ByteString
+packZipWith f = L.packZipWith f'
+    where
+        f' c1 c2 = c2w $ f (w2c c1) (w2c c2)
+{-# INLINE packZipWith #-}
 
 -- | 'lines' breaks a ByteString up into a list of ByteStrings at
 -- newline Chars (@'\\n'@). The resulting strings do not contain newlines.

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -2077,7 +2077,6 @@ pl_tests =
     , testProperty "unzip"       prop_unzipLL
     , testProperty "unzip"       prop_unzipCL
     , testProperty "zipWith"          prop_zipWithPL
---  , testProperty "zipWith"          prop_zipWithCL
     , testProperty "zipWith rules"   prop_zipWithPL_rules
     , testProperty "zipWith/packZipWith" prop_packZipWithPL
 

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -439,6 +439,8 @@ prop_unfoldrBL =
     ((\n f a ->                  take n $
           unfoldr f a) :: Int -> (X -> Maybe (W,X)) -> X -> [W])
 
+prop_packZipWithBL   = L.packZipWith `eq3` (zipWith :: (W -> W -> W) -> [W] -> [W] -> [W])
+
 --
 -- And finally, check correspondance between Data.ByteString and List
 --
@@ -1350,7 +1352,12 @@ prop_zip1BB xs ys = P.zip xs ys == zip (P.unpack xs) (P.unpack ys)
 prop_zipWithBB xs ys = P.zipWith (,) xs ys == P.zip xs ys
 prop_zipWithCC xs ys = C.zipWith (,) xs ys == C.zip xs ys
 prop_zipWithLC xs ys = LC.zipWith (,) xs ys == LC.zip xs ys
-prop_packZipWithBB xs ys = P.pack (P.zipWith (+) xs ys) == P.packZipWith (+) xs ys
+
+prop_packZipWithBB f xs ys = P.pack (P.zipWith f xs ys) == P.packZipWith f xs ys
+prop_packZipWithLL f xs ys = L.pack (L.zipWith f xs ys) == L.packZipWith f xs ys
+prop_packZipWithBC f xs ys = C.pack (C.zipWith f xs ys) == C.packZipWith f xs ys
+prop_packZipWithLC f xs ys = LC.pack (LC.zipWith f xs ys) == LC.packZipWith f xs ys
+
 
 prop_unzipBB x = let (xs,ys) = unzip x in (P.pack xs, P.pack ys) == P.unzip x
 
@@ -1887,6 +1894,7 @@ bl_tests =
     , testProperty "elemIndexEnd"prop_elemIndexEndBL
     , testProperty "elemIndices" prop_elemIndicesBL
     , testProperty "concatMap"   prop_concatMapBL
+    , testProperty "zipWith/packZipWithLazy" prop_packZipWithBL
     ]
 
 ------------------------------------------------------------------------
@@ -2332,7 +2340,10 @@ bb_tests =
     , testProperty "zipWith"        prop_zipWithBB
     , testProperty "zipWith"        prop_zipWithCC
     , testProperty "zipWith"        prop_zipWithLC
-    , testProperty "packZipWith"       prop_packZipWithBB
+    , testProperty "packZipWith"    prop_packZipWithBB
+    , testProperty "packZipWith"    prop_packZipWithLL
+    , testProperty "packZipWith"    prop_packZipWithBC
+    , testProperty "packZipWith"    prop_packZipWithLC
     , testProperty "unzip"          prop_unzipBB
     , testProperty "concatMap"      prop_concatMapBB
 --  , testProperty "join/joinByte"  prop_join_spec

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -2084,9 +2084,9 @@ pl_tests =
     , testProperty "unzip"       prop_unzipPL
     , testProperty "unzip"       prop_unzipLL
     , testProperty "unzip"       prop_unzipCL
-    , testProperty "zipWith"          prop_zipWithPL
-    , testProperty "zipWith rules"   prop_zipWithPL_rules
-    , testProperty "zipWith/packZipWith" prop_packZipWithPL
+    , testProperty "zipWithPL"          prop_zipWithPL
+    , testProperty "zipWithPL rules"   prop_zipWithPL_rules
+    , testProperty "packZipWithPL" prop_packZipWithPL
 
     , testProperty "isPrefixOf"  prop_isPrefixOfPL
     , testProperty "isSuffixOf"  prop_isSuffixOfPL
@@ -2337,13 +2337,13 @@ bb_tests =
     , testProperty "zip"            prop_zipBB
     , testProperty "zip"            prop_zipLC
     , testProperty "zip1"           prop_zip1BB
-    , testProperty "zipWith"        prop_zipWithBB
-    , testProperty "zipWith"        prop_zipWithCC
-    , testProperty "zipWith"        prop_zipWithLC
-    , testProperty "packZipWith"    prop_packZipWithBB
-    , testProperty "packZipWith"    prop_packZipWithLL
-    , testProperty "packZipWith"    prop_packZipWithBC
-    , testProperty "packZipWith"    prop_packZipWithLC
+    , testProperty "zipWithBB"        prop_zipWithBB
+    , testProperty "zipWithCC"        prop_zipWithCC
+    , testProperty "zipWithLC"        prop_zipWithLC
+    , testProperty "packZipWithBB"    prop_packZipWithBB
+    , testProperty "packZipWithLL"    prop_packZipWithLL
+    , testProperty "packZipWithBC"    prop_packZipWithBC
+    , testProperty "packZipWithLC"    prop_packZipWithLC
     , testProperty "unzip"          prop_unzipBB
     , testProperty "concatMap"      prop_concatMapBB
 --  , testProperty "join/joinByte"  prop_join_spec

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -540,7 +540,7 @@ prop_scanr1CL f = eqnotnull2
     (scanr1 :: (Char -> Char -> Char) -> [Char] -> [Char])
     (castFn f)
 
--- prop_zipWithPL'   = P.zipWith'  `eq3` (zipWith :: (W -> W -> W) -> [W] -> [W] -> [W])
+prop_packZipWithPL   = P.packZipWith  `eq3` (zipWith :: (W -> W -> W) -> [W] -> [W] -> [W])
 
 prop_zipWithPL    = (P.zipWith  :: (W -> W -> X) -> P   -> P   -> [X]) `eq3`
                       (zipWith  :: (W -> W -> X) -> [W] -> [W] -> [X])
@@ -1350,7 +1350,7 @@ prop_zip1BB xs ys = P.zip xs ys == zip (P.unpack xs) (P.unpack ys)
 prop_zipWithBB xs ys = P.zipWith (,) xs ys == P.zip xs ys
 prop_zipWithCC xs ys = C.zipWith (,) xs ys == C.zip xs ys
 prop_zipWithLC xs ys = LC.zipWith (,) xs ys == LC.zip xs ys
--- prop_zipWith'BB xs ys = P.pack (P.zipWith (+) xs ys) == P.zipWith' (+) xs ys
+prop_packZipWithBB xs ys = P.pack (P.zipWith (+) xs ys) == P.packZipWith (+) xs ys
 
 prop_unzipBB x = let (xs,ys) = unzip x in (P.pack xs, P.pack ys) == P.unzip x
 
@@ -2079,7 +2079,7 @@ pl_tests =
     , testProperty "zipWith"          prop_zipWithPL
 --  , testProperty "zipWith"          prop_zipWithCL
     , testProperty "zipWith rules"   prop_zipWithPL_rules
---  , testProperty "zipWith/zipWith'" prop_zipWithPL'
+    , testProperty "zipWith/packZipWith" prop_packZipWithPL
 
     , testProperty "isPrefixOf"  prop_isPrefixOfPL
     , testProperty "isSuffixOf"  prop_isSuffixOfPL
@@ -2333,7 +2333,7 @@ bb_tests =
     , testProperty "zipWith"        prop_zipWithBB
     , testProperty "zipWith"        prop_zipWithCC
     , testProperty "zipWith"        prop_zipWithLC
---  , testProperty "zipWith'"       prop_zipWith'BB
+    , testProperty "packZipWith"       prop_packZipWithBB
     , testProperty "unzip"          prop_unzipBB
     , testProperty "concatMap"      prop_concatMapBB
 --  , testProperty "join/joinByte"  prop_join_spec


### PR DESCRIPTION
Renames `zipWith'` to `packZipWith` and exports it
Recovers test cases for `packZipWith` from comments


> A PR renaming `zipWith'` to `packZipWith` and exporting it would be welcome.
_Originally posted by @Bodigrim in https://github.com/haskell/bytestring/issues/208#issuecomment-702330104_

All test cases pass