### PR TITLE
Implement Data.ByteString.Lazy.compareLength

### DIFF
--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -535,38 +535,74 @@ compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - fromIntegral (S.le
 {-# INLINE compareLength #-}
 
 {-# RULES 
-"ByteString.Lazy compareN/length -> compareLength" [~1] forall t n.
+"ByteString.Lazy length/compareN -> compareLength" [~1] forall t n.
   compare (length t) n = compareLength t n
   #-}
 
 {-# RULES 
-"ByteString.Lazy ==N/length -> compareLength/==EQ" [~1] forall t n.
+"ByteString.Lazy compareN/length -> compareLength" [~1] forall t n.
+  compare n (length t) = toEnum $ (2-) $ fromEnum $ compareLength t n
+  #-}
+
+{-# RULES 
+"ByteString.Lazy length/==N -> compareLength/==EQ" [~1] forall t n.
    length t == n = compareLength t n == EQ
   #-}
 
 {-# RULES 
-"ByteString.Lazy /=N/length -> compareLength//=EQ" [~1] forall t n.
+"ByteString.Lazy N==/length -> compareLength/==EQ" [~1] forall t n.
+   n == length t = compareLength t n == EQ
+  #-}
+
+{-# RULES 
+"ByteString.Lazy length//=N -> compareLength//=EQ" [~1] forall t n.
    length t /= n = compareLength t n /= EQ
   #-}
 
 {-# RULES 
-"ByteString.Lazy <N/length -> compareLength/==LT" [~1] forall t n.
+"ByteString.Lazy N/=/length -> compareLength//=EQ" [~1] forall t n.
+   n /= length t = compareLength t n /= EQ
+  #-}
+
+{-# RULES 
+"ByteString.Lazy length/<N -> compareLength/==LT" [~1] forall t n.
    length t < n = compareLength t n == LT
   #-}
 
 {-# RULES 
-"ByteString.Lazy <=N/length -> compareLength//=GT" [~1] forall t n.
+"ByteString.Lazy >N/length -> compareLength/==LT" [~1] forall t n.
+   n > length t = compareLength t n == LT
+  #-}
+
+{-# RULES 
+"ByteString.Lazy length/<=N -> compareLength//=GT" [~1] forall t n.
    length t <= n = compareLength t n /= GT
   #-}
 
 {-# RULES 
-"ByteString.Lazy >N/length -> compareLength/==GT" [~1] forall t n.
+"ByteString.Lazy <=N/length -> compareLength//=GT" [~1] forall t n.
+   n >= length t = compareLength t n /= GT
+  #-}
+
+{-# RULES 
+"ByteString.Lazy length/>N -> compareLength/==GT" [~1] forall t n.
    length t > n = compareLength t n == GT
   #-}
 
 {-# RULES 
-"ByteString.Lazy >=N/length -> compareLength//=LT" [~1] forall t n.
+"ByteString.Lazy <N/length -> compareLength/==GT" [~1] forall t n.
+   n < length t = compareLength t n == GT
+  #-}
+
+
+{-# RULES 
+"ByteString.Lazy length/>=N -> compareLength//=LT" [~1] forall t n.
    length t >= n = compareLength t n /= LT
+  #-}
+
+{-# RULES 
+"ByteString.Lazy >=N/length -> compareLength//=LT" [~1] forall t n.
+   n <= length t = compareLength t n /= LT
   #-}
 
 -- | The 'mapAccumL' function behaves like a combination of 'map' and

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -526,13 +526,6 @@ minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
                                      (S.minimum c) cs
 {-# INLINE minimum #-}
 
--- Unexported helper-function.
--- Required for rewrite rules for 'compareLength'
-negateOrdering :: Ordering -> Ordering
-negateOrdering LT = GT
-negateOrdering EQ = EQ
-negateOrdering GT = LT
-
 -- | /O(c)/ 'compareLength' compares the length of a 'ByteString' 
 -- to an 'Int64'   
 compareLength :: ByteString -> Int64 -> Ordering
@@ -1430,6 +1423,12 @@ interact transformer = putStr . transformer =<< getContents
 
 -- ---------------------------------------------------------------------
 -- Internal utilities
+
+-- Required for rewrite rules for 'compareLength'
+negateOrdering :: Ordering -> Ordering
+negateOrdering LT = GT
+negateOrdering EQ = EQ
+negateOrdering GT = LT
 
 -- Common up near identical calls to `error' to reduce the number
 -- constant strings created when compiled:

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -534,6 +534,41 @@ compareLength Empty toCmp         = compare 0 toCmp
 compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - S.length c)
 {-# INLINE compareLength #-}
 
+{-# RULES 
+"ByteString.Lazy compareN/length -> compareLength" [~1] forall t n.
+  compare (length t) n = compareLength t (fromIntegral n)
+  #-}
+
+{-# RULES 
+"ByteString.Lazy ==N/length -> compareLength/==EQ" [~1] forall t n.
+   length t == n = compareLength t (fromIntegral n) == EQ
+  #-}
+
+{-# RULES 
+"ByteString.Lazy /=N/length -> compareLength//=EQ" [~1] forall t n.
+   length t /= n = compareLength t (fromIntegral n) /= EQ
+  #-}
+
+{-# RULES 
+"ByteString.Lazy <N/length -> compareLength/==LT" [~1] forall t n.
+   length t < n = compareLength t (fromIntegral n) == LT
+  #-}
+
+{-# RULES 
+"ByteString.Lazy <=N/length -> compareLength//=GT" [~1] forall t n.
+   length t <= n = compareLength t (fromIntegral n) /= GT
+  #-}
+
+{-# RULES 
+"ByteString.Lazy >N/length -> compareLength/==GT" [~1] forall t n.
+   length t > n = compareLength t (fromIntegral n) == GT
+  #-}
+
+{-# RULES 
+"ByteString.Lazy >=N/length -> compareLength//=LT" [~1] forall t n.
+   length t >= n = compareLength t (fromIntegral n) /= LT
+  #-}
+
 -- | The 'mapAccumL' function behaves like a combination of 'map' and
 -- 'foldl'; it applies a function to each element of a ByteString,
 -- passing an accumulating parameter from left to right, and returning a

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -529,13 +529,11 @@ minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
 -- | /O(n)/ 'compareLength' compares the length of a 'ByteString' 
 -- to an 'Int'   
 compareLength :: ByteString -> Int -> Ordering
-compareLength s toCmp = go 0 s
+compareLength s toCmp = go toCmp s
   where
-    go currLen Empty        = compare currLen toCmp
-    go currLen (Chunk c cs) = let nextLen = currLen + S.length c
-                               in if nextLen > toCmp 
-                                    then GT 
-                                    else go nextLen cs
+    go remainingLen _ | remainingLen < 0 = GT
+    go remainingLen Empty                = compare 0 remainingLen
+    go remainingLen (Chunk c cs)         = go (remainingLen - S.length c) cs
 {-# INLINE compareLength #-}
 
 -- | The 'mapAccumL' function behaves like a combination of 'map' and

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -529,11 +529,9 @@ minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
 -- | /O(n)/ 'compareLength' compares the length of a 'ByteString' 
 -- to an 'Int'   
 compareLength :: ByteString -> Int -> Ordering
-compareLength s toCmp = go toCmp s
-  where
-    go remainingLen _ | remainingLen < 0 = GT
-    go remainingLen Empty                = compare 0 remainingLen
-    go remainingLen (Chunk c cs)         = go (remainingLen - S.length c) cs
+compareLength _ toCmp | toCmp < 0 = GT
+compareLength Empty toCmp         = compare 0 toCmp
+compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - S.length c)
 {-# INLINE compareLength #-}
 
 -- | The 'mapAccumL' function behaves like a combination of 'map' and

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -560,7 +560,7 @@ mapAccumR f s0 = go s0
     go s Empty        = (s, Empty)
     go s (Chunk c cs) = (s'', Chunk c' cs')
         where (s'', c') = S.mapAccumR f s' c
-              (s', cs') = go s cs        
+              (s', cs') = go s cs
 
 -- ---------------------------------------------------------------------
 -- Building ByteStrings

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -526,6 +526,13 @@ minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
                                      (S.minimum c) cs
 {-# INLINE minimum #-}
 
+-- Unexported helper-function.
+-- Required for rewrite rules for 'compareLength'
+negateOrdering :: Ordering -> Ordering
+negateOrdering LT = GT
+negateOrdering EQ = EQ
+negateOrdering GT = LT
+
 -- | /O(c)/ 'compareLength' compares the length of a 'ByteString' 
 -- to an 'Int64'   
 compareLength :: ByteString -> Int64 -> Ordering
@@ -541,7 +548,7 @@ compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - fromIntegral (S.le
 
 {-# RULES 
 "ByteString.Lazy compareN/length -> compareLength" [~1] forall t n.
-  compare n (length t) = toEnum $ (2-) $ fromEnum $ compareLength t n
+  compare n (length t) = negateOrdering $ compareLength t n
   #-}
 
 {-# RULES 

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -102,7 +102,7 @@ module Data.ByteString.Lazy (
         all,                    -- :: (Word8 -> Bool) -> ByteString -> Bool
         maximum,                -- :: ByteString -> Word8
         minimum,                -- :: ByteString -> Word8
-        compareLength,          -- :: ByteString -> Int -> Ordering
+        compareLength,          -- :: ByteString -> Int64 -> Ordering
 
         -- * Building ByteStrings
         -- ** Scans
@@ -301,7 +301,7 @@ null _     = False
 -- | /O(c)/ 'length' returns the length of a ByteString as an 'Int64'
 length :: ByteString -> Int64
 length cs = foldlChunks (\n c -> n + fromIntegral (S.length c)) 0 cs
-{-# INLINE length #-}
+{-# INLINE [1] length #-}
 
 infixr 5 `cons`, `cons'` --same as list (:)
 infixl 5 `snoc`
@@ -527,46 +527,46 @@ minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
 {-# INLINE minimum #-}
 
 -- | /O(n)/ 'compareLength' compares the length of a 'ByteString' 
--- to an 'Int'   
-compareLength :: ByteString -> Int -> Ordering
+-- to an 'Int64'   
+compareLength :: ByteString -> Int64 -> Ordering
 compareLength _ toCmp | toCmp < 0 = GT
 compareLength Empty toCmp         = compare 0 toCmp
-compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - S.length c)
+compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - fromIntegral (S.length c))
 {-# INLINE compareLength #-}
 
 {-# RULES 
 "ByteString.Lazy compareN/length -> compareLength" [~1] forall t n.
-  compare (length t) n = compareLength t (fromIntegral n)
+  compare (length t) n = compareLength t n
   #-}
 
 {-# RULES 
 "ByteString.Lazy ==N/length -> compareLength/==EQ" [~1] forall t n.
-   length t == n = compareLength t (fromIntegral n) == EQ
+   length t == n = compareLength t n == EQ
   #-}
 
 {-# RULES 
 "ByteString.Lazy /=N/length -> compareLength//=EQ" [~1] forall t n.
-   length t /= n = compareLength t (fromIntegral n) /= EQ
+   length t /= n = compareLength t n /= EQ
   #-}
 
 {-# RULES 
 "ByteString.Lazy <N/length -> compareLength/==LT" [~1] forall t n.
-   length t < n = compareLength t (fromIntegral n) == LT
+   length t < n = compareLength t n == LT
   #-}
 
 {-# RULES 
 "ByteString.Lazy <=N/length -> compareLength//=GT" [~1] forall t n.
-   length t <= n = compareLength t (fromIntegral n) /= GT
+   length t <= n = compareLength t n /= GT
   #-}
 
 {-# RULES 
 "ByteString.Lazy >N/length -> compareLength/==GT" [~1] forall t n.
-   length t > n = compareLength t (fromIntegral n) == GT
+   length t > n = compareLength t n == GT
   #-}
 
 {-# RULES 
 "ByteString.Lazy >=N/length -> compareLength//=LT" [~1] forall t n.
-   length t >= n = compareLength t (fromIntegral n) /= LT
+   length t >= n = compareLength t n /= LT
   #-}
 
 -- | The 'mapAccumL' function behaves like a combination of 'map' and

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -81,6 +81,7 @@ module Data.ByteString.Lazy.Char8 (
         all,                    -- :: (Char -> Bool) -> ByteString -> Bool
         maximum,                -- :: ByteString -> Char
         minimum,                -- :: ByteString -> Char
+        compareLength,          -- :: ByteString -> Int -> Ordering
 
         -- * Building ByteStrings
         -- ** Scans
@@ -207,7 +208,7 @@ import Data.ByteString.Lazy
         ,hGetContents, hGet, hPut, getContents
         ,hGetNonBlocking, hPutNonBlocking
         ,putStr, hPutStr, interact
-        ,readFile,writeFile,appendFile)
+        ,readFile,writeFile,appendFile,compareLength)
 
 -- Functions we need to wrap.
 import qualified Data.ByteString.Lazy as L

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -710,12 +710,12 @@ prop_all xs a = (all (== a) xs) == (L.all (== a) (pack xs))
 prop_maximum xs = (not (null xs)) ==> (maximum xs) == (L.maximum ( pack xs ))
 prop_minimum xs = (not (null xs)) ==> (minimum xs) == (L.minimum ( pack xs ))
 
-prop_compareLength1 xs  =  (L.pack xs         `L.compareLength` length xs) == EQ
-prop_compareLength2 xs c = (L.pack (xs ++ [c]) `L.compareLength` length xs) == GT
-prop_compareLength3 xs c = (L.pack xs `L.compareLength` length (xs ++ [c])) == LT
+prop_compareLength1 xs  =  (L.pack xs         `L.compareLength` fromIntegral (length xs)) == EQ
+prop_compareLength2 xs c = (L.pack (xs ++ [c]) `L.compareLength` fromIntegral (length xs)) == GT
+prop_compareLength3 xs c = (L.pack xs `L.compareLength` fromIntegral (length (xs ++ [c]))) == LT
 prop_compareLength4 xs c = ((L.pack xs `L.append` L.pack [c] `L.append` L.pack [undefined]) 
-                            `L.compareLength` length xs) == GT
-prop_compareLength5 xs l = L.compareLength xs l == compare (L.length xs) (fromIntegral l)
+                            `L.compareLength` fromIntegral (length xs)) == GT
+prop_compareLength5 xs l = L.compareLength xs l == compare (L.length xs) l
 
 prop_replicate1 c =
     forAll arbitrary $ \(Positive n) ->

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -710,6 +710,10 @@ prop_all xs a = (all (== a) xs) == (L.all (== a) (pack xs))
 prop_maximum xs = (not (null xs)) ==> (maximum xs) == (L.maximum ( pack xs ))
 prop_minimum xs = (not (null xs)) ==> (minimum xs) == (L.minimum ( pack xs ))
 
+prop_compareLength1 xs  =  (L.pack xs         `L.compareLength` length xs) == EQ
+prop_compareLength2 xs c = (L.pack (xs++[c]) `L.compareLength` length xs) == GT
+prop_compareLength3 xs c = (L.pack xs `L.compareLength` length (xs++[c])) == LT
+
 prop_replicate1 c =
     forAll arbitrary $ \(Positive n) ->
     unpack (L.replicate (fromIntegral n) c) == replicate n c
@@ -2407,6 +2411,9 @@ ll_tests =
     , testProperty "all"                prop_all
     , testProperty "maximum"            prop_maximum
     , testProperty "minimum"            prop_minimum
+    , testProperty "compareLength 1"    prop_compareLength1
+    , testProperty "compareLength 2"    prop_compareLength2
+    , testProperty "compareLength 3"    prop_compareLength3
     , testProperty "replicate 1"        prop_replicate1
     , testProperty "replicate 2"        prop_replicate2
     , testProperty "take"               prop_take1

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -711,8 +711,10 @@ prop_maximum xs = (not (null xs)) ==> (maximum xs) == (L.maximum ( pack xs ))
 prop_minimum xs = (not (null xs)) ==> (minimum xs) == (L.minimum ( pack xs ))
 
 prop_compareLength1 xs  =  (L.pack xs         `L.compareLength` length xs) == EQ
-prop_compareLength2 xs c = (L.pack (xs++[c]) `L.compareLength` length xs) == GT
-prop_compareLength3 xs c = (L.pack xs `L.compareLength` length (xs++[c])) == LT
+prop_compareLength2 xs c = (L.pack (xs ++ [c]) `L.compareLength` length xs) == GT
+prop_compareLength3 xs c = (L.pack xs `L.compareLength` length (xs ++ [c])) == LT
+prop_compareLength4 xs c = ((L.pack xs `L.append` L.pack [c] `L.append` L.pack [undefined]) 
+                            `L.compareLength` length xs) == GT
 
 prop_replicate1 c =
     forAll arbitrary $ \(Positive n) ->
@@ -2414,6 +2416,7 @@ ll_tests =
     , testProperty "compareLength 1"    prop_compareLength1
     , testProperty "compareLength 2"    prop_compareLength2
     , testProperty "compareLength 3"    prop_compareLength3
+    , testProperty "compareLength 4"    prop_compareLength4
     , testProperty "replicate 1"        prop_replicate1
     , testProperty "replicate 2"        prop_replicate2
     , testProperty "take"               prop_take1

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -715,6 +715,7 @@ prop_compareLength2 xs c = (L.pack (xs ++ [c]) `L.compareLength` length xs) == G
 prop_compareLength3 xs c = (L.pack xs `L.compareLength` length (xs ++ [c])) == LT
 prop_compareLength4 xs c = ((L.pack xs `L.append` L.pack [c] `L.append` L.pack [undefined]) 
                             `L.compareLength` length xs) == GT
+prop_compareLength5 xs l = L.compareLength xs l == compare (L.length xs) (fromIntegral l)
 
 prop_replicate1 c =
     forAll arbitrary $ \(Positive n) ->
@@ -2417,6 +2418,7 @@ ll_tests =
     , testProperty "compareLength 2"    prop_compareLength2
     , testProperty "compareLength 3"    prop_compareLength3
     , testProperty "compareLength 4"    prop_compareLength4
+    , testProperty "compareLength 5"    prop_compareLength5
     , testProperty "replicate 1"        prop_replicate1
     , testProperty "replicate 2"        prop_replicate2
     , testProperty "take"               prop_take1


### PR DESCRIPTION
related to #298 

I tested the function in GHCi. 
Unfortunately I do not yet understand how to add tests to the testsuite.
I'd be great if someone could give me a point in the right direction on where to add tests.

Concerning the documentation: I described the compareLength as being O(n) (where n is the length of the ByteString). This is a bit imprecise, because it neglects the `Int` parameter entirely. However, I was not sure on how to refer to this parameter in the documentation.