### PR TITLE
Backport of safe readInt from streaming-bytestring

### DIFF
--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -89,7 +89,13 @@ module Data.ByteString.Internal (
         accursedUnutterablePerformIO, -- :: IO a -> a
 
         -- * Exported compatibility shim
-        plusForeignPtr
+        plusForeignPtr,
+
+        -- * Internal constants
+        intmaxQuot10,
+        intmaxRem10,
+        intminQuot10,
+        intminRem10
   ) where
 
 import Prelude hiding (concat, null)
@@ -127,7 +133,7 @@ import Data.String              (IsString(..))
 import Control.Exception        (assert)
 
 import Data.Char                (ord)
-import Data.Word                (Word8)
+import Data.Word                (Word8, Word)
 
 import Data.Typeable            (Typeable)
 import Data.Data                (Data(..), mkNoRepType)
@@ -697,6 +703,22 @@ isSpaceChar8 c =
 
 overflowError :: String -> a
 overflowError fun = error $ "Data.ByteString." ++ fun ++ ": size overflow"
+
+-- | Bounds for Word# multiplication by 10 without overflow, and
+-- absolute values of Int bounds.
+intmaxWord, intminWord, intmaxQuot10, intmaxRem10, intminQuot10, intminRem10 :: Word
+intmaxWord = fromIntegral (maxBound :: Int)
+{-# INLINE intmaxWord #-}
+intminWord = fromIntegral (negate (minBound :: Int))
+{-# INLINE intminWord #-}
+intmaxQuot10 = intmaxWord `quot` 10
+{-# INLINE intmaxQuot10 #-}
+intmaxRem10 = intmaxWord `rem` 10
+{-# INLINE intmaxRem10 #-}
+intminQuot10 = intminWord `quot` 10
+{-# INLINE intminQuot10 #-}
+intminRem10 = intminWord `rem` 10
+{-# INLINE intminRem10 #-}
 
 ------------------------------------------------------------------------
 

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -812,18 +812,23 @@ unwords = intercalate (singleton ' ')
 -- 'readInt' does not ignore leading whitespace, the value must start
 -- immediately at the beginning of the input stream.
 --
--- ==== __Example__
--- >>> case readInt str of
--- >>>     Just (n, rest)  -> print n >> gladly rest
--- >>>     Nothing         -> sadly Nothing
+-- ==== __Examples__
+-- >>> readInt "-1729 = (-10)^3 + (-9)^3 = (-12)^3 + (-1)^3"
+-- Just (-1729," = (-10)^3 + (-9)^3 = (-12)^3 + (-1)^3")
+-- >>> readInt "not a decimal number")
+-- Nothing
+-- >>> readInt "12345678901234567890 overflows maxBound")
+-- Nothing
+-- >>> readInt "-12345678901234567890 underflows minBound")
+-- Nothing
 --
 readInt :: ByteString -> Maybe (Int, ByteString)
 {-# INLINABLE readInt #-}
 readInt bs = case L.uncons bs of
-    Just (w, rest) | w - 0x30 <= 9 -> readDec True bs
-                   | w == 0x2b     -> readDec True rest
-                   | w == 0x2d     -> readDec False rest
-    _                              -> Nothing
+    Just (w, rest) | w - 0x30 <= 9 -> readDec True bs    -- starts with digit
+                   | w == 0x2d     -> readDec False rest -- starts with minus
+                   | w == 0x2b     -> readDec True rest  -- starts with plus
+    _                              -> Nothing            -- not signed decimal
   where
 
     -- | Read a decimal 'Int' without overflow.  The caller has already
@@ -866,10 +871,9 @@ readInt bs = case L.uncons bs of
                 go :: Ptr Word8 -> Int -> Word -> IO (Int, Word, Bool)
                 go !p !b !a | p == e = return (b, a, True)
                 go !p !b !a = do
-                    !byte <- peek p
-                    let !w = byte - 0x30
-                        !d = fromIntegral w
-                    if w > 9 -- No more digits
+                    !w <- fmap fromIntegral $ peek p
+                    let !d = w - 0x30
+                    if d > 9 -- No more digits
                         then return (b, a, True)
                         else if a < maxq -- Look for more
                         then go (p `plusPtr` 1) (b + 1) (a * 10 + d)

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -75,6 +75,7 @@ executable regressions
   main-is:          Regressions.hs
   other-modules:    Data.ByteString
                     Data.ByteString.Internal
+                    Data.ByteString.Lazy.Internal
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
   build-depends:    base, ghc-prim, deepseq, random, directory,


### PR DESCRIPTION
This version detects integer overflow and returns 'Nothing'.

With lazy bytestrings it will not read new chunks after an "unreasonable" number
(more than ~32kB) of leading zeros and will instead return 'Nothing'.

Tests check that maxBound and minBound are handled correctly possibly with
explicit signs (for maxBound), and that overflowing by 1, 10 and many
appended zeros all fail.