### PR TITLE
Pin freebsd-vm to 0.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Test
       id: build-freebsd
-      uses: vmactions/freebsd-vm@v0.1
+      uses: vmactions/freebsd-vm@v0.1.4
       with:
         usesh: true
         mem: 4096


### PR DESCRIPTION
I messed up in #386: apparently GitHub Actions allow relaxed version (e. g., `@v1`, `@v2`) only for "stable" packages, but until an action reaches `@v1`, you can use neither `@v0` nor `@v0.1`, but only `@v0.1.4`.

Seems the failure was shadowed by usual Windows stuff, and I missed email notification before too late. Sorry for this.