### PR TITLE
Clean up hlint suggestions

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,21 @@
+- ignore:
+    name: Use camelCase
+    within:
+      - Data.ByteString.Builder.Internal
+      - Data.ByteString.Builder.Prim.Internal.UncheckedShifts
+      - Data.ByteString.Short.Internal
+- ignore:
+    name: Use fewer imports
+    within:
+      - Data.ByteString
+      - Data.ByteString.Internal
+      - Data.ByteString.Short.Internal
+- ignore:
+    name: Avoid lambda
+    within:
+      - Data.ByteString.Builder.Internal
+      - Data.ByteString.Builder.Prim
+- ignore:
+    name: Redundant lambda
+    within:
+      - Data.ByteString.Builder.Internal

--- a/Data/ByteString/Builder.hs
+++ b/Data/ByteString/Builder.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, BangPatterns, MagicHash #-}
+{-# LANGUAGE CPP, MagicHash #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports -fno-warn-orphans #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
@@ -58,8 +58,8 @@ We use the following imports and abbreviate 'mappend' to simplify reading.
 import qualified "Data.ByteString.Lazy"               as L
 import           "Data.ByteString.Builder"
 import           Data.Monoid
-import           Data.Foldable                        ('foldMap')
-import           Data.List                            ('intersperse')
+import           Data.Foldable                        ('Data.Foldable.foldMap')
+import           Data.List                            ('Data.List.intersperse')
 
 infixr 4 \<\>
 (\<\>) :: 'Monoid' m => m -> m -> m
@@ -154,7 +154,7 @@ For example,
 >renderRow :: Row -> Builder
 >renderRow  = mconcat . intersperse (charUtf8 ',') . map renderCell
 
-Similarly, using /O(n)/ concatentations like '++' or the equivalent 'S.concat'
+Similarly, using /O(n)/ concatentations like '++' or the equivalent 'Data.ByteString.concat'
   operations on strict and lazy 'L.ByteString's should be avoided.
 The following definition of @renderString@ is also about 20% slower.
 
@@ -265,15 +265,6 @@ import           System.IO (Handle)
 import           Foreign
 import           GHC.Base (unpackCString#, unpackCStringUtf8#,
                            unpackFoldrCString#, build)
-
--- HADDOCK only imports
-import qualified Data.ByteString               as S (concat)
-#if !(MIN_VERSION_base(4,8,0))
-import           Data.Monoid (Monoid(..))
-#endif
-import           Data.Foldable                      (foldMap)
-import           Data.List                          (intersperse)
-
 
 -- | Execute a 'Builder' and return the generated chunks as a lazy 'L.ByteString'.
 -- The work is performed lazy, i.e., only when a chunk of the lazy 'L.ByteString'

--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -18,7 +18,7 @@ module Data.ByteString.Builder.ASCII
       -- | Formatting of numbers as ASCII text.
       --
       -- Note that you can also use these functions for the ISO/IEC 8859-1 and
-      -- UTF-8 encodings, as the ASCII encoding is equivalent on the 
+      -- UTF-8 encodings, as the ASCII encoding is equivalent on the
       -- codepoints 0-127.
 
       -- *** Decimal numbers
@@ -336,7 +336,7 @@ integerDec :: Integer -> Builder
 integerDec (IS i#) = intDec (I# i#)
 integerDec i
     | i < 0     = P.primFixed P.char8 '-' `mappend` go (-i)
-    | otherwise =                                   go ( i)
+    | otherwise =                                   go i
   where
     errImpossible fun =
         error $ "integerDec: " ++ fun ++ ": the impossible happened."

--- a/Data/ByteString/Builder/Prim/ASCII.hs
+++ b/Data/ByteString/Builder/Prim/ASCII.hs
@@ -287,5 +287,3 @@ floatHexFixed = encodeFloatViaWord32F word32HexFixed
 {-# INLINE doubleHexFixed #-}
 doubleHexFixed :: FixedPrim Double
 doubleHexFixed = encodeDoubleViaWord64F word64HexFixed
-
-

--- a/Data/ByteString/Builder/Prim/Binary.hs
+++ b/Data/ByteString/Builder/Prim/Binary.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, BangPatterns #-}
+{-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -88,7 +88,7 @@ word16BE = word16Host
 #else
 word16BE = fixedPrim 2 $ \w p -> do
     poke p               (fromIntegral (shiftr_w16 w 8) :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral (w)              :: Word8)
+    poke (p `plusPtr` 1) (fromIntegral w                :: Word8)
 #endif
 
 -- | Encoding 'Word16's in little endian format.
@@ -96,7 +96,7 @@ word16BE = fixedPrim 2 $ \w p -> do
 word16LE :: FixedPrim Word16
 #ifdef WORDS_BIGENDIAN
 word16LE = fixedPrim 2 $ \w p -> do
-    poke p               (fromIntegral (w)              :: Word8)
+    poke p               (fromIntegral w                :: Word8)
     poke (p `plusPtr` 1) (fromIntegral (shiftr_w16 w 8) :: Word8)
 #else
 word16LE = word16Host
@@ -112,7 +112,7 @@ word32BE = fixedPrim 4 $ \w p -> do
     poke p               (fromIntegral (shiftr_w32 w 24) :: Word8)
     poke (p `plusPtr` 1) (fromIntegral (shiftr_w32 w 16) :: Word8)
     poke (p `plusPtr` 2) (fromIntegral (shiftr_w32 w  8) :: Word8)
-    poke (p `plusPtr` 3) (fromIntegral (w)               :: Word8)
+    poke (p `plusPtr` 3) (fromIntegral w                 :: Word8)
 #endif
 
 -- | Encoding 'Word32's in little endian format.
@@ -120,7 +120,7 @@ word32BE = fixedPrim 4 $ \w p -> do
 word32LE :: FixedPrim Word32
 #ifdef WORDS_BIGENDIAN
 word32LE = fixedPrim 4 $ \w p -> do
-    poke p               (fromIntegral (w)               :: Word8)
+    poke p               (fromIntegral w                 :: Word8)
     poke (p `plusPtr` 1) (fromIntegral (shiftr_w32 w  8) :: Word8)
     poke (p `plusPtr` 2) (fromIntegral (shiftr_w32 w 16) :: Word8)
     poke (p `plusPtr` 3) (fromIntegral (shiftr_w32 w 24) :: Word8)
@@ -149,11 +149,11 @@ word64BE =
         poke p               (fromIntegral (shiftr_w32 a 24) :: Word8)
         poke (p `plusPtr` 1) (fromIntegral (shiftr_w32 a 16) :: Word8)
         poke (p `plusPtr` 2) (fromIntegral (shiftr_w32 a  8) :: Word8)
-        poke (p `plusPtr` 3) (fromIntegral (a)               :: Word8)
+        poke (p `plusPtr` 3) (fromIntegral a                 :: Word8)
         poke (p `plusPtr` 4) (fromIntegral (shiftr_w32 b 24) :: Word8)
         poke (p `plusPtr` 5) (fromIntegral (shiftr_w32 b 16) :: Word8)
         poke (p `plusPtr` 6) (fromIntegral (shiftr_w32 b  8) :: Word8)
-        poke (p `plusPtr` 7) (fromIntegral (b)               :: Word8)
+        poke (p `plusPtr` 7) (fromIntegral b                 :: Word8)
 #else
 word64BE = fixedPrim 8 $ \w p -> do
     poke p               (fromIntegral (shiftr_w64 w 56) :: Word8)
@@ -163,7 +163,7 @@ word64BE = fixedPrim 8 $ \w p -> do
     poke (p `plusPtr` 4) (fromIntegral (shiftr_w64 w 24) :: Word8)
     poke (p `plusPtr` 5) (fromIntegral (shiftr_w64 w 16) :: Word8)
     poke (p `plusPtr` 6) (fromIntegral (shiftr_w64 w  8) :: Word8)
-    poke (p `plusPtr` 7) (fromIntegral (w)               :: Word8)
+    poke (p `plusPtr` 7) (fromIntegral w                 :: Word8)
 #endif
 #endif
 
@@ -176,17 +176,17 @@ word64LE =
     fixedPrim 8 $ \w p -> do
         let b = fromIntegral (shiftr_w64 w 32) :: Word32
             a = fromIntegral w                 :: Word32
-        poke (p)             (fromIntegral (a)               :: Word8)
+        poke (p)             (fromIntegral a                 :: Word8)
         poke (p `plusPtr` 1) (fromIntegral (shiftr_w32 a  8) :: Word8)
         poke (p `plusPtr` 2) (fromIntegral (shiftr_w32 a 16) :: Word8)
         poke (p `plusPtr` 3) (fromIntegral (shiftr_w32 a 24) :: Word8)
-        poke (p `plusPtr` 4) (fromIntegral (b)               :: Word8)
+        poke (p `plusPtr` 4) (fromIntegral b                 :: Word8)
         poke (p `plusPtr` 5) (fromIntegral (shiftr_w32 b  8) :: Word8)
         poke (p `plusPtr` 6) (fromIntegral (shiftr_w32 b 16) :: Word8)
         poke (p `plusPtr` 7) (fromIntegral (shiftr_w32 b 24) :: Word8)
 #else
 word64LE = fixedPrim 8 $ \w p -> do
-    poke p               (fromIntegral (w)               :: Word8)
+    poke p               (fromIntegral w                 :: Word8)
     poke (p `plusPtr` 1) (fromIntegral (shiftr_w64 w  8) :: Word8)
     poke (p `plusPtr` 2) (fromIntegral (shiftr_w64 w 16) :: Word8)
     poke (p `plusPtr` 3) (fromIntegral (shiftr_w64 w 24) :: Word8)
@@ -332,5 +332,3 @@ floatHost = storableToF
 {-# INLINE doubleHost #-}
 doubleHost :: FixedPrim Double
 doubleHost = storableToF
-
-

--- a/Data/ByteString/Builder/Prim/Internal/Floating.hs
+++ b/Data/ByteString/Builder/Prim/Internal/Floating.hs
@@ -38,7 +38,7 @@ FFI to store the Float/Double in the buffer and peek it out again from there.
 encodeFloatViaWord32F :: FixedPrim Word32 -> FixedPrim Float
 encodeFloatViaWord32F w32fe
   | size w32fe < sizeOf (undefined :: Float) =
-      error $ "encodeFloatViaWord32F: encoding not wide enough"
+      error "encodeFloatViaWord32F: encoding not wide enough"
   | otherwise = fixedPrim (size w32fe) $ \x op -> do
       poke (castPtr op) x
       x' <- peek (castPtr op)
@@ -51,7 +51,7 @@ encodeFloatViaWord32F w32fe
 encodeDoubleViaWord64F :: FixedPrim Word64 -> FixedPrim Double
 encodeDoubleViaWord64F w64fe
   | size w64fe < sizeOf (undefined :: Float) =
-      error $ "encodeDoubleViaWord64F: encoding not wide enough"
+      error "encodeDoubleViaWord64F: encoding not wide enough"
   | otherwise = fixedPrim (size w64fe) $ \x op -> do
       poke (castPtr op) x
       x' <- peek (castPtr op)

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface, BangPatterns #-}
 {-# LANGUAGE UnliftedFFITypes, MagicHash,
             UnboxedTuples, DeriveDataTypeable #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
@@ -101,6 +102,8 @@ module Data.ByteString.Internal (
 import Prelude hiding (concat, null)
 import qualified Data.List as List
 
+import Control.Monad            (void)
+
 import Foreign.ForeignPtr       (ForeignPtr, withForeignPtr)
 import Foreign.Ptr              (Ptr, FunPtr, plusPtr, minusPtr)
 import Foreign.Storable         (Storable(..))
@@ -134,7 +137,7 @@ import Control.Exception        (assert)
 
 import Data.Bits                ((.&.))
 import Data.Char                (ord)
-import Data.Word                (Word8, Word)
+import Data.Word
 
 import Data.Typeable            (Typeable)
 import Data.Data                (Data(..), mkNoRepType)
@@ -153,11 +156,7 @@ import GHC.Base                 (unpackCString#)
 
 import GHC.Prim                 (Addr#)
 
-#if __GLASGOW_HASKELL__ >= 611
 import GHC.IO                   (IO(IO),unsafeDupablePerformIO)
-#else
-import GHC.IOBase               (IO(IO),RawBuffer,unsafeDupablePerformIO)
-#endif
 
 import GHC.ForeignPtr           (ForeignPtr(ForeignPtr)
 #if __GLASGOW_HASKELL__ < 900
@@ -233,7 +232,7 @@ data ByteString = BS {-# UNPACK #-} !(ForeignPtr Word8) -- payload
 -- as the base will be manipulated by 'plusForeignPtr' instead.
 --
 pattern PS :: ForeignPtr Word8 -> Int -> Int -> ByteString
-pattern PS fp zero len <- BS fp (((,) 0) -> (zero, len)) where
+pattern PS fp zero len <- BS fp ((0,) -> (zero, len)) where
   PS fp o len = BS (plusForeignPtr fp o) len
 {-# COMPLETE PS #-}
 #endif
@@ -472,7 +471,7 @@ fromForeignPtr :: ForeignPtr Word8
                -> Int -- ^ Offset
                -> Int -- ^ Length
                -> ByteString
-fromForeignPtr fp o len = BS (plusForeignPtr fp o) len
+fromForeignPtr fp o = BS (plusForeignPtr fp o)
 {-# INLINE fromForeignPtr #-}
 
 fromForeignPtr0 :: ForeignPtr Word8
@@ -666,13 +665,13 @@ times n (BS fp len)
   | len == 1 = unsafeCreate size $ \destptr ->
     withForeignPtr fp $ \p -> do
       byte <- peek p
-      memset destptr byte (fromIntegral size) >> return ()
+      void $ memset destptr byte (fromIntegral size)
   | otherwise = unsafeCreate size $ \destptr ->
     withForeignPtr fp $ \p -> do
       memcpy destptr p len
       fillFrom destptr len
   where
-    size = len * (fromIntegral n)
+    size = len * fromIntegral n
 
     fillFrom :: Ptr Word8 -> Int -> IO ()
     fillFrom destptr copied
@@ -786,7 +785,7 @@ foreign import ccall unsafe "string.h memchr" c_memchr
     :: Ptr Word8 -> CInt -> CSize -> IO (Ptr Word8)
 
 memchr :: Ptr Word8 -> Word8 -> CSize -> IO (Ptr Word8)
-memchr p w s = c_memchr p (fromIntegral w) s
+memchr p w = c_memchr p (fromIntegral w)
 
 foreign import ccall unsafe "string.h memcmp" c_memcmp
     :: Ptr Word8 -> Ptr Word8 -> CSize -> IO CInt
@@ -798,7 +797,7 @@ foreign import ccall unsafe "string.h memcpy" c_memcpy
     :: Ptr Word8 -> Ptr Word8 -> CSize -> IO (Ptr Word8)
 
 memcpy :: Ptr Word8 -> Ptr Word8 -> Int -> IO ()
-memcpy p q s = c_memcpy p q (fromIntegral s) >> return ()
+memcpy p q s = void $ c_memcpy p q (fromIntegral s)
 
 {-
 foreign import ccall unsafe "string.h memmove" c_memmove
@@ -813,7 +812,7 @@ foreign import ccall unsafe "string.h memset" c_memset
     :: Ptr Word8 -> CInt -> CSize -> IO (Ptr Word8)
 
 memset :: Ptr Word8 -> Word8 -> CSize -> IO (Ptr Word8)
-memset p w s = c_memset p (fromIntegral w) s
+memset p w = c_memset p (fromIntegral w)
 
 -- ---------------------------------------------------------------------
 --

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -267,11 +267,11 @@ unpack = unpackBytes
 
 -- | /O(c)/ Convert a list of strict 'ByteString' into a lazy 'ByteString'
 fromChunks :: [P.ByteString] -> ByteString
-fromChunks cs = L.foldr chunk Empty cs
+fromChunks = L.foldr chunk Empty
 
 -- | /O(c)/ Convert a lazy 'ByteString' into a list of strict 'ByteString'
 toChunks :: ByteString -> [P.ByteString]
-toChunks cs = foldrChunks (:) [] cs
+toChunks = foldrChunks (:) []
 
 ------------------------------------------------------------------------
 
@@ -301,7 +301,7 @@ null _     = False
 
 -- | /O(c)/ 'length' returns the length of a ByteString as an 'Int64'
 length :: ByteString -> Int64
-length cs = foldlChunks (\n c -> n + fromIntegral (S.length c)) 0 cs
+length = foldlChunks (\n c -> n + fromIntegral (S.length c)) 0
 {-# INLINE [1] length #-}
 
 infixr 5 `cons`, `cons'` --same as list (:)
@@ -310,7 +310,7 @@ infixl 5 `snoc`
 -- | /O(1)/ 'cons' is analogous to '(Prelude.:)' for lists.
 --
 cons :: Word8 -> ByteString -> ByteString
-cons c cs = Chunk (S.singleton c) cs
+cons c = Chunk (S.singleton c)
 {-# INLINE cons #-}
 
 -- | /O(1)/ Unlike 'cons', 'cons'' is
@@ -396,7 +396,7 @@ append = mappend
 -- | /O(n)/ 'map' @f xs@ is the ByteString obtained by applying @f@ to each
 -- element of @xs@.
 map :: (Word8 -> Word8) -> ByteString -> ByteString
-map f s = go s
+map f = go
     where
         go Empty        = Empty
         go (Chunk x xs) = Chunk y ys
@@ -407,7 +407,7 @@ map f s = go s
 
 -- | /O(n)/ 'reverse' @xs@ returns the elements of @xs@ in reverse order.
 reverse :: ByteString -> ByteString
-reverse cs0 = rev Empty cs0
+reverse = rev Empty
   where rev a Empty        = a
         rev a (Chunk c cs) = rev (Chunk (S.reverse c) a) cs
 {-# INLINE reverse #-}
@@ -439,14 +439,14 @@ transpose css = L.map (\ss -> Chunk (S.pack ss) Empty)
 -- the left-identity of the operator), and a ByteString, reduces the
 -- ByteString using the binary operator, from left to right.
 foldl :: (a -> Word8 -> a) -> a -> ByteString -> a
-foldl f z = go z
+foldl f = go
   where go a Empty        = a
         go a (Chunk c cs) = go (S.foldl f a c) cs
 {-# INLINE foldl #-}
 
 -- | 'foldl'' is like 'foldl', but strict in the accumulator.
 foldl' :: (a -> Word8 -> a) -> a -> ByteString -> a
-foldl' f z = go z
+foldl' f = go
   where go !a Empty        = a
         go !a (Chunk c cs) = go (S.foldl' f a c) cs
 {-# INLINE foldl' #-}
@@ -455,7 +455,7 @@ foldl' f z = go z
 -- (typically the right-identity of the operator), and a ByteString,
 -- reduces the ByteString using the binary operator, from right to left.
 foldr :: (Word8 -> a -> a) -> a -> ByteString -> a
-foldr k z = foldrChunks (flip (S.foldr k)) z
+foldr k = foldrChunks (flip (S.foldr k))
 {-# INLINE foldr #-}
 
 -- | 'foldl1' is a variant of 'foldl' that has no starting value
@@ -502,14 +502,14 @@ concatMap f (Chunk c0 cs0) = to c0 cs0
 -- | /O(n)/ Applied to a predicate and a ByteString, 'any' determines if
 -- any element of the 'ByteString' satisfies the predicate.
 any :: (Word8 -> Bool) -> ByteString -> Bool
-any f cs = foldrChunks (\c rest -> S.any f c || rest) False cs
+any f = foldrChunks (\c rest -> S.any f c || rest) False
 {-# INLINE any #-}
 -- todo fuse
 
 -- | /O(n)/ Applied to a predicate and a 'ByteString', 'all' determines
 -- if all elements of the 'ByteString' satisfy the predicate.
 all :: (Word8 -> Bool) -> ByteString -> Bool
-all f cs = foldrChunks (\c rest -> S.all f c && rest) True cs
+all f = foldrChunks (\c rest -> S.all f c && rest) True
 {-# INLINE all #-}
 -- todo fuse
 
@@ -527,15 +527,15 @@ minimum (Chunk c cs) = foldlChunks (\n c' -> n `min` S.minimum c')
                                      (S.minimum c) cs
 {-# INLINE minimum #-}
 
--- | /O(c)/ 'compareLength' compares the length of a 'ByteString' 
--- to an 'Int64'   
+-- | /O(c)/ 'compareLength' compares the length of a 'ByteString'
+-- to an 'Int64'
 compareLength :: ByteString -> Int64 -> Ordering
 compareLength _ toCmp | toCmp < 0 = GT
 compareLength Empty toCmp         = compare 0 toCmp
 compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - fromIntegral (S.length c))
 {-# INLINE compareLength #-}
 
-{-# RULES 
+{-# RULES
 "ByteString.Lazy length/compareN -> compareLength" [~1] forall t n.
   compare (length t) n = compareLength t n
 "ByteString.Lazy compareN/length -> compareLength" [~1] forall t n.
@@ -572,7 +572,7 @@ compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - fromIntegral (S.le
 -- passing an accumulating parameter from left to right, and returning a
 -- final value of this accumulator together with the new ByteString.
 mapAccumL :: (acc -> Word8 -> (acc, Word8)) -> acc -> ByteString -> (acc, ByteString)
-mapAccumL f s0 = go s0
+mapAccumL f = go
   where
     go s Empty        = (s, Empty)
     go s (Chunk c cs) = (s'', Chunk c' cs')
@@ -584,7 +584,7 @@ mapAccumL f s0 = go s0
 -- passing an accumulating parameter from right to left, and returning a
 -- final value of this accumulator together with the new ByteString.
 mapAccumR :: (acc -> Word8 -> (acc, Word8)) -> acc -> ByteString -> (acc, ByteString)
-mapAccumR f s0 = go s0
+mapAccumR f = go
   where
     go s Empty        = (s, Empty)
     go s (Chunk c cs) = (s'', Chunk c' cs')
@@ -665,7 +665,7 @@ cycle cs    = cs' where cs' = foldrChunks Chunk cs' cs
 -- prepending to the ByteString and @b@ is used as the next element in a
 -- recursive call.
 unfoldr :: (a -> Maybe (Word8, a)) -> a -> ByteString
-unfoldr f z = unfoldChunk 32 z
+unfoldr f = unfoldChunk 32
   where unfoldChunk n x =
           case S.unfoldrN n f x of
             (c, Nothing)
@@ -718,7 +718,7 @@ splitAt i cs0 = splitAt' i cs0
 -- returns the longest (possibly empty) prefix of elements
 -- satisfying the predicate.
 takeWhile :: (Word8 -> Bool) -> ByteString -> ByteString
-takeWhile f cs0 = takeWhile' cs0
+takeWhile f = takeWhile'
   where takeWhile' Empty        = Empty
         takeWhile' (Chunk c cs) =
           case findIndexOrEnd (not . f) c of
@@ -730,7 +730,7 @@ takeWhile f cs0 = takeWhile' cs0
 -- drops the longest (possibly empty) prefix of elements
 -- satisfying the predicate and returns the remainder.
 dropWhile :: (Word8 -> Bool) -> ByteString -> ByteString
-dropWhile f cs0 = dropWhile' cs0
+dropWhile f = dropWhile'
   where dropWhile' Empty        = Empty
         dropWhile' (Chunk c cs) =
           case findIndexOrEnd (not . f) c of
@@ -744,7 +744,7 @@ dropWhile f cs0 = dropWhile' cs0
 -- 'break' @p@ is equivalent to @'span' (not . p)@ and to @('takeWhile' (not . p) &&& 'dropWhile' (not . p))@.
 --
 break :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
-break f cs0 = break' cs0
+break f = break'
   where break' Empty        = (Empty, Empty)
         break' (Chunk c cs) =
           case findIndexOrEnd f c of
@@ -816,9 +816,9 @@ splitWith _ Empty          = []
 splitWith p (Chunk c0 cs0) = comb [] (S.splitWith p c0) cs0
 
   where comb :: [P.ByteString] -> [P.ByteString] -> ByteString -> [ByteString]
-        comb acc (s:[]) Empty        = revChunks (s:acc) : []
-        comb acc (s:[]) (Chunk c cs) = comb (s:acc) (S.splitWith p c) cs
-        comb acc (s:ss) cs           = revChunks (s:acc) : comb [] ss cs
+        comb acc [s] Empty        = [revChunks (s:acc)]
+        comb acc [s] (Chunk c cs) = comb (s:acc) (S.splitWith p c) cs
+        comb acc (s:ss) cs        = revChunks (s:acc) : comb [] ss cs
 {-# INLINE splitWith #-}
 
 -- | /O(n)/ Break a 'ByteString' into pieces separated by the byte
@@ -843,8 +843,8 @@ split _ Empty     = []
 split w (Chunk c0 cs0) = comb [] (S.split w c0) cs0
 
   where comb :: [P.ByteString] -> [P.ByteString] -> ByteString -> [ByteString]
-        comb acc (s:[]) Empty        = revChunks (s:acc) : []
-        comb acc (s:[]) (Chunk c cs) = comb (s:acc) (S.split w c) cs
+        comb acc [s] Empty        = [revChunks (s:acc)]
+        comb acc [s] (Chunk c cs) = comb (s:acc) (S.split w c) cs
         comb acc (s:ss) cs        = revChunks (s:acc) : comb [] ss cs
 {-# INLINE split #-}
 
@@ -865,7 +865,7 @@ group = go
       | S.length c == 1  = to [c] (S.unsafeHead c) cs
       | otherwise        = to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
 
-    to acc !_ Empty        = revNonEmptyChunks acc : []
+    to acc !_ Empty        = [revNonEmptyChunks acc]
     to acc !w (Chunk c cs) =
       case findIndexOrEnd (/= w) c of
         0                    -> revNonEmptyChunks acc
@@ -884,7 +884,7 @@ groupBy k = go
       | S.length c == 1  = to [c] (S.unsafeHead c) cs
       | otherwise        = to [S.unsafeTake 1 c] (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
 
-    to acc !_ Empty        = revNonEmptyChunks acc : []
+    to acc !_ Empty        = [revNonEmptyChunks acc]
     to acc !w (Chunk c cs) =
       case findIndexOrEnd (not . k w) c of
         0                    -> revNonEmptyChunks acc
@@ -940,7 +940,7 @@ indexMaybe cs0 i       = index' cs0 i
 -- element, or 'Nothing' if there is no such element.
 -- This implementation uses memchr(3).
 elemIndex :: Word8 -> ByteString -> Maybe Int64
-elemIndex w cs0 = elemIndex' 0 cs0
+elemIndex w = elemIndex' 0
   where elemIndex' _ Empty        = Nothing
         elemIndex' n (Chunk c cs) =
           case S.elemIndex w c of
@@ -964,7 +964,7 @@ elemIndexEnd = findIndexEnd . (==)
 -- the indices of all elements equal to the query element, in ascending order.
 -- This implementation uses memchr(3).
 elemIndices :: Word8 -> ByteString -> [Int64]
-elemIndices w cs0 = elemIndices' 0 cs0
+elemIndices w = elemIndices' 0
   where elemIndices' _ Empty        = []
         elemIndices' n (Chunk c cs) = L.map ((+n).fromIntegral) (S.elemIndices w c)
                              ++ elemIndices' (n + fromIntegral (S.length c)) cs
@@ -975,13 +975,13 @@ elemIndices w cs0 = elemIndices' 0 cs0
 --
 -- But more efficiently than using length on the intermediate list.
 count :: Word8 -> ByteString -> Int64
-count w cs = foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0 cs
+count w = foldlChunks (\n c -> n + fromIntegral (S.count w c)) 0
 
 -- | The 'findIndex' function takes a predicate and a 'ByteString' and
 -- returns the index of the first element in the ByteString
 -- satisfying the predicate.
 findIndex :: (Word8 -> Bool) -> ByteString -> Maybe Int64
-findIndex k cs0 = findIndex' 0 cs0
+findIndex k = findIndex' 0
   where findIndex' _ Empty        = Nothing
         findIndex' n (Chunk c cs) =
           case S.findIndex k c of
@@ -1000,7 +1000,7 @@ findIndexEnd k = findIndexEnd' 0
     findIndexEnd' _ Empty = Nothing
     findIndexEnd' n (Chunk c cs) =
       let !n' = n + S.length c
-          !i  = fmap (fromIntegral . (n +)) $ S.findIndexEnd k c
+          !i  = fromIntegral . (n +) <$> S.findIndexEnd k c
       in findIndexEnd' n' cs `mplus` i
 {-# INLINE findIndexEnd #-}
 
@@ -1011,7 +1011,7 @@ findIndexEnd k = findIndexEnd' 0
 -- > find f p = case findIndex f p of Just n -> Just (p ! n) ; _ -> Nothing
 --
 find :: (Word8 -> Bool) -> ByteString -> Maybe Word8
-find f cs0 = find' cs0
+find f = find'
   where find' Empty        = Nothing
         find' (Chunk c cs) = case S.find f c of
             Nothing -> find' cs
@@ -1021,7 +1021,7 @@ find f cs0 = find' cs0
 -- | The 'findIndices' function extends 'findIndex', by returning the
 -- indices of all elements satisfying the predicate, in ascending order.
 findIndices :: (Word8 -> Bool) -> ByteString -> [Int64]
-findIndices k cs0 = findIndices' 0 cs0
+findIndices k = findIndices' 0
   where findIndices' _ Empty        = []
         findIndices' n (Chunk c cs) = L.map ((+n).fromIntegral) (S.findIndices k c)
                              ++ findIndices' (n + fromIntegral (S.length c)) cs
@@ -1036,13 +1036,13 @@ elem w cs = case elemIndex w cs of Nothing -> False ; _ -> True
 
 -- | /O(n)/ 'notElem' is the inverse of 'elem'
 notElem :: Word8 -> ByteString -> Bool
-notElem w cs = not (elem w cs)
+notElem w cs = not (w `elem` cs)
 
 -- | /O(n)/ 'filter', applied to a predicate and a ByteString,
 -- returns a ByteString containing those characters that satisfy the
 -- predicate.
 filter :: (Word8 -> Bool) -> ByteString -> ByteString
-filter p s = go s
+filter p = go
     where
         go Empty        = Empty
         go (Chunk x xs) = chunk (S.filter p x) (go xs)
@@ -1203,7 +1203,7 @@ inits = (Empty :) . inits'
 
 -- | /O(n)/ Return all final segments of the given 'ByteString', longest first.
 tails :: ByteString -> [ByteString]
-tails Empty         = Empty : []
+tails Empty         = [Empty]
 tails cs@(Chunk c cs')
   | S.length c == 1 = cs : tails cs'
   | otherwise       = cs : tails (Chunk (S.unsafeTail c) cs')
@@ -1217,7 +1217,7 @@ tails cs@(Chunk c cs')
 --   if a large string has been read in, and only a small part of it
 --   is needed in the rest of the program.
 copy :: ByteString -> ByteString
-copy cs = foldrChunks (Chunk . S.copy) Empty cs
+copy = foldrChunks (Chunk . S.copy) Empty
 --TODO, we could coalese small blocks here
 --FIXME: probably not strict enough, if we're doing this to avoid retaining
 -- the parent blocks then we'd better copy strictly.
@@ -1250,8 +1250,7 @@ hGetContentsN k h = lazyRead -- TODO close on exceptions
         c <- S.hGetSome h k -- only blocks if there is no data available
         if S.null c
           then hClose h >> return Empty
-          else do cs <- lazyRead
-                  return (Chunk c cs)
+          else Chunk c <$> lazyRead
 
 -- | Read @n@ bytes into a 'ByteString', directly from the
 -- specified 'Handle', in chunks of size @k@.
@@ -1351,7 +1350,7 @@ getContents = hGetContents stdin
 -- writes, and hence 'hPut' alone might not be suitable for concurrent writes.
 --
 hPut :: Handle -> ByteString -> IO ()
-hPut h cs = foldrChunks (\c rest -> S.hPut h c >> rest) (return ()) cs
+hPut h = foldrChunks (\c rest -> S.hPut h c >> rest) (return ())
 
 -- | Similar to 'hPut' except that it will never block. Instead it returns
 -- any tail that did not get written. This tail may be 'empty' in the case that
@@ -1403,11 +1402,11 @@ moduleError fun msg = error ("Data.ByteString.Lazy." ++ fun ++ ':':' ':msg)
 
 -- reverse a list of non-empty chunks into a lazy ByteString
 revNonEmptyChunks :: [P.ByteString] -> ByteString
-revNonEmptyChunks cs = L.foldl' (flip Chunk) Empty cs
+revNonEmptyChunks = L.foldl' (flip Chunk) Empty
 
 -- reverse a list of possibly-empty chunks into a lazy ByteString
 revChunks :: [P.ByteString] -> ByteString
-revChunks cs = L.foldl' (flip chunk) Empty cs
+revChunks = L.foldl' (flip chunk) Empty
 
 -- | 'findIndexOrEnd' is a variant of findIndex, that returns the length
 -- of the string if no element is found, rather than Nothing.

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -203,7 +203,7 @@ foldrChunks f z = go
 -- | Consume the chunks of a lazy ByteString with a strict, tail-recursive,
 -- accumulating left fold.
 foldlChunks :: (a -> S.ByteString -> a) -> a -> ByteString -> a
-foldlChunks f z = go z
+foldlChunks f = go
   where go a _ | a `seq` False = undefined
         go a Empty        = a
         go a (Chunk c cs) = go (f a c) cs
@@ -269,7 +269,7 @@ append :: ByteString -> ByteString -> ByteString
 append xs ys = foldrChunks Chunk ys xs
 
 concat :: [ByteString] -> ByteString
-concat css0 = to css0
+concat = to
   where
     go Empty        css = to css
     go (Chunk c cs) css = Chunk c (go cs css)
@@ -329,7 +329,7 @@ toStrict = \cs -> goLen0 cs cs
     -- Copy the data
     goCopy Empty                    !_   = return ()
     goCopy (Chunk (S.BS _  0  ) cs) !ptr = goCopy cs ptr
-    goCopy (Chunk (S.BS fp len) cs) !ptr = do
+    goCopy (Chunk (S.BS fp len) cs) !ptr =
       withForeignPtr fp $ \p -> do
         S.memcpy ptr p len
         goCopy cs (ptr `plusPtr` len)

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -360,7 +360,7 @@ unpackBytes bs = unpackAppendBytesLazy bs []
 -- (5 words per list element, 8 bytes per word, 100 elements = 4000 bytes)
 
 unpackAppendCharsLazy :: ShortByteString -> [Char] -> [Char]
-unpackAppendCharsLazy sbs cs0 = go 0 (length sbs) cs0
+unpackAppendCharsLazy sbs = go 0 (length sbs)
   where
     sz = 100
 
@@ -370,7 +370,7 @@ unpackAppendCharsLazy sbs cs0 = go 0 (length sbs) cs0
                       where remainder = go (off+sz) (len-sz) cs
 
 unpackAppendBytesLazy :: ShortByteString -> [Word8] -> [Word8]
-unpackAppendBytesLazy sbs ws0 = go 0 (length sbs) ws0
+unpackAppendBytesLazy sbs = go 0 (length sbs)
   where
     sz = 100
 
@@ -385,7 +385,7 @@ unpackAppendBytesLazy sbs ws0 = go 0 (length sbs) ws0
 -- buffer and loops down until we hit the sentinal:
 
 unpackAppendCharsStrict :: ShortByteString -> Int -> Int -> [Char] -> [Char]
-unpackAppendCharsStrict !sbs off len cs = go (off-1) (off-1 + len) cs
+unpackAppendCharsStrict !sbs off len = go (off-1) (off-1 + len)
   where
     go !sentinal !i !acc
       | i == sentinal = acc
@@ -393,7 +393,7 @@ unpackAppendCharsStrict !sbs off len cs = go (off-1) (off-1 + len) cs
                         in go sentinal (i-1) (c:acc)
 
 unpackAppendBytesStrict :: ShortByteString -> Int -> Int -> [Word8] -> [Word8]
-unpackAppendBytesStrict !sbs off len ws = go (off-1) (off-1 + len) ws
+unpackAppendBytesStrict !sbs off len = go (off-1) (off-1 + len)
   where
     go !sentinal !i !acc
       | i == sentinal = acc
@@ -568,13 +568,13 @@ copyByteArrayToAddr# = GHC.Exts.copyByteArrayToAddr#
 
 #else
 
-copyAddrToByteArray# src dst dst_off len s =
-  unIO_ (memcpy_AddrToByteArray dst (csize dst_off) src 0 (csize len)) s
+copyAddrToByteArray# src dst dst_off len =
+  unIO_ (memcpy_AddrToByteArray dst (csize dst_off) src 0 (csize len))
 
 copyAddrToByteArray0 :: Addr# -> MutableByteArray# s -> Int#
                      -> State# RealWorld -> State# RealWorld
-copyAddrToByteArray0 src dst len s =
-  unIO_ (memcpy_AddrToByteArray0 dst src (csize len)) s
+copyAddrToByteArray0 src dst len =
+  unIO_ (memcpy_AddrToByteArray0 dst src (csize len))
 
 {-# INLINE [0] copyAddrToByteArray# #-}
 {-# RULES "copyAddrToByteArray# dst_off=0"
@@ -589,13 +589,13 @@ foreign import ccall unsafe "string.h memcpy"
   memcpy_AddrToByteArray0 :: MutableByteArray# s -> Addr# -> CSize -> IO ()
 
 
-copyByteArrayToAddr# src src_off dst len s =
-  unIO_ (memcpy_ByteArrayToAddr dst 0 src (csize src_off) (csize len)) s
+copyByteArrayToAddr# src src_off dst len =
+  unIO_ (memcpy_ByteArrayToAddr dst 0 src (csize src_off) (csize len))
 
 copyByteArrayToAddr0 :: ByteArray# -> Addr# -> Int#
                      -> State# RealWorld -> State# RealWorld
-copyByteArrayToAddr0 src dst len s =
-  unIO_ (memcpy_ByteArrayToAddr0 dst src (csize len)) s
+copyByteArrayToAddr0 src dst len =
+  unIO_ (memcpy_ByteArrayToAddr0 dst src (csize len))
 
 {-# INLINE [0] copyByteArrayToAddr# #-}
 {-# RULES "copyByteArrayToAddr# src_off=0"


### PR DESCRIPTION
`haskell-language-server-0.6` enabled hlint plugin by default, so hlint suggestions became annoying. Most of them are good stuff, so I think it makes sense to get them fixed instead of muting.  