### PR TITLE
Workaround CI failures on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,20 @@ jobs:
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}
+    # We rebuild tests several times to avoid intermittent failures on Windows
+    # https://github.com/haskell/actions/issues/36
     - name: Test
       run: |
         cabal sdist -z -o .
         cabal get bytestring-*.tar.gz
         cd bytestring-*/
-        cp ../cabal.project .
-        cabal test --test-show-details=direct
+        bld() { cabal build bytestring:tests; }
+        bld || bld || bld
+        cabal test --test-show-details=direct all
     - name: Bench
       run: |
         cd bytestring-*/
-        cabal bench --benchmark-option=-l
+        cabal bench --benchmark-option=-l all
     - name: Haddock
       run: cabal haddock
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,9 +1,3 @@
 packages: .
 tests: True
 benchmarks: True
-
-constraints:
-  semigroups -hashable -text -binary -bytestring
-
-allow-newer:
-  hsc2hs:base


### PR DESCRIPTION
Try building tests several times to workaround an intermittent failure with a temporary file in #370. 

And we no longer need to use `cabal.project`, `hsc2hs` has been revised. 