### PR TITLE
Implement intersperse using SSE2

### DIFF
--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -361,6 +361,10 @@ main = do
       , benchFE "floatHexFixed"    $ fromIntegral >$< P.floatHexFixed
       , benchFE "doubleHexFixed"   $ fromIntegral >$< P.doubleHexFixed
       ]
+    , bgroup "intersperse"
+      [ bench "intersperse" $ whnf (S.intersperse 32) byteStringData
+      , bench "intersperse (unaligned)" $ whnf (S.intersperse 32) (S.drop 1 byteStringData)
+      ]
     , bgroup "partition"
       [
         bgroup "strict"


### PR DESCRIPTION
SSE2 is available on every x86_64 CPU, so there is no need for a capability check.

Before:

```
benchmarked intersperse/intersperse
time                 1.127 μs   (1.104 μs .. 1.149 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 1.103 μs   (1.096 μs .. 1.112 μs)
std dev              26.95 ns   (20.98 ns .. 34.21 ns)
```

After:

```
benchmarked intersperse/intersperse
time                 715.9 ns   (697.3 ns .. 730.9 ns)
                     0.997 R²   (0.996 R² .. 0.999 R²)
mean                 688.7 ns   (683.4 ns .. 696.8 ns)
std dev              21.36 ns   (15.97 ns .. 32.29 ns)
```