### PR TITLE
Changes for GHC 9.0

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -278,6 +278,7 @@ import GHC.IO                   (unsafePerformIO, unsafeDupablePerformIO)
 import Data.Char                (ord)
 import Foreign.Marshal.Utils    (copyBytes)
 
+import GHC.Prim                 (Word8#)
 import GHC.Base                 (build)
 import GHC.Word hiding (Word8)
 

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -882,7 +882,7 @@ unsafeHead  = w2c . B.unsafeHead
 -- > break isSpace == breakSpace
 --
 breakSpace :: ByteString -> (ByteString,ByteString)
-breakSpace (BS x l) = accursedUnutterablePerformIO $ withForeignPtr x $ \p -> do
+breakSpace (BS x l) = accursedUnutterablePerformIO $ unsafeWithForeignPtr x $ \p -> do
     i <- firstspace p 0 l
     return $! case () of {_
         | i == 0    -> (empty, BS x l)
@@ -905,7 +905,7 @@ firstspace !ptr !n !m
 --
 -- @since 0.10.12.0
 dropSpace :: ByteString -> ByteString
-dropSpace (BS x l) = accursedUnutterablePerformIO $ withForeignPtr x $ \p -> do
+dropSpace (BS x l) = accursedUnutterablePerformIO $ unsafeWithForeignPtr x $ \p -> do
     i <- firstnonspace p 0 l
     return $! if i == l then empty else BS (plusForeignPtr x i) (l-i)
 {-# INLINE dropSpace #-}
@@ -931,7 +931,7 @@ strip = dropWhile isSpace . dropWhileEnd isSpace
 -- but it is more efficient than using multiple reverses.
 --
 dropSpaceEnd :: ByteString -> ByteString
-dropSpaceEnd (BS x l) = accursedUnutterablePerformIO $ withForeignPtr x $ \p -> do
+dropSpaceEnd (BS x l) = accursedUnutterablePerformIO $ unsafeWithForeignPtr x $ \p -> do
     i <- lastnonspace p (l-1)
     return $! if i == (-1) then empty else BS x (i+1)
 {-# INLINE dropSpaceEnd #-}
@@ -964,7 +964,7 @@ lines (BS x l) = go x l
     nl = c2w '\n'
     -- It is important to remain lazy in the tail of the list.  The caller
     -- might only want the first few lines.
-    go !f !len = accursedUnutterablePerformIO $ withForeignPtr f $ \p -> do
+    go !f !len = accursedUnutterablePerformIO $ unsafeWithForeignPtr f $ \p -> do
         q <- memchr p nl $! fromIntegral len
         if q == nullPtr
             then return [BS f len]
@@ -1028,7 +1028,7 @@ readInt bs = case B.uncons bs of
     -- Here we just deal with the digits.
     {-# INLINE readDec #-}
     readDec !positive (B.BS fp len) = B.accursedUnutterablePerformIO $
-        withForeignPtr fp $ \ptr -> do
+        unsafeWithForeignPtr fp $ \ptr -> do
             let end = ptr `plusPtr` len
             (!n, !a, !inRange) <- if positive
                 then digits intmaxQuot10 intmaxRem10 end ptr 0 0

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -182,6 +182,10 @@ import GHC.Ptr                  (Ptr(..), castPtr)
 import GHC.Types                (Int (..))
 #endif
 
+#if MIN_VERSION_base(4,15,0)
+import GHC.ForeignPtr           (unsafeWithForeignPtr)
+#endif
+
 #if !MIN_VERSION_base(4,15,0)
 unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
 unsafeWithForeignPtr = withForeignPtr

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -91,6 +91,7 @@ module Data.ByteString.Internal (
 
         -- * Exported compatibility shim
         plusForeignPtr,
+        unsafeWithForeignPtr,
 
         -- * Internal constants
         intmaxQuot10,
@@ -179,6 +180,11 @@ import GHC.Ptr                  (Ptr(..), castPtr)
 
 #if (__GLASGOW_HASKELL__ < 802) || (__GLASGOW_HASKELL__ >= 811)
 import GHC.Types                (Int (..))
+#endif
+
+#if !MIN_VERSION_base(4,15,0)
+unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
+unsafeWithForeignPtr = withForeignPtr
 #endif
 
 -- CFILES stuff is Hugs only
@@ -430,7 +436,7 @@ unpackAppendCharsLazy (BS fp len) cs
 
 unpackAppendBytesStrict :: ByteString -> [Word8] -> [Word8]
 unpackAppendBytesStrict (BS fp len) xs =
-    accursedUnutterablePerformIO $ withForeignPtr fp $ \base ->
+    accursedUnutterablePerformIO $ unsafeWithForeignPtr fp $ \base ->
       loop (base `plusPtr` (-1)) (base `plusPtr` (-1+len)) xs
   where
     loop !sentinal !p acc
@@ -440,7 +446,7 @@ unpackAppendBytesStrict (BS fp len) xs =
 
 unpackAppendCharsStrict :: ByteString -> [Char] -> [Char]
 unpackAppendCharsStrict (BS fp len) xs =
-    accursedUnutterablePerformIO $ withForeignPtr fp $ \base ->
+    accursedUnutterablePerformIO $ unsafeWithForeignPtr fp $ \base ->
       loop (base `plusPtr` (-1)) (base `plusPtr` (-1+len)) xs
   where
     loop !sentinal !p acc
@@ -588,8 +594,8 @@ compareBytes :: ByteString -> ByteString -> Ordering
 compareBytes (BS _   0)    (BS _   0)    = EQ  -- short cut for empty strings
 compareBytes (BS fp1 len1) (BS fp2 len2) =
     accursedUnutterablePerformIO $
-      withForeignPtr fp1 $ \p1 ->
-      withForeignPtr fp2 $ \p2 -> do
+      unsafeWithForeignPtr fp1 $ \p1 ->
+      unsafeWithForeignPtr fp2 $ \p2 -> do
         i <- memcmp p1 p2 (min len1 len2)
         return $! case i `compare` 0 of
                     EQ  -> len1 `compare` len2
@@ -601,8 +607,8 @@ append a             (BS _   0)    = a
 append (BS fp1 len1) (BS fp2 len2) =
     unsafeCreate (len1+len2) $ \destptr1 -> do
       let destptr2 = destptr1 `plusPtr` len1
-      withForeignPtr fp1 $ \p1 -> memcpy destptr1 p1 len1
-      withForeignPtr fp2 $ \p2 -> memcpy destptr2 p2 len2
+      unsafeWithForeignPtr fp1 $ \p1 -> memcpy destptr1 p1 len1
+      unsafeWithForeignPtr fp2 $ \p2 -> memcpy destptr2 p2 len2
 
 concat :: [ByteString] -> ByteString
 concat = \bss0 -> goLen0 bss0 bss0
@@ -644,7 +650,7 @@ concat = \bss0 -> goLen0 bss0 bss0
     goCopy []                  !_   = return ()
     goCopy (BS _  0  :bss) !ptr = goCopy bss ptr
     goCopy (BS fp len:bss) !ptr = do
-      withForeignPtr fp $ \p -> memcpy ptr p len
+      unsafeWithForeignPtr fp $ \p -> memcpy ptr p len
       goCopy bss (ptr `plusPtr` len)
 {-# NOINLINE concat #-}
 
@@ -663,11 +669,11 @@ times n (BS fp len)
   | n == 1 = BS fp len
   | len == 0 = mempty
   | len == 1 = unsafeCreate size $ \destptr ->
-    withForeignPtr fp $ \p -> do
+    unsafeWithForeignPtr fp $ \p -> do
       byte <- peek p
       void $ memset destptr byte (fromIntegral size)
   | otherwise = unsafeCreate size $ \destptr ->
-    withForeignPtr fp $ \p -> do
+    unsafeWithForeignPtr fp $ \p -> do
       memcpy destptr p len
       fillFrom destptr len
   where

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -421,7 +421,7 @@ intersperse w (Chunk c cs) = Chunk (S.intersperse w c)
                                    (foldrChunks (Chunk . intersperse') Empty cs)
   where intersperse' :: P.ByteString -> P.ByteString
         intersperse' (S.BS fp l) =
-          S.unsafeCreate (2*l) $ \p' -> withForeignPtr fp $ \p -> do
+          S.unsafeCreate (2*l) $ \p' -> S.unsafeWithForeignPtr fp $ \p -> do
             poke p' w
             S.c_intersperse (p' `plusPtr` 1) p (fromIntegral l) w
 

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -111,15 +111,6 @@ import Prelude ( Eq(..), Ord(..), Ordering(..), Read(..), Show(..)
                , return
                , Maybe(..) )
 
-#if MIN_VERSION_base(4,15,0)
-import GHC.Exts ( extendWord8#, narrowWord8# )
-#else
-import GHC.Prim (Word#)
-extendWord8#, narrowWord8# :: Word# -> Word#
-extendWord8#  w = w
-narrowWord8#  w = w
-#endif
-
 -- | A compact representation of a 'Word8' vector.
 --
 -- It has a lower memory overhead than a 'ByteString' and does not
@@ -493,7 +484,7 @@ indexCharArray :: BA -> Int -> Char
 indexCharArray (BA# ba#) (I# i#) = C# (indexCharArray# ba# i#)
 
 indexWord8Array :: BA -> Int -> Word8
-indexWord8Array (BA# ba#) (I# i#) = W8# (narrowWord8# (indexWord8Array# ba# i#))
+indexWord8Array (BA# ba#) (I# i#) = W8# (indexWord8Array# ba# i#)
 
 newByteArray :: Int -> ST s (MBA s)
 newByteArray (I# len#) =
@@ -519,7 +510,7 @@ writeCharArray (MBA# mba#) (I# i#) (C# c#) =
 
 writeWord8Array :: MBA s -> Int -> Word8 -> ST s ()
 writeWord8Array (MBA# mba#) (I# i#) (W8# w#) =
-  ST $ \s -> case writeWord8Array# mba# i# (extendWord8# w#) s of
+  ST $ \s -> case writeWord8Array# mba# i# w# s of
                s -> (# s, () #)
 
 copyAddrToByteArray :: Ptr a -> MBA RealWorld -> Int -> Int -> ST RealWorld ()

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -111,6 +111,14 @@ import Prelude ( Eq(..), Ord(..), Ordering(..), Read(..), Show(..)
                , return
                , Maybe(..) )
 
+#if MIN_VERSION_base(4,15,0)
+import GHC.Exts ( extendWord8#, narrowWord8# )
+#else
+import GHC.Prim (Word#)
+extendWord8#, narrowWord8# :: Word# -> Word#
+extendWord8#  w = w
+narrowWord8#  w = w
+#endif
 
 -- | A compact representation of a 'Word8' vector.
 --
@@ -485,7 +493,7 @@ indexCharArray :: BA -> Int -> Char
 indexCharArray (BA# ba#) (I# i#) = C# (indexCharArray# ba# i#)
 
 indexWord8Array :: BA -> Int -> Word8
-indexWord8Array (BA# ba#) (I# i#) = W8# (indexWord8Array# ba# i#)
+indexWord8Array (BA# ba#) (I# i#) = W8# (narrowWord8# (indexWord8Array# ba# i#))
 
 newByteArray :: Int -> ST s (MBA s)
 newByteArray (I# len#) =
@@ -511,7 +519,7 @@ writeCharArray (MBA# mba#) (I# i#) (C# c#) =
 
 writeWord8Array :: MBA s -> Int -> Word8 -> ST s ()
 writeWord8Array (MBA# mba#) (I# i#) (W8# w#) =
-  ST $ \s -> case writeWord8Array# mba# i# w# s of
+  ST $ \s -> case writeWord8Array# mba# i# (extendWord8# w#) s of
                s -> (# s, () #)
 
 copyAddrToByteArray :: Ptr a -> MBA RealWorld -> Int -> Int -> ST RealWorld ()


### PR DESCRIPTION
This includes changes rewriting uses of `withForeignPtr` to `unsafeWithForeignPtr` where appropriate for GHC 9.0.