### PR TITLE
Combine all benchmarks into a single executable

### DIFF
--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE PackageImports      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MagicHash           #-}
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -10,7 +6,12 @@
 -- Stability   : experimental
 -- Portability : tested on GHC only
 --
--- Benchmark all 'Builder' functions.
+
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE PackageImports      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MagicHash           #-}
+
 module Main (main) where
 
 import           Data.Foldable                         (foldMap)
@@ -37,6 +38,10 @@ import qualified Data.ByteString.Builder.Prim.Internal as PI
 import           Foreign
 
 import System.Random
+
+import BenchBoundsCheckFusion
+import BenchCSV
+import BenchIndices
 
 ------------------------------------------------------------------------------
 -- Benchmark support
@@ -242,7 +247,7 @@ smallTraversalInput = S8.pack "The quick brown fox"
 main :: IO ()
 main = do
   mapM_ putStrLn sanityCheckInfo
-  Gauge.defaultMain
+  defaultMain
     [ bgroup "Data.ByteString.Builder"
       [ bgroup "Small payload"
         [ benchB' "mempty"        ()  (const mempty)
@@ -443,4 +448,7 @@ main = do
       [ bench "map (+1)"   $ nf (S.map (+ 1)) largeTraversalInput
       , bench "map (+1)"   $ nf (S.map (+ 1)) smallTraversalInput
       ]
+    , benchBoundsCheckFusion
+    , benchCSV
+    , benchIndices
     ]

--- a/bench/BenchBoundsCheckFusion.hs
+++ b/bench/BenchBoundsCheckFusion.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PackageImports, ScopedTypeVariables, BangPatterns #-}
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -8,7 +7,10 @@
 -- Portability : tested on GHC only
 --
 -- Benchmark that the bounds checks fuse.
-module Main (main) where
+
+{-# LANGUAGE PackageImports, ScopedTypeVariables, BangPatterns #-}
+
+module BenchBoundsCheckFusion (benchBoundsCheckFusion) where
 
 import Prelude hiding (words)
 import Data.Monoid
@@ -69,31 +71,10 @@ benchBInts name = benchB name intData
 -- benchmarks
 -------------
 
-sanityCheckInfo :: [String]
-sanityCheckInfo =
-  [ "Sanity checks:"
-  , " lengths of input data: " ++ show
-      [ length intData ]
-  ]
-
-main :: IO ()
-main = do
-  mapM_ putStrLn sanityCheckInfo
-  putStrLn ""
-  Gauge.defaultMain
+benchBoundsCheckFusion :: Benchmark
+benchBoundsCheckFusion = bgroup "BoundsCheckFusion"
     [ bgroup "Data.ByteString.Builder"
-        [ -- benchBInts "foldMap intHost" $
-            -- foldMap (intHost . fromIntegral)
-
-{-
-          benchBInts "mapM_ (\\x -> intHost x `mappend` intHost x)" $
-            foldMap ((\x -> intHost x `mappend` intHost x)
-
-        , benchBInts "foldMap (\\x -> intHost x `mappend` intHost x)" $
-            foldMap (\x -> intHost x `mappend` intHost x)
--}
-
-          benchBInts "foldMap (left-assoc)" $
+        [ benchBInts "foldMap (left-assoc)" $
             foldMap (\x -> (stringUtf8 "s" `mappend` intHost x) `mappend` intHost x)
 
         , benchBInts "foldMap (right-assoc)" $
@@ -104,9 +85,6 @@ main = do
 
         , benchBInts "foldMap [manually fused, right-assoc]" $
             foldMap (\x -> P.primBounded (P.liftFixedToBounded $ P.intHost >*< P.intHost) (x, x) `mappend` stringUtf8 "s")
-
-        -- , benchBInts "encodeListWithF intHost" $
-            -- P.encodeListWithF (fromIntegral >$< P.intHost)
         ]
     ]
 

--- a/bench/BenchCSV.hs
+++ b/bench/BenchCSV.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings, PackageImports #-}
 -- |
 -- Copyright   : (c) 2010-2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -9,7 +8,10 @@
 --
 -- Running example for documentation of Data.ByteString.Builder
 --
-module Main (main) where
+
+{-# LANGUAGE OverloadedStrings, PackageImports #-}
+
+module BenchCSV (benchCSV) where
 
 -- **************************************************************************
 -- CamHac 2011: An introduction to Data.ByteString.Builder
@@ -117,7 +119,7 @@ import           Data.ByteString.Builder                         as B
 import Data.Monoid
 import Data.Foldable (foldMap)
 
-import Gauge.Main
+import Gauge
 import Control.DeepSeq
 
 
@@ -396,15 +398,8 @@ benchTextBuilderUtf8 = bench "utf8 + renderTableTB maxiTable" $
 -- Benchmarking
 ------------------------------------------------------------------------------
 
-main :: IO ()
-main = do
-    putStrLn "Encoding the maxiTable"
-    putStrLn $ "Total length in bytes: " ++
-        (show $ L.length $ encodeUtf8CSV maxiTable)
-    putStrLn $ "Chunk lengths: " ++
-        (show $ map S.length $ L.toChunks $ encodeUtf8CSV maxiTable)
-    putStrLn ""
-    defaultMain
+benchCSV :: Benchmark
+benchCSV = bgroup "CSV"
       [ benchNF
       , benchString
       , benchStringUtf8

--- a/bench/BenchIndices.hs
+++ b/bench/BenchIndices.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
 -- |
 -- Copyright   : (c) 2020 Peter Duchovni
 -- License     : BSD3-style (see LICENSE)
@@ -6,7 +5,10 @@
 -- Maintainer  : Peter Duchovni <caufeminecraft+github@gmail.com>
 --
 -- Benchmark elemIndex, findIndex, elemIndices, and findIndices
-module Main (main) where
+
+{-# LANGUAGE BangPatterns        #-}
+
+module BenchIndices (benchIndices) where
 
 import           Data.Foldable                         (foldMap)
 import           Data.Maybe                            (listToMaybe)
@@ -43,9 +45,8 @@ absurdlong = S.replicate 200 0x61 <> S.singleton nl
           <> S.replicate 200 0x65 <> S.singleton nl
           <> S.replicate 999999 0x66
 
-main :: IO ()
-main = do
-  Gauge.defaultMain
+benchIndices :: Benchmark
+benchIndices = bgroup "Indices"
     [ bgroup "ByteString strict first index" $
         [ bench "FindIndices" $ nf (listToMaybe . S.findIndices (== nl)) absurdlong
         , bench "ElemIndices" $ nf (listToMaybe . S.elemIndices     nl)  absurdlong

--- a/bench/bench-bytestring.cabal
+++ b/bench/bench-bytestring.cabal
@@ -30,9 +30,14 @@ flag integer-simple
   description: Use the simple integer library instead of GMP
   default: False
 
-common bench-stanza
+benchmark bytestring-bench
+  main-is:          BenchAll.hs
+  other-modules:    BenchBoundsCheckFusion
+                    BenchCSV
+                    BenchIndices
+  type:             exitcode-stdio-1.0
   hs-source-dirs:   . ..
-  default-language: Haskell98
+  default-language: Haskell2010
 
   other-modules:
         Data.ByteString
@@ -61,9 +66,13 @@ common bench-stanza
                     -fspec-constr-count=6
 
   build-depends:     base >= 4.8 && < 5
+                   , bytestring
                    , deepseq
+                   , dlist
                    , gauge         >= 0.2.5
                    , ghc-prim
+                   , random
+                   , text
 
   if impl(ghc >= 8.11)
     build-depends: ghc-bignum >= 1.0
@@ -71,25 +80,3 @@ common bench-stanza
     if !flag(integer-simple)
       cpp-options: -DINTEGER_GMP
       build-depends: integer-gmp >= 0.2
-
-benchmark bench-builder
-  import:           bench-stanza
-  main-is:          BenchAll.hs
-  type:             exitcode-stdio-1.0
-  build-depends:    random
-
-benchmark bench-boundscheck
-  import:           bench-stanza
-  main-is:          BoundsCheckFusion.hs
-  type:             exitcode-stdio-1.0
-
-benchmark bench-csv
-  import:           bench-stanza
-  main-is:          CSV.hs
-  type:             exitcode-stdio-1.0
-  build-depends:    bytestring, dlist, text
-
-benchmark bench-indices
-  import:           bench-stanza
-  main-is:          BenchIndices.hs
-  type:             exitcode-stdio-1.0


### PR DESCRIPTION
I noticed that `cabal bench` tends to run all four benchmarks in parallel, with makes results quite useless. This PR works around this deficiency, unifying all benchmarks under the same umbrella to produce a single executable. It also improves linking times.