### PR TITLE
Convert folds to take two arguments

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -15,6 +15,11 @@
       - Data.ByteString.Builder.Internal
       - Data.ByteString.Builder.Prim
 - ignore:
+    name: Reduce duplication
+    within:
+      - Data.ByteString  
+- ignore:
     name: Redundant lambda
     within:
       - Data.ByteString.Builder.Internal
+      - Data.ByteString  


### PR DESCRIPTION
This pull request changes the fold functions of the form: `fold f z bs` to `fold f z = \bs -> ...` fixing issue https://github.com/haskell/bytestring/issues/329.

On my machine it looked like this significantly improved the folds benchmarks but I am unsure if that is because I was running in a noisy environment or some other reason e.g.

Before:
```
benchmarked Data.ByteString.Builder/folds/foldl'/32768
time                 120.4 μs   (117.8 μs .. 124.2 μs)
                     0.993 R²   (0.986 R² .. 0.997 R²)
mean                 121.9 μs   (120.3 μs .. 124.0 μs)
std dev              6.364 μs   (5.074 μs .. 7.591 μs)
variance introduced by outliers: 31% (moderately inflated)

benchmarked Data.ByteString.Builder/folds/foldl'/65536
time                 233.3 μs   (230.9 μs .. 237.1 μs)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 235.4 μs   (234.0 μs .. 238.2 μs)
std dev              6.545 μs   (4.637 μs .. 9.409 μs)
variance introduced by outliers: 11% (moderately inflated)
```

After:
```
benchmarked Data.ByteString.Builder/folds/foldl'/32768
time                 13.79 μs   (13.00 μs .. 14.59 μs)
                     0.987 R²   (0.980 R² .. 0.995 R²)
mean                 13.78 μs   (13.59 μs .. 14.00 μs)
std dev              710.7 ns   (599.7 ns .. 869.6 ns)
variance introduced by outliers: 31% (moderately inflated)

benchmarked Data.ByteString.Builder/folds/foldl'/65536
time                 26.19 μs   (25.51 μs .. 27.10 μs)
                     0.992 R²   (0.988 R² .. 0.995 R²)
mean                 27.38 μs   (26.95 μs .. 28.04 μs)
std dev              1.701 μs   (1.345 μs .. 2.364 μs)
variance introduced by outliers: 39% (moderately inflated)
```

This was done using `ghc-8.10.2`.
