### PR TITLE
Expose ShortByteString construstor

### DIFF
--- a/Data/ByteString/Short.hs
+++ b/Data/ByteString/Short.hs
@@ -30,7 +30,7 @@ module Data.ByteString.Short (
 
     -- * The @ShortByteString@ type
 
-    ShortByteString,
+    ShortByteString(..),
 
     -- ** Memory overhead
     -- | With GHC, the memory overheads are as follows, expressed in words and


### PR DESCRIPTION
After #305 there remain no reasons to hide `SBS` constructor into an `Internal` module: there is no internal invariant left which could possibly violated by its exposure. 

This allows users to implement `byteArrayToByteString` and `byteStringToByteArray` from #186 without reaching out for internal modules. Cf. #253.