### PR TITLE
Do not depend on directory

### DIFF
--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -1,67 +1,61 @@
-import qualified Data.ByteString       as S
-import qualified Data.ByteString.Char8 as S8
+module Main (main) where
 
+import Control.Monad (void, forM_)
+import Data.ByteString.Internal (toForeignPtr)
+import Foreign.C.String (withCString)
+import Foreign.ForeignPtr (finalizeForeignPtr)
+import System.IO (openFile, IOMode(..))
+import System.Posix.Internals (c_unlink)
+
+import qualified Data.ByteString            as S
+import qualified Data.ByteString.Char8      as S8
 import qualified Data.ByteString.Lazy       as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 
-import Control.Monad
-import System.Directory
-import System.Mem
-import System.IO
-
-import Data.ByteString.Internal
-import Foreign.ForeignPtr
-
 main :: IO ()
 main = do
-    writeFile "a" "x"
+    let n = 1000
+        fn = "lazyhclose-test.tmp"
+
+    writeFile fn "x"
 
     ------------------------------------------------------------------------
     -- readFile tests
 
-    print "Testing resource leaks for Strict.readFile"
+    putStrLn "Testing resource leaks for Strict.readFile"
     forM_ [1..n] $ const $ do
-         r <- S.readFile "a"
-         S.writeFile "b" (S8.pack "abc")
-         renameFile "b" "a"
+         r <- S.readFile fn
+         appendFile fn "" -- will fail, if fn has not been closed yet
 
-    print "Testing resource leaks for Lazy.readFile"
+    putStrLn "Testing resource leaks for Lazy.readFile"
     forM_ [1..n] $ const $ do
-         r <- L.readFile "a"
-         L.length r `seq` return ()      -- force the input, and done with 'r' now.
-         L.writeFile "b" (L8.pack "abc") -- but we still need the finalizers to run
-         renameFile "b" "a"
+         r <- L.readFile fn
+         L.length r `seq` return ()
+         appendFile fn "" -- will fail, if fn has not been closed yet
 
     -- manage the resources explicitly.
-    print "Testing resource leaks when converting lazy to strict"
+    putStrLn "Testing resource leaks when converting lazy to strict"
     forM_ [1..n] $ const $ do
          let release c = finalizeForeignPtr fp where (fp,_,_) = toForeignPtr c
-         r <- L.readFile "a"
-         mapM_ release (L.toChunks r) -- should close it.
-         L.writeFile "b" (L8.pack "abc")
-         renameFile "b" "a"
+         r <- L.readFile fn
+         mapM_ release (L.toChunks r)
+         appendFile fn "" -- will fail, if fn has not been closed yet
 
     ------------------------------------------------------------------------
     -- hGetContents tests
 
-    -- works now
-    print "Testing strict hGetContents"
+    putStrLn "Testing strict hGetContents"
     forM_ [1..n] $ const $ do
-         h <- openFile "a" ReadMode
-         r <- S.hGetContents h -- should be strict, and hClosed.
+         h <- openFile fn ReadMode
+         r <- S.hGetContents h
          S.last r `seq` return ()
-         S.writeFile "b" (S8.pack "abc")
-         renameFile "b" "a"
+         appendFile fn "" -- will fail, if fn has not been closed yet
 
-    -- works now
-    print "Testing lazy hGetContents"
+    putStrLn "Testing lazy hGetContents"
     forM_ [1..n] $ const $ do
-         h <- openFile "a" ReadMode
-         r <- L.hGetContents h -- should be strict, and hClosed.
+         h <- openFile fn ReadMode
+         r <- L.hGetContents h
          L.last r `seq` return ()
-         L.writeFile "b" (L8.pack "abc")
-         renameFile "b" "a"
+         appendFile fn "" -- will fail, if fn has not been closed yet
 
-    removeFile "a"
-
-n = 1000
+    void $ withCString fn c_unlink

--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -4,7 +4,7 @@ import Control.Monad (void, forM_)
 import Data.ByteString.Internal (toForeignPtr)
 import Foreign.C.String (withCString)
 import Foreign.ForeignPtr (finalizeForeignPtr)
-import System.IO (openFile, IOMode(..))
+import System.IO (openFile, openTempFile, hClose, hPutStrLn, IOMode(..))
 import System.Posix.Internals (c_unlink)
 
 import qualified Data.ByteString            as S
@@ -15,9 +15,9 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 main :: IO ()
 main = do
     let n = 1000
-        fn = "lazyhclose-test.tmp"
-
-    writeFile fn "x"
+    (fn, h) <- openTempFile "." "lazy-hclose-test.tmp"
+    hPutStrLn h "x"
+    hClose h
 
     ------------------------------------------------------------------------
     -- readFile tests
@@ -58,4 +58,7 @@ main = do
          L.last r `seq` return ()
          appendFile fn "" -- will fail, if fn has not been closed yet
 
-    void $ withCString fn c_unlink
+    removeFile fn
+
+removeFile :: String -> IO ()
+removeFile fn = void $ withCString fn c_unlink

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -11,6 +11,7 @@
 -- -fhpc interferes with rewrite rules firing.
 --
 
+import Foreign.C.String (withCString)
 import Foreign.Storable
 import Foreign.ForeignPtr
 import Foreign.Marshal.Alloc
@@ -21,7 +22,7 @@ import Control.Applicative
 import Control.Monad
 import Control.Concurrent
 import Control.Exception
-import System.Directory
+import System.Posix.Internals (c_unlink)
 
 import Data.List
 import Data.Char
@@ -1672,7 +1673,7 @@ prop_read_write_file_P x = ioProperty $ do
     let f = "qc-test-" ++ show tid
     P.writeFile f x
     y <- P.readFile f
-    removeFile f
+    _ <- withCString f c_unlink
     return (x == y)
 
 prop_read_write_file_C x = ioProperty $ do
@@ -1680,7 +1681,7 @@ prop_read_write_file_C x = ioProperty $ do
     let f = "qc-test-" ++ show tid
     C.writeFile f x
     y <- C.readFile f
-    removeFile f
+    _ <- withCString f c_unlink
     return (x == y)
 
 prop_read_write_file_L x = ioProperty $ do
@@ -1688,7 +1689,7 @@ prop_read_write_file_L x = ioProperty $ do
     let f = "qc-test-" ++ show tid
     L.writeFile f x
     y <- L.readFile f
-    L.length y `seq` removeFile f
+    _ <- L.length y `seq` withCString f c_unlink
     return (x == y)
 
 prop_read_write_file_D x = ioProperty $ do
@@ -1696,7 +1697,7 @@ prop_read_write_file_D x = ioProperty $ do
     let f = "qc-test-" ++ show tid
     D.writeFile f x
     y <- D.readFile f
-    D.length y `seq` removeFile f
+    _ <- D.length y `seq` withCString f c_unlink
     return (x == y)
 
 ------------------------------------------------------------------------
@@ -1707,7 +1708,7 @@ prop_append_file_P x y = ioProperty $ do
     P.writeFile f x
     P.appendFile f y
     z <- P.readFile f
-    removeFile f
+    _ <- withCString f c_unlink
     return (z == x `P.append` y)
 
 prop_append_file_C x y = ioProperty $ do
@@ -1716,7 +1717,7 @@ prop_append_file_C x y = ioProperty $ do
     C.writeFile f x
     C.appendFile f y
     z <- C.readFile f
-    removeFile f
+    _ <- withCString f c_unlink
     return (z == x `C.append` y)
 
 prop_append_file_L x y = ioProperty $ do
@@ -1725,7 +1726,7 @@ prop_append_file_L x y = ioProperty $ do
     L.writeFile f x
     L.appendFile f y
     z <- L.readFile f
-    L.length z `seq` removeFile f
+    _ <- L.length y `seq` withCString f c_unlink
     return (z == x `L.append` y)
 
 prop_append_file_D x y = ioProperty $ do
@@ -1734,7 +1735,7 @@ prop_append_file_D x y = ioProperty $ do
     D.writeFile f x
     D.appendFile f y
     z <- D.readFile f
-    D.length z `seq` removeFile f
+    _ <- D.length y `seq` withCString f c_unlink
     return (z == x `D.append` y)
 
 prop_packAddress = C.pack "this is a test"

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1669,73 +1669,73 @@ prop_fromForeignPtr x = (let (a,b,c) = (P.toForeignPtr x)
 -- IO
 
 prop_read_write_file_P x = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    P.writeFile f x
-    y <- P.readFile f
-    _ <- withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    P.writeFile fn x
+    y <- P.readFile fn
+    removeFile fn
     return (x == y)
 
 prop_read_write_file_C x = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    C.writeFile f x
-    y <- C.readFile f
-    _ <- withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    C.writeFile fn x
+    y <- C.readFile fn
+    removeFile fn
     return (x == y)
 
 prop_read_write_file_L x = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    L.writeFile f x
-    y <- L.readFile f
-    _ <- L.length y `seq` withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    L.writeFile fn x
+    y <- L.readFile fn
+    L.length y `seq` removeFile fn
     return (x == y)
 
 prop_read_write_file_D x = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    D.writeFile f x
-    y <- D.readFile f
-    _ <- D.length y `seq` withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    D.writeFile fn x
+    y <- D.readFile fn
+    D.length y `seq` removeFile fn
     return (x == y)
 
 ------------------------------------------------------------------------
 
 prop_append_file_P x y = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    P.writeFile f x
-    P.appendFile f y
-    z <- P.readFile f
-    _ <- withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    P.writeFile fn x
+    P.appendFile fn y
+    z <- P.readFile fn
+    removeFile fn
     return (z == x `P.append` y)
 
 prop_append_file_C x y = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    C.writeFile f x
-    C.appendFile f y
-    z <- C.readFile f
-    _ <- withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    C.writeFile fn x
+    C.appendFile fn y
+    z <- C.readFile fn
+    removeFile fn
     return (z == x `C.append` y)
 
 prop_append_file_L x y = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    L.writeFile f x
-    L.appendFile f y
-    z <- L.readFile f
-    _ <- L.length y `seq` withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    L.writeFile fn x
+    L.appendFile fn y
+    z <- L.readFile fn
+    L.length y `seq` removeFile fn
     return (z == x `L.append` y)
 
 prop_append_file_D x y = ioProperty $ do
-    tid <- myThreadId
-    let f = "qc-test-" ++ show tid
-    D.writeFile f x
-    D.appendFile f y
-    z <- D.readFile f
-    _ <- D.length y `seq` withCString f c_unlink
+    (fn, h) <- openTempFile "." "prop-compiled.tmp"
+    hClose h
+    D.writeFile fn x
+    D.appendFile fn y
+    z <- D.readFile fn
+    D.length y `seq` removeFile fn
     return (z == x `D.append` y)
 
 prop_packAddress = C.pack "this is a test"
@@ -2610,3 +2610,6 @@ findIndexEnd p = go . findIndices p
 
 elemIndexEnd :: Eq a => a -> [a] -> Maybe Int
 elemIndexEnd = findIndexEnd . (==)
+
+removeFile :: String -> IO ()
+removeFile fn = void $ withCString fn c_unlink

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -15,7 +15,7 @@
 module Data.ByteString.Builder.Tests (tests) where
 
 import           Control.Applicative
-import           Control.Monad (unless)
+import           Control.Monad (unless, void)
 import           Control.Monad.Trans.State (StateT, evalStateT, evalState, put, get)
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Writer (WriterT, execWriterT, tell)
@@ -110,7 +110,7 @@ testHandlePutBuilder =
             between = filter safeChr a2
             after   = filter safeChr a3
 #endif
-        (tempFile, tempH) <- openTempFile "." "TestBuilder"
+        (tempFile, tempH) <- openTempFile "." "test-builder.tmp"
         -- switch to UTF-8 encoding
         hSetEncoding tempH utf8
         hSetNewlineMode tempH noNewlineTranslation
@@ -125,7 +125,7 @@ testHandlePutBuilder =
         -- read file
         lbs <- L.readFile tempFile
         _ <- evaluate (L.length $ lbs)
-        _ <- withCString tempFile c_unlink
+        removeFile tempFile
         -- compare to pure builder implementation
         let lbsRef = toLazyByteString $ fold
               [stringUtf8 before, b, stringUtf8 between, b, stringUtf8 after]
@@ -160,7 +160,7 @@ testHandlePutBuilderChar8 =
         -- read file
         lbs <- L.readFile tempFile
         _ <- evaluate (L.length $ lbs)
-        _ <- withCString tempFile c_unlink
+        removeFile tempFile
         -- compare to pure builder implementation
         let lbsRef = toLazyByteString $ fold
               [string8 before, b, string8 between, b, string8 after]
@@ -175,6 +175,8 @@ testHandlePutBuilderChar8 =
         unless success (error msg)
         return success
 
+removeFile :: String -> IO ()
+removeFile fn = void $ withCString fn c_unlink
 
 -- Recipes with which to test the builder functions
 ---------------------------------------------------

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -35,7 +35,7 @@ test-suite prop-compiled
                     Data.ByteString.Short.Internal
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
-  build-depends:    base, ghc-prim, deepseq, random, directory,
+  build-depends:    base, ghc-prim, deepseq, random,
                     test-framework, test-framework-quickcheck2,
                     QuickCheck >= 2.10 && < 2.15
   c-sources:        ../cbits/fpstring.c
@@ -55,7 +55,7 @@ test-suite lazy-hclose
                     Data.ByteString.Lazy.Internal
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
-  build-depends:    base, ghc-prim, deepseq, random, directory,
+  build-depends:    base, ghc-prim, deepseq, random,
                     test-framework, test-framework-quickcheck2,
                     QuickCheck >= 2.10 && < 2.15
   c-sources:        ../cbits/fpstring.c
@@ -71,7 +71,7 @@ executable regressions
                     Data.ByteString.Lazy.Internal
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
-  build-depends:    base, ghc-prim, deepseq, random, directory,
+  build-depends:    base, ghc-prim, deepseq, random,
                     test-framework, test-framework-hunit, HUnit
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
@@ -110,7 +110,6 @@ test-suite test-builder
                     QuickCheck                 >= 2.10 && < 2.15,
                     byteorder                  == 1.0.*,
                     dlist                      >= 0.5 && < 0.9,
-                    directory,
                     transformers               >= 0.3,
                     HUnit,
                     test-framework,


### PR DESCRIPTION
This is a necessary prerequisite for #316: if we want to move tests to the `bytestring` package itself, test components should avoid packages, which depend on `bytestring`. Except replacing `test-framework` with something having smaller dependency footprint (there is a good progress on this), the only remaining offender is `directory`, which depends on `bytestring` transitively via `unix` and `Win32` packages.

This PR unties `bytestring-tests` from `directory`:

* `removeFile` can be replaced with a POSIX `c_unlink`.

* Not sure what exactly `renameFile` was meant to test in `LazyHClose.hs` (this file was not run for ages, and only recently salvaged and integrated in the test suite). If the purpose was to ensure, that a file is properly closed, opening it for write should be enough (and better).

* I had to sacrifice `getTemporaryDirectory` call in builder tests. Given that all other test components do not bother with it and create files in the current folder, it seems to be an acceptable tradeoff.