### PR TITLE
Assorted test-suite tweaks 

### DIFF
--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -62,5 +62,6 @@ main = do
          L.writeFile "b" (L8.pack "abc")
          renameFile "b" "a"
 
+    removeFile "a"
 
 n = 1000

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 --
 -- Must have rules off, otherwise the rewrite rules will replace the rhs
 -- with the lhs, and we only end up testing lhs == lhs
@@ -1654,8 +1655,8 @@ prop_packAddress = C.pack "this is a test"
             ==
                    C.pack "this is a test"
 
-prop_isSpaceWord8 (w :: Word8) = isSpace c == P.isSpaceChar8 c
-   where c = chr (fromIntegral w)
+prop_isSpaceWord8 w = isSpace c == P.isSpaceChar8 c
+   where c = chr (fromIntegral (w :: Word8))
 
 
 ------------------------------------------------------------------------

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP, ScopedTypeVariables, BangPatterns #-}
 --
 -- Must have rules off, otherwise the rewrite rules will replace the rhs
 -- with the lhs, and we only end up testing lhs == lhs
@@ -51,12 +50,8 @@ import Prelude hiding (abs)
 
 import Rules
 import QuickCheckUtils
-#if defined(HAVE_TEST_FRAMEWORK)
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2
-#else
-import TestFramework
-#endif
 
 toInt64 :: Int -> Int64
 toInt64 = fromIntegral

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1754,7 +1754,7 @@ short_tests =
 -- The entry point
 
 main :: IO ()
-main = defaultMainWithArgs tests ["-o 3"] -- timeout if a test runs for >3 secs
+main = defaultMain tests
 
 --
 -- And now a list of all the properties to test.

--- a/tests/Rules.hs
+++ b/tests/Rules.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Rules where
 --
 -- Tests to ensure rules are firing.
@@ -15,12 +13,7 @@ import Data.Word
 
 import QuickCheckUtils
 
-#if defined(HAVE_TEST_FRAMEWORK)
 import Test.Framework.Providers.QuickCheck2
-#else
-import TestFramework
-#endif
-
 
 prop_break_C :: Word8 -> C.ByteString -> Bool
 prop_break_C w = C.break ((==) x) `eq1` break ((==) x)

--- a/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP, ScopedTypeVariables #-}
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -83,14 +82,10 @@ import Foreign
 
 import           System.ByteOrder
 
-#if defined(HAVE_TEST_FRAMEWORK)
 import           Test.HUnit (assertBool)
 import           Test.Framework
 import           Test.Framework.Providers.HUnit
 import           Test.Framework.Providers.QuickCheck2
-#else
-import           TestFramework
-#endif
 import           Test.QuickCheck (Arbitrary(..))
 
 -- Helper functions

--- a/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -69,18 +70,14 @@ import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal      as S
 import qualified Data.ByteString.Builder.Prim.Internal as I
 
+import           Data.Bits (Bits(..))
 import           Data.Char (chr, ord)
-
+import           Data.Int
+import           Data.Word
+import           Foreign (Storable(..), castPtr, minusPtr, with)
 import           Numeric (showHex)
-
-#if MIN_VERSION_base(4,4,0)
-import Foreign hiding (unsafePerformIO)
-import System.IO.Unsafe (unsafePerformIO)
-#else
-import Foreign
-#endif
-
 import           System.ByteOrder
+import           System.IO.Unsafe (unsafePerformIO)
 
 import           Test.HUnit (assertBool)
 import           Test.Framework

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP, ScopedTypeVariables, MagicHash #-}
-
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -19,13 +17,8 @@ import           Data.ByteString.Builder
 import qualified Data.ByteString.Builder.Prim          as BP
 import           Data.ByteString.Builder.Prim.TestUtils
 
-#if defined(HAVE_TEST_FRAMEWORK)
 import           Test.Framework
 import           Test.Framework.Providers.QuickCheck2
-#else
-import           TestFramework
-#endif
-
 
 tests :: [Test]
 tests = concat [ testsBinary, testsASCII, testsChar8, testsUtf8

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MagicHash #-}
+
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, FlexibleContexts, ScopedTypeVariables, BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- |
@@ -42,12 +42,8 @@ import           System.IO (hSetEncoding, utf8)
 import           System.Directory
 import           Foreign (ForeignPtr, withForeignPtr, castPtr)
 
-#if defined(HAVE_TEST_FRAMEWORK)
 import           Test.Framework
 import           Test.Framework.Providers.QuickCheck2
-#else
-import           TestFramework
-#endif
 
 import           Test.QuickCheck
                    ( Arbitrary(..), oneof, choose, listOf, elements

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -19,7 +19,6 @@ import           Control.Monad.State
 import           Control.Monad.Writer
 
 import           Foreign (Word, Word8, minusPtr)
-import           System.IO.Unsafe (unsafePerformIO)
 
 import           Data.Char (chr)
 import qualified Data.DList      as D
@@ -52,7 +51,7 @@ import           TestFramework
 
 import           Test.QuickCheck
                    ( Arbitrary(..), oneof, choose, listOf, elements
-                   , counterexample, ioProperty, UnicodeString(..) )
+                   , counterexample, ioProperty, UnicodeString(..), Property )
 
 
 tests :: [Test]
@@ -95,9 +94,9 @@ testHandlePutBuilder :: Test
 testHandlePutBuilder =
     testProperty "hPutBuilder" testRecipe
   where
-    testRecipe :: (UnicodeString, UnicodeString, UnicodeString, Recipe) -> Bool
+    testRecipe :: (UnicodeString, UnicodeString, UnicodeString, Recipe) -> Property
     testRecipe args =
-      unsafePerformIO $ do
+      ioProperty $ do
         let (UnicodeString a1, UnicodeString a2, UnicodeString a3, recipe) = args
 #if MIN_VERSION_base(4,5,0)
             before  = a1
@@ -146,8 +145,8 @@ testHandlePutBuilderChar8 :: Test
 testHandlePutBuilderChar8 =
     testProperty "char8 hPutBuilder" testRecipe
   where
-    testRecipe :: (String, String, String, Recipe) -> Bool
-    testRecipe args@(before, between, after, recipe) = unsafePerformIO $ do
+    testRecipe :: (String, String, String, Recipe) -> Property
+    testRecipe args@(before, between, after, recipe) = ioProperty $ do
         tempDir <- getTemporaryDirectory
         (tempFile, tempH) <- openTempFile tempDir "TestBuilder"
         -- switch to binary / latin1 encoding

--- a/tests/builder/TestSuite.hs
+++ b/tests/builder/TestSuite.hs
@@ -1,13 +1,8 @@
-{-# LANGUAGE CPP #-}
 module Main where
 
 import qualified Data.ByteString.Builder.Tests
 import qualified Data.ByteString.Builder.Prim.Tests
-#if defined(HAVE_TEST_FRAMEWORK)
 import           Test.Framework (defaultMain, Test, testGroup)
-#else
-import           TestFramework
-#endif
 
 main :: IO ()
 main = defaultMain tests

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -111,7 +111,7 @@ test-suite test-builder
                     byteorder                  == 1.0.*,
                     dlist                      >= 0.5 && < 0.9,
                     directory,
-                    mtl                        >= 2.0 && < 2.3,
+                    transformers               >= 0.3,
                     HUnit,
                     test-framework,
                     test-framework-hunit,

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -43,11 +43,6 @@ test-suite prop-compiled
   ghc-options:      -fwarn-unused-binds
                     -fno-enable-rewrite-rules
                     -threaded -rtsopts
-  extensions:       BangPatterns
-                    UnliftedFFITypes,
-                    MagicHash,
-                    ScopedTypeVariables
-                    NamedFieldPuns
 
 test-suite lazy-hclose
   type:             exitcode-stdio-1.0
@@ -73,6 +68,7 @@ executable regressions
   main-is:          Regressions.hs
   other-modules:    Data.ByteString
                     Data.ByteString.Internal
+                    Data.ByteString.Lazy.Internal
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
   build-depends:    base, ghc-prim, deepseq, random, directory,
@@ -82,11 +78,6 @@ executable regressions
   ghc-options:      -fwarn-unused-binds
                     -fno-enable-rewrite-rules
                     -threaded -rtsopts
-  extensions:       BangPatterns
-                    UnliftedFFITypes,
-                    MagicHash,
-                    ScopedTypeVariables
-                    NamedFieldPuns
 
 test-suite test-builder
   type:             exitcode-stdio-1.0
@@ -126,13 +117,6 @@ test-suite test-builder
                     test-framework-hunit,
                     test-framework-quickcheck2  >= 0.3
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
-  extensions:       CPP, ForeignFunctionInterface
-                    UnliftedFFITypes,
-                    MagicHash,
-                    ScopedTypeVariables
-                    Rank2Types
-                    BangPatterns
-                    NamedFieldPuns
   c-sources:        ../cbits/fpstring.c
                     ../cbits/itoa.c
   include-dirs:     ../include

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -40,7 +40,6 @@ test-suite prop-compiled
                     QuickCheck >= 2.10 && < 2.15
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
-  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
   ghc-options:      -fwarn-unused-binds
                     -fno-enable-rewrite-rules
                     -threaded -rtsopts
@@ -66,7 +65,6 @@ test-suite lazy-hclose
                     QuickCheck >= 2.10 && < 2.15
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
-  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
   ghc-options:      -fwarn-unused-binds
                     -fno-enable-rewrite-rules
                     -threaded -rtsopts
@@ -81,7 +79,6 @@ executable regressions
                     test-framework, test-framework-hunit, HUnit
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
-  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
   ghc-options:      -fwarn-unused-binds
                     -fno-enable-rewrite-rules
                     -threaded -rtsopts
@@ -128,7 +125,6 @@ test-suite test-builder
                     test-framework,
                     test-framework-hunit,
                     test-framework-quickcheck2  >= 0.3
-  cpp-options:      -DHAVE_TEST_FRAMEWORK=1
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
   extensions:       CPP, ForeignFunctionInterface
                     UnliftedFFITypes,


### PR DESCRIPTION
(Depending on `tranformers` instead of `mtl` is motivated mostly by https://github.com/haskell/mtl/pull/74)