### PR TITLE
Optimize isSpace functions

### DIFF
--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -671,16 +671,16 @@ c2w = fromIntegral . ord
 {-# INLINE c2w #-}
 
 -- | Selects words corresponding to white-space characters in the Latin-1 range
--- ordered by frequency.
 isSpaceWord8 :: Word8 -> Bool
-isSpaceWord8 w =
-    w == 0x20 ||
-    w == 0x0A || -- LF, \n
-    w == 0x09 || -- HT, \t
-    w == 0x0C || -- FF, \f
-    w == 0x0D || -- CR, \r
-    w == 0x0B || -- VT, \v
-    w == 0xA0    -- spotted by QC..
+isSpaceWord8 w8 =
+    -- Avoid the cost of narrowing arithmetic results to Word8,
+    -- the conversion from Word8 to Word is free.
+    let w :: Word
+        !w = fromIntegral w8
+     in w - 0x21 > 0x7e   -- not [x21..0x9f]
+        && ( w == 0x20    -- SP
+          || w - 0x09 < 5 -- HT, NL, VT, FF, CR
+          || w == 0xa0 )  -- NBSP
 {-# INLINE isSpaceWord8 #-}
 
 -- | Selects white-space characters in the Latin-1 range

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -126,6 +126,7 @@ import Data.String              (IsString(..))
 
 import Control.Exception        (assert)
 
+import Data.Bits                ((.&.))
 import Data.Char                (ord)
 import Data.Word                (Word8)
 
@@ -677,10 +678,11 @@ isSpaceWord8 w8 =
     -- the conversion from Word8 to Word is free.
     let w :: Word
         !w = fromIntegral w8
-     in w - 0x21 > 0x7e   -- not [x21..0x9f]
-        && ( w == 0x20    -- SP
-          || w - 0x09 < 5 -- HT, NL, VT, FF, CR
-          || w == 0xa0 )  -- NBSP
+     in w .&. 0x50 == 0    -- Quick non-whitespace filter
+        && w - 0x21 > 0x7e -- Second non-whitespace filter
+        && ( w == 0x20     -- SP
+          || w == 0xa0     -- NBSP
+          || w - 0x09 < 5) -- HT, NL, VT, FF, CR
 {-# INLINE isSpaceWord8 #-}
 
 -- | Selects white-space characters in the Latin-1 range

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -687,14 +687,7 @@ isSpaceWord8 w8 =
 
 -- | Selects white-space characters in the Latin-1 range
 isSpaceChar8 :: Char -> Bool
-isSpaceChar8 c =
-    c == ' '     ||
-    c == '\t'    ||
-    c == '\n'    ||
-    c == '\r'    ||
-    c == '\f'    ||
-    c == '\v'    ||
-    c == '\xa0'
+isSpaceChar8 = isSpaceWord8 . c2w
 {-# INLINE isSpaceChar8 #-}
 
 overflowError :: String -> a

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -128,7 +128,7 @@ import Control.Exception        (assert)
 
 import Data.Bits                ((.&.))
 import Data.Char                (ord)
-import Data.Word                (Word8)
+import Data.Word                (Word8, Word)
 
 import Data.Typeable            (Typeable)
 import Data.Data                (Data(..), mkNoRepType)

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -101,6 +101,9 @@ byteStringChunksData = map (S.pack . replicate (4 ) . fromIntegral) intData
 oldByteStringChunksData :: [OldS.ByteString]
 oldByteStringChunksData = map (OldS.pack . replicate (4 ) . fromIntegral) intData
 
+{-# NOINLINE loremIpsum #-}
+loremIpsum :: S.ByteString
+loremIpsum = S8.pack "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?\n"
 
 -- benchmark wrappers
 ---------------------
@@ -397,6 +400,10 @@ main = do
         ]
       ]
     , bgroup "sort" $ map (\s -> bench (S8.unpack s) $ nf S.sort s) sortInputs
+    , bgroup "words"
+      [ bench "lorem ipsum" $ nf S8.words loremIpsum
+      , bench "one huge word" $ nf S8.words byteStringData
+      ]
     , bgroup "folds"
       [ bgroup "foldl'" $ map (\s -> bench (show $ S.length s) $
           nf (S.foldl' (\acc x -> acc + fromIntegral x) (0 :: Int)) s) foldInputs

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -103,7 +103,14 @@ oldByteStringChunksData = map (OldS.pack . replicate (4 ) . fromIntegral) intDat
 
 {-# NOINLINE loremIpsum #-}
 loremIpsum :: S.ByteString
-loremIpsum = S8.pack "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?\n"
+loremIpsum = S8.unlines $ map S8.pack
+  [ "  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+  , "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis"
+  , "nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+  , "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu"
+  , "fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in"
+  , "culpa qui officia deserunt mollit anim id est laborum."
+  ]
 
 -- benchmark wrappers
 ---------------------


### PR DESCRIPTION
GHC unlike GCC does not optimize expressions like `x == 10 || x == 11 || x == 12 || x == 13` into `x >= 10 && x <= 13` and further into `x - 10 <= 3` so I did it here manually. Turns out this optimization was already applied years ago to `Data.Char.isSpace`: https://hackage.haskell.org/package/base-4.12.0.0/docs/src/GHC.Unicode.html#isSpace

I chose the `w == 0x20 || w == 0xA0 || w - 0x09 <= 4` order or terms instead of `w == 0x20 || w - 0x09 <= 4 || w == 0xA0` because it was faster on my machine. It also uses one fewer register according to the Compiler Explorer. It might be beneficial to adopt this order of terms in `Data.Char.isSpace` as well.

I also added a benchmark for `words` that uses `isSpaceWord8` a lot.

Before:

```
benchmarked words/lots of words
time                 142.2 μs   (141.8 μs .. 142.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 141.9 μs   (141.7 μs .. 142.2 μs)
std dev              746.9 ns   (611.1 ns .. 927.7 ns)

benchmarked words/one huge word
time                 11.73 μs   (11.71 μs .. 11.75 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 11.74 μs   (11.72 μs .. 11.76 μs)
std dev              62.67 ns   (46.41 ns .. 86.93 ns)

```

After:

```
benchmarked words/lots of words
time                 133.1 μs   (132.7 μs .. 133.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 133.1 μs   (132.8 μs .. 133.5 μs)
std dev              1.003 μs   (671.2 ns .. 1.578 μs)

benchmarked words/one huge word
time                 10.11 μs   (10.08 μs .. 10.13 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.10 μs   (10.08 μs .. 10.13 μs)
std dev              71.64 ns   (50.03 ns .. 116.5 ns)

```