### PR TITLE
SSE speed up of minimum

### DIFF
--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -425,6 +425,8 @@ main = do
           nf (S.scanr (+) 0) s) foldInputs
       , bgroup "filter" $ map (\s -> bench (show $ S.length s) $
           nf (S.filter odd) s) foldInputs
+      , bgroup "minimum" $ map (\s -> bench (show $ S.length s) $
+          nf S.minimum s) foldInputs
       ]
     , bgroup "findIndexOrLength"
       [ bench "takeWhile"      $ nf (L.takeWhile even) zeroes

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -32,7 +32,6 @@
 #include "fpstring.h"
 #if defined(__x86_64__)
 #include <emmintrin.h>
-#include <pmmintrin.h>
 #include <xmmintrin.h>
 #endif
 
@@ -88,9 +87,9 @@ unsigned char fps_minimum(unsigned char *p, size_t len) {
     unsigned char *q, c = *p;
     q = p;
     if (len > 16) {
-        __m128i mins = _mm_lddqu_si128((void *) p);
+        __m128i mins = _mm_loadu_si128((__m128i *) p);
         for (q = p + 16; q < p + len - 16; q = q + 16)
-            mins = _mm_min_epu8(mins, _mm_lddqu_si128((void *) q));
+            mins = _mm_min_epu8(mins, _mm_loadu_si128((__m128i *) q));
         unsigned char dest[16];
         _mm_store_si128((__m128i *)dest, mins);
         for (int i = 0; i < 16; i++)


### PR DESCRIPTION
I was curious about SSE instructions so I implemented a faster version of Minimum. From my benchmarking it performs better than the old version. Please let me know if you would like any changes or if this isn't something you are looking to add to the project. 

From my own benchmarks I was able to get speed ups of as much as 40% and it is consistently quicker on datasets of the string sizes I tested which were 10, 100, ..., up to 1,000,000.