### PR TITLE
Add findIndex benchmarks

### DIFF
--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -424,4 +424,8 @@ main = do
       , bench "groupBy (>=)"   $ nf (L.groupBy (>=)) zeroes
       , bench "groupBy (>)"    $ nf (L.groupBy (>)) zeroes
       ]
+    , bgroup "findIndex"
+      [ bench "findIndices"    $ nf (sum . S.findIndices even) byteStringData
+      , bench "find"           $ nf (S.find (>= 9998)) byteStringData
+      ]
     ]


### PR DESCRIPTION
Adds some (not necessarily well-thought out) benchmarks for `findIndex`.