### PR TITLE
Switch from test-framework to tasty

### DIFF
--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -60,8 +60,8 @@ import Prelude hiding (abs)
 
 import Rules
 import QuickCheckUtils
-import Test.Framework
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty
+import Test.Tasty.QuickCheck
 
 toInt64 :: Int -> Int64
 toInt64 = fromIntegral
@@ -1854,7 +1854,7 @@ short_tests =
 -- The entry point
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMain $ testGroup "All" tests
 
 --
 -- And now a list of all the properties to test.

--- a/tests/Regressions.hs
+++ b/tests/Regressions.hs
@@ -3,8 +3,8 @@
 import Control.Exception (SomeException, handle)
 import Test.HUnit (assertBool, assertEqual, assertFailure)
 import qualified Data.ByteString as B
-import qualified Test.Framework as F
-import qualified Test.Framework.Providers.HUnit as F
+import qualified Test.Tasty as F
+import qualified Test.Tasty.HUnit as F
 
 -- Try to generate arguments to concat that are big enough to cause an
 -- Int to overflow.
@@ -17,9 +17,7 @@ concat_overflow =
     (lsize, bsize) | maxBound == (2147483647::Int) = (2^14, 2^18)
                    | otherwise                     = (2^34, 2^29)
 
-tests :: [F.Test]
-tests = [
-    F.testCase "concat_overflow" concat_overflow
-  ]
+tests :: F.TestTree
+tests = F.testCase "concat_overflow" concat_overflow
 
 main = F.defaultMain tests

--- a/tests/Rules.hs
+++ b/tests/Rules.hs
@@ -13,7 +13,7 @@ import Data.Word
 
 import QuickCheckUtils
 
-import Test.Framework.Providers.QuickCheck2
+import Test.Tasty.QuickCheck
 
 prop_break_C :: Word8 -> C.ByteString -> Bool
 prop_break_C w = C.break ((==) x) `eq1` break ((==) x)

--- a/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
@@ -80,9 +80,9 @@ import           System.ByteOrder
 import           System.IO.Unsafe (unsafePerformIO)
 
 import           Test.HUnit (assertBool)
-import           Test.Framework
-import           Test.Framework.Providers.HUnit
-import           Test.Framework.Providers.QuickCheck2
+import           Test.Tasty
+import           Test.Tasty.HUnit (testCase)
+import           Test.Tasty.QuickCheck (testProperty)
 import           Test.QuickCheck (Arbitrary(..))
 
 -- Helper functions
@@ -91,7 +91,7 @@ import           Test.QuickCheck (Arbitrary(..))
 -- | Quickcheck test that includes a check that the property holds on the
 -- bounds of a bounded value.
 testBoundedProperty :: forall a. (Arbitrary a, Show a, Bounded a)
-                    => String -> (a -> Bool) -> Test
+                    => String -> (a -> Bool) -> TestTree
 testBoundedProperty name p = testGroup name
   [ testProperty name p
   , testCase (name ++ " minBound") $ assertBool "minBound" (p (minBound :: a))
@@ -146,7 +146,7 @@ testF :: (Arbitrary a, Show a)
       => String
       -> (a -> [Word8])
       -> FixedPrim a
-      -> Test
+      -> TestTree
 testF name ref fe =
     testProperty name prop
   where
@@ -167,7 +167,7 @@ testBoundedF :: (Arbitrary a, Bounded a, Show a)
              => String
              -> (a -> [Word8])
              -> FixedPrim a
-             -> Test
+             -> TestTree
 testBoundedF name ref fe =
     testBoundedProperty name $ \x -> evalF fe x == ref x
 
@@ -177,7 +177,7 @@ testFixedBoundF :: (Arbitrary a, Show a, Integral a)
                 => String
                 -> (a -> a -> [Word8])
                 -> (a -> FixedPrim a)
-                -> Test
+                -> TestTree
 testFixedBoundF name ref bfe =
     testProperty name prop
   where
@@ -204,7 +204,7 @@ testBoundedB :: (Arbitrary a, Bounded a, Show a)
              => String
              -> (a -> [Word8])
              -> BoundedPrim a
-             -> Test
+             -> TestTree
 testBoundedB name ref fe =
     testBoundedProperty name check
   where
@@ -221,7 +221,7 @@ testBoundedB name ref fe =
 
 -- | Compare two implementations of a function.
 compareImpls :: (Arbitrary a, Show a, Show b, Eq b)
-             => TestName -> (a -> b) -> (a -> b) -> Test
+             => TestName -> (a -> b) -> (a -> b) -> TestTree
 compareImpls name f1 f2 =
     testProperty name check
   where

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -19,19 +19,19 @@ import           Data.ByteString.Builder
 import qualified Data.ByteString.Builder.Prim          as BP
 import           Data.ByteString.Builder.Prim.TestUtils
 
-import           Test.Framework
-import           Test.Framework.Providers.QuickCheck2
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
-tests :: [Test]
+tests :: [TestTree]
 tests = concat [ testsBinary, testsASCII, testsChar8, testsUtf8
                , testsCombinatorsB, [testCString, testCStringUtf8] ]
 
-testCString :: Test
+testCString :: TestTree
 testCString = testProperty "cstring" $
     toLazyByteString (BP.cstring "hello world!"#) ==
       LC.pack "hello" `L.append` L.singleton 0x20 `L.append` LC.pack "world!"
 
-testCStringUtf8 :: Test
+testCStringUtf8 :: TestTree
 testCStringUtf8 = testProperty "cstringUtf8" $
     toLazyByteString (BP.cstringUtf8 "hello\xc0\x80world!"#) ==
       LC.pack "hello" `L.append` L.singleton 0x00 `L.append` LC.pack "world!"
@@ -40,7 +40,7 @@ testCStringUtf8 = testProperty "cstringUtf8" $
 -- Binary
 ------------------------------------------------------------------------------
 
-testsBinary :: [Test]
+testsBinary :: [TestTree]
 testsBinary =
   [ testBoundedF "word8"     bigEndian_list    BP.word8
   , testBoundedF "int8"      bigEndian_list    BP.int8
@@ -89,7 +89,7 @@ testsBinary =
 -- Latin-1  aka  Char8
 ------------------------------------------------------------------------------
 
-testsChar8 :: [Test]
+testsChar8 :: [TestTree]
 testsChar8 =
   [ testBoundedF "char8"     char8_list        BP.char8  ]
 
@@ -98,7 +98,7 @@ testsChar8 =
 -- ASCII
 ------------------------------------------------------------------------------
 
-testsASCII :: [Test]
+testsASCII :: [TestTree]
 testsASCII =
   [ testBoundedF "char7" char7_list BP.char7
 
@@ -139,7 +139,7 @@ testsASCII =
 -- UTF-8
 ------------------------------------------------------------------------------
 
-testsUtf8 :: [Test]
+testsUtf8 :: [TestTree]
 testsUtf8 =
   [ testBoundedB "charUtf8"  charUtf8_list  BP.charUtf8 ]
 
@@ -151,7 +151,7 @@ testsUtf8 =
 maybeB :: BP.BoundedPrim () -> BP.BoundedPrim a -> BP.BoundedPrim (Maybe a)
 maybeB nothing just = maybe (Left ()) Right BP.>$< BP.eitherB nothing just
 
-testsCombinatorsB :: [Test]
+testsCombinatorsB :: [TestTree]
 testsCombinatorsB =
   [ compareImpls "mapMaybe (via BoundedPrim)"
         (L.pack . concatMap encChar)

--- a/tests/builder/TestSuite.hs
+++ b/tests/builder/TestSuite.hs
@@ -2,12 +2,12 @@ module Main where
 
 import qualified Data.ByteString.Builder.Tests
 import qualified Data.ByteString.Builder.Prim.Tests
-import           Test.Framework (defaultMain, Test, testGroup)
+import           Test.Tasty (defaultMain, TestTree, testGroup)
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMain $ testGroup "All" tests
 
-tests :: [Test]
+tests :: [TestTree]
 tests =
   [ testGroup "Data.ByteString.Builder"
        Data.ByteString.Builder.Tests.tests

--- a/tests/bytestring-tests.cabal
+++ b/tests/bytestring-tests.cabal
@@ -36,7 +36,7 @@ test-suite prop-compiled
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
   build-depends:    base, ghc-prim, deepseq, random,
-                    test-framework, test-framework-quickcheck2,
+                    tasty, tasty-quickcheck,
                     QuickCheck >= 2.10 && < 2.15
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
@@ -56,7 +56,7 @@ test-suite lazy-hclose
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
   build-depends:    base, ghc-prim, deepseq, random,
-                    test-framework, test-framework-quickcheck2,
+                    tasty,
                     QuickCheck >= 2.10 && < 2.15
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
@@ -72,7 +72,7 @@ executable regressions
                     Data.ByteString.Unsafe
   hs-source-dirs:   . ..
   build-depends:    base, ghc-prim, deepseq, random,
-                    test-framework, test-framework-hunit, HUnit
+                    tasty, HUnit
   c-sources:        ../cbits/fpstring.c
   include-dirs:     ../include
   ghc-options:      -fwarn-unused-binds
@@ -111,9 +111,7 @@ test-suite test-builder
                     dlist                      >= 0.5 && < 0.9,
                     transformers               >= 0.3,
                     HUnit,
-                    test-framework,
-                    test-framework-hunit,
-                    test-framework-quickcheck2  >= 0.3
+                    tasty, tasty-hunit, tasty-quickcheck
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
   c-sources:        ../cbits/fpstring.c
                     ../cbits/itoa.c


### PR DESCRIPTION
This is the next step to #316. Since `tasty-1.4.0.1` supports GHC 7.0, we can switch from `test-framework` to it. 