### PR TITLE
Fix IO tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [windows-latest, macOS-latest]
         ghc: ['8.6', '8.8', '8.10']
-        exclude:
-        - os: windows-latest
-          ghc: "8.8"
-        - os: windows-latest
-          ghc: "8.10"
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1.1.3

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1297,7 +1297,7 @@ prop_unfoldrBB c =
     forAll arbitrarySizedIntegral $ \n ->
       (fst $ C.unfoldrN n fn c) == (C.pack $ take n $ unfoldr fn c)
   where
-    fn x = Just (x, chr (ord x + 1))
+    fn x = Just (x, if x == maxBound then x else succ x)
 
 prop_prefixBB xs ys = isPrefixOf xs ys == (P.pack xs `P.isPrefixOf` P.pack ys)
 prop_prefixLL xs ys = isPrefixOf xs ys == (L.pack xs `L.isPrefixOf` L.pack ys)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1590,81 +1590,73 @@ prop_fromForeignPtr x = (let (a,b,c) = (P.toForeignPtr x)
 
 prop_read_write_file_P x = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do P.writeFile f x)
-        (const $ do removeFile f)
-        (const $ do y <- P.readFile f
-                    return (x==y))
+    let f = "qc-test-" ++ show tid
+    P.writeFile f x
+    y <- P.readFile f
+    removeFile f
+    return (x == y)
 
 prop_read_write_file_C x = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do C.writeFile f x)
-        (const $ do removeFile f)
-        (const $ do y <- C.readFile f
-                    return (x==y))
+    let f = "qc-test-" ++ show tid
+    C.writeFile f x
+    y <- C.readFile f
+    removeFile f
+    return (x == y)
 
 prop_read_write_file_L x = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do L.writeFile f x)
-        (const $ do removeFile f)
-        (const $ do y <- L.readFile f
-                    return (x==y))
+    let f = "qc-test-" ++ show tid
+    L.writeFile f x
+    y <- L.readFile f
+    L.length y `seq` removeFile f
+    return (x == y)
 
 prop_read_write_file_D x = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do D.writeFile f x)
-        (const $ do removeFile f)
-        (const $ do y <- D.readFile f
-                    return (x==y))
+    let f = "qc-test-" ++ show tid
+    D.writeFile f x
+    y <- D.readFile f
+    D.length y `seq` removeFile f
+    return (x == y)
 
 ------------------------------------------------------------------------
 
 prop_append_file_P x y = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do P.writeFile f x
-            P.appendFile f y)
-        (const $ do removeFile f)
-        (const $ do z <- P.readFile f
-                    return (z==(x `P.append` y)))
+    let f = "qc-test-" ++ show tid
+    P.writeFile f x
+    P.appendFile f y
+    z <- P.readFile f
+    removeFile f
+    return (z == x `P.append` y)
 
 prop_append_file_C x y = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do C.writeFile f x
-            C.appendFile f y)
-        (const $ do removeFile f)
-        (const $ do z <- C.readFile f
-                    return (z==(x `C.append` y)))
+    let f = "qc-test-" ++ show tid
+    C.writeFile f x
+    C.appendFile f y
+    z <- C.readFile f
+    removeFile f
+    return (z == x `C.append` y)
 
 prop_append_file_L x y = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do L.writeFile f x
-            L.appendFile f y)
-        (const $ do removeFile f)
-        (const $ do z <- L.readFile f
-                    return (z==(x `L.append` y)))
+    let f = "qc-test-" ++ show tid
+    L.writeFile f x
+    L.appendFile f y
+    z <- L.readFile f
+    L.length z `seq` removeFile f
+    return (z == x `L.append` y)
 
 prop_append_file_D x y = ioProperty $ do
     tid <- myThreadId
-    let f = "qc-test-"++show tid
-    bracket
-        (do D.writeFile f x
-            D.appendFile f y)
-        (const $ do removeFile f)
-        (const $ do z <- D.readFile f
-                    return (z==(x `D.append` y)))
+    let f = "qc-test-" ++ show tid
+    D.writeFile f x
+    D.appendFile f y
+    z <- D.readFile f
+    D.length z `seq` removeFile f
+    return (z == x `D.append` y)
 
 prop_packAddress = C.pack "this is a test"
             ==

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -40,7 +40,7 @@ import qualified Data.ByteString.Builder.Prim       as BP
 import           Data.ByteString.Builder.Prim.TestUtils
 
 import           Control.Exception (evaluate)
-import           System.IO (openTempFile, hPutStr, hClose, hSetBinaryMode)
+import           System.IO (openTempFile, hPutStr, hClose, hSetBinaryMode, hSetNewlineMode, noNewlineTranslation)
 import           System.IO (hSetEncoding, utf8)
 import           System.Directory
 import           Foreign (ForeignPtr, withForeignPtr, castPtr)
@@ -114,6 +114,7 @@ testHandlePutBuilder =
         (tempFile, tempH) <- openTempFile tempDir "TestBuilder"
         -- switch to UTF-8 encoding
         hSetEncoding tempH utf8
+        hSetNewlineMode tempH noNewlineTranslation
         -- output recipe with intermediate direct writing to handle
         let b = fst $ recipeComponents recipe
         hPutStr tempH before


### PR DESCRIPTION
As dicovered in #311, certain tests fail for Windows build with GHC 8.10: `DeleteFile "\\\\?\\D:\\a\\bytestring\\bytestring\\tests\\qc-test-ThreadId 5": permission denied (The process cannot access the file because it is being used by another process.)`, emitted by `System.Directory.removeFile`, invoked in `Properties.hs`. 
https://github.com/haskell/bytestring/blob/a83b77853abf209e04a77348586334f82114aa38/tests/Properties.hs#L1609-L1616

It's actually amazing that these tests have worked for ages under all other platforms, because they are reference examples of lazy I/O done wrong. Clearly the file is unlinked before its content is read in full. And `bracket` is useless here, because there is no resource to capture. One must explicitly force evaluation of lazy bytestring before removing the file.