### PR TITLE
Cleanup benchmarks

### DIFF
--- a/bench/CSV.hs
+++ b/bench/CSV.hs
@@ -127,8 +127,6 @@ import qualified Data.ByteString.Builder.Prim         as E
 
 -- To be used in a later comparison
 import qualified Data.DList                                      as D
-import qualified Codec.Binary.UTF8.Light                         as Utf8Light
-import qualified Data.String.UTF8                                as Utf8String
 import qualified Data.Text.Lazy                                  as TL
 import qualified Data.Text.Lazy.Encoding                         as TL
 import qualified Data.Text.Lazy.Builder                          as TB
@@ -361,27 +359,6 @@ benchDListUtf8 :: Benchmark
 benchDListUtf8 = bench "utf8 + renderTableD maxiTable" $
   nf (L.length . B.toLazyByteString . B.stringUtf8 . D.toList . renderTableD) maxiTable
 
-
-------------------------------------------------------------------------------
--- utf8-string and utf8-light
-------------------------------------------------------------------------------
-
--- 4.12 ms
-benchDListUtf8Light :: Benchmark
-benchDListUtf8Light = bench "utf8-light + renderTable maxiTable" $
-  whnf (Utf8Light.encode . D.toList . renderTableD) maxiTable
-
-{- Couldn't get utf8-string to work :-(
-
-benchDListUtf8String :: Benchmark
-benchDListUtf8String = bench "utf8-light + renderTable maxiTable" $
-  whnf (Utf8String.toRep . encode .
-        D.toList . renderTableD) maxiTable
-  where
-    encode :: String -> Utf8String.UTF8 S.ByteString
-    encode = Utf8String.fromString
--}
-
 ------------------------------------------------------------------------------
 -- Text Builder
 ------------------------------------------------------------------------------
@@ -432,7 +409,6 @@ main = do
       , benchString
       , benchStringUtf8
       , benchDListUtf8
-      , benchDListUtf8Light
       , benchTextBuilder
       , benchTextBuilderUtf8
       , benchBuilderUtf8

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -1,3 +1,4 @@
+Cabal-Version:       2.2
 Name:                bench-bytestring
 Version:             0.1.0.0
 Synopsis:            Benchmarks for bytestring
@@ -7,7 +8,7 @@ Description:
     gauge depends on bytestring. Here, we just include the whole source of
     the bytestring library directly.
 
-License:             BSD3
+License:             BSD-3-Clause
 License-file:        LICENSE
 Category:            Data
 Copyright:           (c) Simon Meier          2010-2011.
@@ -20,7 +21,6 @@ Bug-reports:         iridcode@gmail.com
 Tested-With:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2,
                      GHC==8.0.2, GHC==7.10.3
 Build-Type:          Simple
-Cabal-Version:       >= 1.10
 
 source-repository head
   type:     darcs
@@ -30,16 +30,10 @@ flag integer-simple
   description: Use the simple integer library instead of GMP
   default: False
 
-benchmark bench-bytestring-builder
-  hs-source-dirs:    . ..
-  main-is:           BenchAll.hs
-  type:              exitcode-stdio-1.0
+common bench-stanza
+  hs-source-dirs:   . ..
+  default-language: Haskell98
 
-  build-depends:     base >= 4.8 && < 5
-                   , ghc-prim
-                   , deepseq       >= 1.2
-                   , gauge         >= 0.2.5
-                   , random
   other-modules:
         Data.ByteString
         Data.ByteString.Builder
@@ -53,108 +47,52 @@ benchmark bench-bytestring-builder
         Data.ByteString.Builder.Prim.Internal.Base16
         Data.ByteString.Builder.Prim.Internal.Floating
         Data.ByteString.Builder.Prim.Internal.UncheckedShifts
+        Data.ByteString.Char8
         Data.ByteString.Internal
         Data.ByteString.Lazy
         Data.ByteString.Lazy.Internal
         Data.ByteString.Short.Internal
         Data.ByteString.Unsafe
-
-  -- cabal complains about ../ dirs. However, this is better than symlinks,
-  -- which probably don't work on windows.
   c-sources:         ../cbits/fpstring.c
                      ../cbits/itoa.c
   include-dirs:      ../include
   includes:          fpstring.h
-  install-includes:  fpstring.h
 
-  default-language: Haskell98
   ghc-options:      -O2
                     -fmax-simplifier-iterations=10
                     -fdicts-cheap
                     -fspec-constr-count=6
 
-  -- flags for the decimal integer serialization code
+  build-depends:     base >= 4.8 && < 5
+                   , deepseq
+                   , gauge         >= 0.2.5
+                   , ghc-prim
+
   if impl(ghc >= 8.11)
     build-depends: ghc-bignum >= 1.0
-
-  if impl(ghc < 8.11)
+  else
     if !flag(integer-simple)
       cpp-options: -DINTEGER_GMP
       build-depends: integer-gmp >= 0.2
 
+benchmark bench-bytestring-builder
+  import:           bench-stanza
+  main-is:          BenchAll.hs
+  type:             exitcode-stdio-1.0
+  build-depends:    random
+
 benchmark bench-builder-boundscheck
-  hs-source-dirs:   .. .
+  import:           bench-stanza
   main-is:          BoundsCheckFusion.hs
   type:             exitcode-stdio-1.0
-  build-depends:    base >= 4.8 && < 5,
-                    deepseq,
-                    ghc-prim,
-                    gauge
-  c-sources:        ../cbits/fpstring.c
-                    ../cbits/itoa.c
-  include-dirs:     ../include
-  ghc-options:      -O2
-                    -fmax-simplifier-iterations=10
-                    -fdicts-cheap
-                    -fspec-constr-count=6
-  default-language: Haskell98
-  other-modules:
-        Data.ByteString
-        Data.ByteString.Builder
-        Data.ByteString.Builder.ASCII
-        Data.ByteString.Builder.Extra
-        Data.ByteString.Builder.Internal
-        Data.ByteString.Builder.Prim
-        Data.ByteString.Builder.Prim.ASCII
-        Data.ByteString.Builder.Prim.Binary
-        Data.ByteString.Builder.Prim.Internal
-        Data.ByteString.Builder.Prim.Internal.Base16
-        Data.ByteString.Builder.Prim.Internal.Floating
-        Data.ByteString.Builder.Prim.Internal.UncheckedShifts
-        Data.ByteString.Internal
-        Data.ByteString.Lazy
-        Data.ByteString.Lazy.Internal
-        Data.ByteString.Short.Internal
-        Data.ByteString.Unsafe
 
 benchmark bench-builder-csv
-  hs-source-dirs:   .. .
+  import:           bench-stanza
   main-is:          CSV.hs
   type:             exitcode-stdio-1.0
-  build-depends:    base >= 4.8 && < 5,
-                    deepseq,
-                    ghc-prim,
-                    text,
-                    gauge,
-                    utf8-string,
-                    utf8-light,
-                    bytestring,
-                    dlist
-  c-sources:        ../cbits/fpstring.c
-                    ../cbits/itoa.c
-  include-dirs:     ../include
-  ghc-options:      -O2
-                    -fmax-simplifier-iterations=10
-                    -fdicts-cheap
-                    -fspec-constr-count=6
-  default-language: Haskell2010
+  build-depends:    bytestring, dlist, text, utf8-light, utf8-string
 
 benchmark bench-strict-indices
-  hs-source-dirs:   .. .
+  import:           bench-stanza
   main-is:          BenchIndices.hs
-  other-modules:    Data.ByteString
-                    Data.ByteString.Internal
-                    Data.ByteString.Unsafe
   type:             exitcode-stdio-1.0
-  c-sources:        ../cbits/fpstring.c
-                    ../cbits/itoa.c
-  include-dirs:     ../include
-  build-depends:    base >= 4.8 && < 5
-                  , ghc-prim
-                  , deepseq       >= 1.2
-                  , gauge         >= 0.2.5
-  ghc-options:      -O2
-                    -fmax-simplifier-iterations=10
-                    -fdicts-cheap
-                    -fspec-constr-count=6
-  default-language: Haskell2010

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -73,24 +73,24 @@ common bench-stanza
       cpp-options: -DINTEGER_GMP
       build-depends: integer-gmp >= 0.2
 
-benchmark bench-bytestring-builder
+benchmark bench-builder
   import:           bench-stanza
   main-is:          BenchAll.hs
   type:             exitcode-stdio-1.0
   build-depends:    random
 
-benchmark bench-builder-boundscheck
+benchmark bench-boundscheck
   import:           bench-stanza
   main-is:          BoundsCheckFusion.hs
   type:             exitcode-stdio-1.0
 
-benchmark bench-builder-csv
+benchmark bench-csv
   import:           bench-stanza
   main-is:          CSV.hs
   type:             exitcode-stdio-1.0
   build-depends:    bytestring, dlist, text
 
-benchmark bench-strict-indices
+benchmark bench-indices
   import:           bench-stanza
   main-is:          BenchIndices.hs
   type:             exitcode-stdio-1.0

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -1,6 +1,6 @@
 Name:                bench-bytestring
 Version:             0.1.0.0
-Synopsis:            Benchmarks for the lazy bytestring builder.
+Synopsis:            Benchmarks for bytestring
 Description:
     This package is not meant for public release. It fixes a problem with the
     current benchmarking support in cabal, which has trouble compiling because
@@ -39,10 +39,6 @@ benchmark bench-bytestring-builder
                    , ghc-prim
                    , deepseq       >= 1.2
                    , gauge         >= 0.2.5
-                   , blaze-textual == 0.2.*
-                   -- we require bytestring due to benchmarking against
-                   -- blaze-textual, which uses blaze-builder
-                   , bytestring    >= 0.9
                    , random
   other-modules:
         Data.ByteString
@@ -76,15 +72,6 @@ benchmark bench-bytestring-builder
                     -fmax-simplifier-iterations=10
                     -fdicts-cheap
                     -fspec-constr-count=6
-
-  -- Since blaze-builder-0.4+ is just a wrapper around bytestring, we prefer
-  -- building with blaze-builder-0.3.*. However blaze-builder-0.3.* isn't
-  -- compatible with GHC-8.4+, so we relax the version bounds when building
-  -- with these GHC versions.
-  if impl(ghc >= 8.4)
-     build-depends: blaze-builder >= 0.3 && < 0.5
-  else
-     build-depends: blaze-builder == 0.3.*
 
   -- flags for the decimal integer serialization code
   if impl(ghc >= 8.11)

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -23,8 +23,8 @@ Tested-With:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2
 Build-Type:          Simple
 
 source-repository head
-  type:     darcs
-  location: http://darcs.haskell.org/bytestring/
+  type:     git
+  location: https://github.com/haskell/bytestring
 
 flag integer-simple
   description: Use the simple integer library instead of GMP

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -88,7 +88,7 @@ benchmark bench-builder-csv
   import:           bench-stanza
   main-is:          CSV.hs
   type:             exitcode-stdio-1.0
-  build-depends:    bytestring, dlist, text, utf8-light, utf8-string
+  build-depends:    bytestring, dlist, text
 
 benchmark bench-strict-indices
   import:           bench-stanza

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -17,7 +17,8 @@ Maintainer:          Simon Meier <iridcode@gmail.com>
                      Duncan Coutts <duncan@community.haskell.org>
 Bug-reports:         iridcode@gmail.com
                      duncan@community.haskell.org
-Tested-With:         GHC==7.0.3
+Tested-With:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2,
+                     GHC==8.0.2, GHC==7.10.3
 Build-Type:          Simple
 Cabal-Version:       >= 1.10
 
@@ -34,7 +35,7 @@ benchmark bench-bytestring-builder
   main-is:           BenchAll.hs
   type:              exitcode-stdio-1.0
 
-  build-depends:     base >= 4.4 && < 5
+  build-depends:     base >= 4.8 && < 5
                    , ghc-prim
                    , deepseq       >= 1.2
                    , gauge         >= 0.2.5
@@ -86,20 +87,21 @@ benchmark bench-bytestring-builder
      build-depends: blaze-builder == 0.3.*
 
   -- flags for the decimal integer serialization code
-  if impl(ghc >= 6.11)
+  if impl(ghc >= 8.11)
+    build-depends: ghc-bignum >= 1.0
+
+  if impl(ghc < 8.11)
     if !flag(integer-simple)
       cpp-options: -DINTEGER_GMP
       build-depends: integer-gmp >= 0.2
-
-  if impl(ghc >= 6.9) && impl(ghc < 6.11)
-    cpp-options: -DINTEGER_GMP
-    build-depends: integer >= 0.1 && < 0.2
 
 benchmark bench-builder-boundscheck
   hs-source-dirs:   .. .
   main-is:          BoundsCheckFusion.hs
   type:             exitcode-stdio-1.0
-  build-depends:    base, deepseq, ghc-prim,
+  build-depends:    base >= 4.8 && < 5,
+                    deepseq,
+                    ghc-prim,
                     gauge
   c-sources:        ../cbits/fpstring.c
                     ../cbits/itoa.c
@@ -132,7 +134,9 @@ benchmark bench-builder-csv
   hs-source-dirs:   .. .
   main-is:          CSV.hs
   type:             exitcode-stdio-1.0
-  build-depends:    base, deepseq, ghc-prim,
+  build-depends:    base >= 4.8 && < 5,
+                    deepseq,
+                    ghc-prim,
                     text,
                     gauge,
                     utf8-string,
@@ -158,7 +162,7 @@ benchmark bench-strict-indices
   c-sources:        ../cbits/fpstring.c
                     ../cbits/itoa.c
   include-dirs:     ../include
-  build-depends:    base >= 4.4 && < 5
+  build-depends:    base >= 4.8 && < 5
                   , ghc-prim
                   , deepseq       >= 1.2
                   , gauge         >= 0.2.5

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -95,53 +95,6 @@ benchmark bench-bytestring-builder
     cpp-options: -DINTEGER_GMP
     build-depends: integer >= 0.1 && < 0.2
 
--- executable bench-float-decimal
---   hs-source-dirs:    . ..
---   main-is:           BenchFloatDec.hs
---
---   build-depends:     base >= 4 && < 5
---                    , ghc-prim
---                    , deepseq       == 1.2.*
---                    , criterion     == 0.5.*
---                    , blaze-textual == 0.2.*
---                    , blaze-builder == 0.3.*
---                    -- we require bytestring due to benchmarking against
---                    -- blaze-textual, which uses blaze-builder
---                    , bytestring    == 0.9.*
---
---   -- cabal complains about ../ dirs. However, this is better than symlinks,
---   -- which probably don't work on windows.
---   c-sources:         ../cbits/fpstring.c
---                      ../cbits/itoa.c
---                      ../cbits/varint.c
---   include-dirs:      ../include
---   includes:          fpstring.h
---   install-includes:  fpstring.h
---
---   ghc-options:      -O2
---                     -fmax-simplifier-iterations=10
---                     -fdicts-cheap
---                     -fspec-constr-count=6
---
---   if impl(ghc >= 6.11)
---     cpp-options: -DINTEGER_GMP
---     build-depends: integer-gmp >= 0.2 && < 0.4
---
---   if impl(ghc >= 6.9) && impl(ghc < 6.11)
---     cpp-options: -DINTEGER_GMP
---     build-depends: integer >= 0.1 && < 0.2
---
---   if impl(ghc)
---     extensions:   UnliftedFFITypes,
---                   MagicHash,
---                   UnboxedTuples,
---                   DeriveDataTypeable
---                   ScopedTypeVariables
---                   Rank2Types
---                   NamedFieldPuns
---                   PackageImports
---                   ForeignFunctionInterface
-
 benchmark bench-builder-boundscheck
   hs-source-dirs:   .. .
   main-is:          BoundsCheckFusion.hs

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -53,10 +53,8 @@ common bench-stanza
         Data.ByteString.Lazy.Internal
         Data.ByteString.Short.Internal
         Data.ByteString.Unsafe
-  c-sources:         ../cbits/fpstring.c
-                     ../cbits/itoa.c
-  include-dirs:      ../include
-  includes:          fpstring.h
+  c-sources:        ../cbits/fpstring.c
+  include-dirs:     ../include
 
   ghc-options:      -O2
                     -fmax-simplifier-iterations=10


### PR DESCRIPTION
The most hilarious stuff happened in 43dc70a: Windows build used to fail because of paths exceeding 256 symbols with a cryptic error message:
`Fatal error: can't create D:\\a\\bytestring\\bytestring\\bench\\dist-newstyle\\build\\x86_64-windows\\ghc-8.6.5\\bench-bytestring-0.1.0.0\\b\\bench-bytestring-builder\\build\\bench-bytestring-builder\\bench-bytestring-builder-tmp\\Data\\ByteString\\Builder\\Prim\\Internal\\UncheckedShifts.o: No such file or directory`