### PR TITLE
Deduplicate findIndexOrEnd by exporting it from Data.ByteString.Internal

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -2023,21 +2023,6 @@ appendFile = modifyFile AppendMode
 -- ---------------------------------------------------------------------
 -- Internal utilities
 
--- | 'findIndexOrEnd' is a variant of findIndex, that returns the length
--- of the string if no element is found, rather than Nothing.
-findIndexOrEnd :: (Word8 -> Bool) -> ByteString -> Int
-findIndexOrEnd k (BS x l) =
-    accursedUnutterablePerformIO $ withForeignPtr x g
-  where
-    g ptr = go 0
-      where
-        go !n | n >= l    = return l
-              | otherwise = do w <- peek $ ptr `plusPtr` n
-                               if k w
-                                 then return n
-                                 else go (n+1)
-{-# INLINE findIndexOrEnd #-}
-
 -- Common up near identical calls to `error' to reduce the number
 -- constant strings created when compiled:
 errorEmptyList :: String -> a

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -38,6 +38,9 @@ module Data.ByteString.Internal (
 #endif
         ), -- instances: Eq, Ord, Show, Read, Data, Typeable
 
+        -- * Internal indexing
+        findIndexOrEnd,
+
         -- * Conversion with lists: packing and unpacking
         packBytes, packUptoLenBytes, unsafePackLenBytes,
         packChars, packUptoLenChars, unsafePackLenChars,
@@ -287,6 +290,24 @@ instance Data ByteString where
   toConstr _     = error "Data.ByteString.ByteString.toConstr"
   gunfold _ _    = error "Data.ByteString.ByteString.gunfold"
   dataTypeOf _   = mkNoRepType "Data.ByteString.ByteString"
+
+------------------------------------------------------------------------
+-- Internal indexing
+
+-- | 'findIndexOrEnd' is a variant of findIndex, that returns the length
+-- of the string if no element is found, rather than Nothing.
+findIndexOrEnd :: (Word8 -> Bool) -> ByteString -> Int
+findIndexOrEnd k (BS x l) =
+    accursedUnutterablePerformIO $ withForeignPtr x g
+  where
+    g ptr = go 0
+      where
+        go !n | n >= l    = return l
+              | otherwise = do w <- peek $ ptr `plusPtr` n
+                               if k w
+                                 then return n
+                                 else go (n+1)
+{-# INLINE findIndexOrEnd #-}
 
 ------------------------------------------------------------------------
 -- Packing and unpacking from lists

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -226,6 +226,12 @@ sortInputs = map (`S.take` S.pack [122, 121 .. 32]) [10..25]
 foldInputs :: [S.ByteString]
 foldInputs = map (\k -> S.pack $ if k <= 6 then take (2 ^ k) [32..95] else concat (replicate (2 ^ (k - 6)) [32..95])) [0..16]
 
+zeroes :: L.ByteString
+zeroes = L.replicate 10000 0
+
+zeroOneRepeating :: L.ByteString
+zeroOneRepeating = L.take 10000 (L.cycle (L.pack [0,1]))
+
 main :: IO ()
 main = do
   mapM_ putStrLn sanityCheckInfo
@@ -408,5 +414,14 @@ main = do
           nf (S.scanr (+) 0) s) foldInputs
       , bgroup "filter" $ map (\s -> bench (show $ S.length s) $
           nf (S.filter odd) s) foldInputs
+      ]
+    , bgroup "findIndexOrEnd"
+      [ bench "takeWhile"      $ nf (L.takeWhile even) zeroes
+      , bench "dropWhile"      $ nf (L.dropWhile even) zeroes
+      , bench "break"          $ nf (L.break odd) zeroes
+      , bench "group zeroes"   $ nf L.group zeroes
+      , bench "group zero-one" $ nf L.group zeroOneRepeating
+      , bench "groupBy (>=)"   $ nf (L.groupBy (>=)) zeroes
+      , bench "groupBy (>)"    $ nf (L.groupBy (>)) zeroes
       ]
     ]


### PR DESCRIPTION
Closes #334 

I am open to other suggestions for the section name "Internal indexing". 