### PR TITLE
Release 0.11.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 [0.12.0.0]: https://github.com/haskell/bytestring/compare/0.11.1.0...0.12.0.0
 
-[0.11.1.0] — Unreleased
+[0.11.1.0] — February 2021
 
 * [Add `Data.ByteString.Char8.findIndexEnd` and `Data.ByteString.Lazy.Char8.{elemIndexEnd,findIndexEnd,unzip}`](https://github.com/haskell/bytestring/pull/342)
 * [Expose `ShortByteString` constructor from `Data.ByteString.Short`](https://github.com/haskell/bytestring/pull/313)

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -1,5 +1,5 @@
 Name:                bytestring
-Version:             0.11.0.0
+Version:             0.11.1.0
 Synopsis:            Fast, compact, strict and lazy byte strings with a list interface
 Description:
     An efficient compact, immutable byte string type (both strict and lazy)


### PR DESCRIPTION
Since GHC 9.0 is finally out, and `bytestring-0.11` is incompatible with it because of a CPP issue (fixed in #293), I think it is a good time to make the next release in `0.11` series, which can be actually built with GHC 9.0. 

Changelog seems to be up to date, so this PR only bumps version in the cabal file. If it looks good, I'll merge, cherry-pick to `bytestring-0.11` branch and release.