### PR TITLE
Add CI build on Ubuntu 16.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           ghc: 'latest'
         - os: macOS-latest
           ghc: 'latest'
+        - os: ubuntu-16.04
+          ghc: 'latest'
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           ghc: 'latest'
         - os: macOS-latest
           ghc: 'latest'
-        - os: ubuntu-16.04
+        - os: ubuntu-16.04 # testing that cbits are compatible with gcc-5
           ghc: 'latest'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
To check that `cbits` are compatible with `gcc-5`. This is motivated by https://github.com/haskell/bytestring/pull/202#issuecomment-757333850

https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners