### PR TITLE
Drop outdated comment

### DIFF
--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -758,30 +758,6 @@ lines (Chunk c0 cs0) = loop0 c0 cs0
                 let c' = revChunks (B.unsafeTake n c : line)
                  in c' `seq` (c' : loop0 (B.unsafeDrop (n+1) c) cs)
 
-{-
-
-This function is too strict!  Consider,
-
-> prop_lazy =
-    (L.unpack . head . lazylines $ L.append (L.pack "a\nb\n") (error "failed"))
-  ==
-    "a"
-
-fails.  Here's a properly lazy version of 'lines' for lazy bytestrings
-
-    lazylines           :: L.ByteString -> [L.ByteString]
-    lazylines s
-        | L.null s  = []
-        | otherwise =
-            let (l,s') = L.break ((==) '\n') s
-            in l : if L.null s' then []
-                                else lazylines (L.tail s')
-
-we need a similarly lazy, but efficient version.
-
--}
-
-
 -- | 'unlines' is an inverse operation to 'lines'.  It joins lines,
 -- after appending a terminating newline to each.
 unlines :: [ByteString] -> ByteString

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1184,6 +1184,11 @@ prop_unlinesBB (String8 xs) =
 prop_unlinesLC (String8 xs) =
     (unlines.lines) xs == (LC.unpack. LC.unlines .  LC.lines .LC.pack) xs
 
+prop_lines_lazy1 =
+    head (LC.lines (LC.append (LC.pack "a\nb\n") undefined)) == LC.pack "a"
+prop_lines_lazy2 =
+    head (tail (LC.lines (LC.append (LC.pack "a\nb\n") undefined))) == LC.pack "b"
+
 prop_wordsBB (String8 xs) =
     (words xs) == ((map C.unpack) . C.words . C.pack) xs
 -- prop_wordstokensBB xs = C.words xs == C.tokens isSpace xs
@@ -2334,6 +2339,8 @@ bb_tests =
     , testProperty "lines"          prop_linesBB
     , testProperty "unlines"        prop_unlinesBB
     , testProperty "unlines"        prop_unlinesLC
+    , testProperty "lines_lazy1"    prop_lines_lazy1
+    , testProperty "lines_lazy2"    prop_lines_lazy2
     , testProperty "words"          prop_wordsBB
     , testProperty "words"          prop_wordsLC
     , testProperty "unwords"        prop_unwordsBB


### PR DESCRIPTION
The Lazy `lines` function has not been `too` strict for some
time now.  The issue was resolved a day or so after the comment
was added, but the comment was inadvertently left behind.