### PR TITLE
Optimize findIndex, findIndexEnd and map

### DIFF
--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -232,6 +232,13 @@ zeroes = L.replicate 10000 0
 zeroOneRepeating :: L.ByteString
 zeroOneRepeating = L.take 10000 (L.cycle (L.pack [0,1]))
 
+
+largeTraversalInput :: S.ByteString
+largeTraversalInput = S.concat (replicate 10 byteStringData)
+
+smallTraversalInput :: S.ByteString
+smallTraversalInput = S8.pack "The quick brown fox"
+
 main :: IO ()
 main = do
   mapM_ putStrLn sanityCheckInfo
@@ -424,8 +431,16 @@ main = do
       , bench "groupBy (>=)"   $ nf (L.groupBy (>=)) zeroes
       , bench "groupBy (>)"    $ nf (L.groupBy (>)) zeroes
       ]
-    , bgroup "findIndex"
-      [ bench "findIndices"    $ nf (sum . S.findIndices even) byteStringData
-      , bench "find"           $ nf (S.find (>= 9998)) byteStringData
+    , bgroup "findIndex_"
+      [ bench "findIndices"    $ nf (sum . S.findIndices (\x -> x ==  129 || x == 72)) byteStringData
+      , bench "find"           $ nf (S.find (>= 198)) byteStringData
+      ]
+    , bgroup "findIndexEnd"
+      [ bench "findIndexEnd"   $ nf (S.findIndexEnd (<= 57)) byteStringData
+      , bench "elemIndexInd"   $ nf (S.elemIndexEnd 42) byteStringData
+      ]
+    , bgroup "traversals"
+      [ bench "map (+1)"   $ nf (S.map (+ 1)) largeTraversalInput
+      , bench "map (+1)"   $ nf (S.map (+ 1)) smallTraversalInput
       ]
     ]


### PR DESCRIPTION
This makes the suggested change from https://github.com/haskell/bytestring/issues/338 so that constant arguments are not passed to helper functions.  Here are the benchmarks for findIndex and findIndexEnd:
```
old:
findIndex1/findIndices                   mean 556.2 ns  ( +- 8.501 ns  )
findIndex1/find                          mean 645.2 ns  ( +- 8.517 ns  )
findIndex1End/findIndexEnd               mean 9.832 ns  ( +- 115.2 ps  )
findIndex1End/elemIndexInd               mean 557.8 ns  ( +- 8.507 ns  )
```

```
new:
findIndex1/findIndices                   mean 526.4 ns  ( +- 12.05 ns  )
findIndex1/find                          mean 416.7 ns  ( +- 6.734 ns  )
findIndex1End/findIndexEnd               mean 9.355 ns  ( +- 111.5 ps  )
findIndex1End/elemIndexInd               mean 477.8 ns  ( +- 5.754 ns  )
```

Here is the benchmarks for map:
```
old:
traversals/map (+1)                      mean 393.1 μs  ( +- 22.82 μs  )
traversals/map (+1)                      mean 90.71 ns  ( +- 1.528 ns  )
```

```
new:
traversals/map (+1)                      mean 55.09 μs  ( +- 3.310 μs  )
traversals/map (+1)                      mean 23.46 ns  ( +- 539.6 ps  )
```
