### PR TITLE
Adapt to GHC 9.0 and latest haskell/actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['7.10', '8.0', '8.2', '8.4', '8.6', '8.8', '8.10']
+        ghc: ['7.10', '8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
         include:
         - os: windows-latest
           ghc: 'latest'

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -247,7 +247,9 @@ data ByteString = BS {-# UNPACK #-} !(ForeignPtr Word8) -- payload
 pattern PS :: ForeignPtr Word8 -> Int -> Int -> ByteString
 pattern PS fp zero len <- BS fp ((0,) -> (zero, len)) where
   PS fp o len = BS (plusForeignPtr fp o) len
+#if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE PS #-}
+#endif
 #endif
 
 instance Eq  ByteString where
@@ -686,6 +688,7 @@ concat = \bss0 -> goLen0 bss0 bss0
    concat [x] = x
  #-}
 
+#if MIN_VERSION_base(4,9,0)
 -- | /O(log n)/ Repeats the given ByteString n times.
 times :: Integral a => a -> ByteString -> ByteString
 times n (BS fp len)
@@ -710,6 +713,7 @@ times n (BS fp len)
         memcpy (destptr `plusPtr` copied) destptr copied
         fillFrom destptr (copied * 2)
       | otherwise = memcpy (destptr `plusPtr` copied) destptr (size - copied)
+#endif
 
 -- | Add two non-negative numbers. Errors out on overflow.
 checkedAdd :: String -> Int -> Int -> Int

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -239,7 +239,6 @@ import System.IO                (Handle,openBinaryFile,stdin,stdout,withBinaryFi
 import System.IO.Error          (mkIOError, illegalOperationErrorType)
 import System.IO.Unsafe
 
-import Foreign.ForeignPtr       (withForeignPtr)
 import Foreign.Ptr
 import Foreign.Storable
 

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -275,6 +275,7 @@ concat = to
     to []               = Empty
     to (cs:css)         = go cs css
 
+#if MIN_VERSION_base(4,9,0)
 -- | Repeats the given ByteString n times.
 times :: Integral a => a -> ByteString -> ByteString
 times 0 _ = Empty
@@ -286,6 +287,7 @@ times n lbs0
   where
     go Empty = times (n-1) lbs0
     go (Chunk c cs) = Chunk c (go cs)
+#endif
 
 ------------------------------------------------------------------------
 -- Conversions

--- a/cabal.project
+++ b/cabal.project
@@ -4,3 +4,6 @@ benchmarks: True
 
 constraints:
   semigroups -hashable -text -binary -bytestring
+
+allow-newer:
+  hsc2hs:base


### PR DESCRIPTION
The latest `haskell/actions` introduce GHC 9.0 as a `latest` version and displays build warnings alongside with changes. The first change has broken our Windows build, because `hcs2hs` has not yet been revised for GHC 9.0. The second change means that we need to clean up all existing warnings - otherwise they are repeated many-many times. 