### PR TITLE
Update maintainer info

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -51,7 +51,7 @@ Copyright:           Copyright (c) Don Stewart          2005-2009,
 
 Author:              Don Stewart,
                      Duncan Coutts
-Maintainer:          Duncan Coutts <duncan@community.haskell.org>
+Maintainer:          Haskell Bytestring Team <andrew.lelechenko@gmail.com>, Core Libraries Committee
 Homepage:            https://github.com/haskell/bytestring
 Bug-reports:         https://github.com/haskell/bytestring/issues
 Tested-With:         GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2,


### PR DESCRIPTION
* The Haskell Bytestring Team (@haskell/bytestring) serves as the primary maintainer.
* Andrew Lelechenko (@Bodigrim) is the primary contact for this team.
* The CLC (@haskell/core-libraries-committee) "owns" bytestring and oversees the primary maintainers.

Closes #256.