### PR TITLE
TH Lift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,20 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.ghc }}
     # We rebuild tests several times to avoid intermittent failures on Windows
     # https://github.com/haskell/actions/issues/36
+    # We also use --enable-tests and --enable-benchmarks to avoid
+    # test and bench commands from reconfiguring and thus rebuilding.
     - name: Test
       run: |
         cabal sdist -z -o .
         cabal get bytestring-*.tar.gz
         cd bytestring-*/
-        bld() { cabal build bytestring:tests; }
+        bld() { cabal build bytestring:tests --enable-tests --enable-benchmarks; }
         bld || bld || bld
-        cabal test --test-show-details=direct all
+        cabal test --enable-tests --enable-benchmarks --test-show-details=direct all -j1
     - name: Bench
       run: |
         cd bytestring-*/
-        cabal bench --benchmark-option=-l all
+        cabal bench --enable-tests --enable-benchmarks --benchmark-option=-l all
     - name: Haddock
       run: cabal haddock
 

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Unsafe #-}
 {-# OPTIONS_HADDOCK not-home #-}
@@ -70,6 +71,8 @@ import Data.Data                (Data(..), mkNoRepType)
 
 import GHC.Exts                 (IsList(..))
 
+import qualified Language.Haskell.TH.Syntax as TH
+
 -- | A space-efficient representation of a 'Word8' vector, supporting many
 -- efficient operations.
 --
@@ -78,7 +81,7 @@ import GHC.Exts                 (IsList(..))
 -- 8-bit characters.
 --
 data ByteString = Empty | Chunk {-# UNPACK #-} !S.ByteString ByteString
-    deriving (Typeable)
+    deriving (Typeable, TH.Lift)
 -- See 'invariant' function later in this module for internal invariants.
 
 -- | Type synonym for the lazy flavour of 'ByteString'.

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -70,7 +70,7 @@ source-repository head
   location: https://github.com/haskell/bytestring
 
 library
-  build-depends:     base >= 4.9 && < 5, ghc-prim, deepseq
+  build-depends:     base >= 4.9 && < 5, ghc-prim, deepseq, template-haskell
 
   exposed-modules:   Data.ByteString
                      Data.ByteString.Char8
@@ -162,6 +162,15 @@ test-suite test-builder
                     tasty-quickcheck
   if impl(ghc < 8.4)
     build-depends:  ghc-byteorder
+  ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
+  default-language: Haskell2010
+
+test-suite bytestring-th
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests
+  main-is:          bytestring-th.hs
+  other-extensions: TemplateHaskell
+  build-depends:    base, bytestring, template-haskell, tasty, tasty-hunit
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
   default-language: Haskell2010
 

--- a/tests/bytestring-th.hs
+++ b/tests/bytestring-th.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import           Test.Tasty (defaultMain, testGroup)
+import           Test.Tasty.HUnit (testCase, (@=?))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Short as SBS
+import qualified Language.Haskell.TH.Syntax as TH
+
+main :: IO ()
+main = defaultMain $ testGroup "bytestring-th"
+  [ testGroup "strict"
+    [ testCase "normal" $ do
+        let bs :: BS.ByteString
+            bs = "foobar"
+
+        bs @=? $(TH.lift $ BS.pack [102,111,111,98,97,114])
+
+    , testCase "binary" $ do
+        let bs :: BS.ByteString
+            bs = "\0\1\2\3\0\1\2\3"
+
+        bs @=? $(TH.lift $ BS.pack [0,1,2,3,0,1,2,3])
+
+#if MIN_VERSION_template_haskell(2,16,0)
+    , testCase "typed" $ do
+        let bs :: BS.ByteString
+            bs = "\0\1\2\3\0\1\2\3"
+
+        bs @=? $$(TH.liftTyped $ BS.pack [0,1,2,3,0,1,2,3])
+#endif
+    ]
+
+  , testGroup "lazy"
+    [ testCase "normal" $ do
+        let bs :: LBS.ByteString
+            bs = "foobar"
+
+        bs @=? $(TH.lift $ LBS.pack [102,111,111,98,97,114])
+
+    , testCase "binary" $ do
+        let bs :: LBS.ByteString
+            bs = "\0\1\2\3\0\1\2\3"
+
+        -- print $ LBS.unpack bs
+        -- print $ LBS.unpack $(TH.lift $ LBS.pack [0,1,2,3,0,1,2,3])
+
+        bs @=? $(TH.lift $ LBS.pack [0,1,2,3,0,1,2,3])
+
+#if MIN_VERSION_template_haskell(2,16,0)
+    , testCase "typed" $ do
+        let bs :: LBS.ByteString
+            bs = "\0\1\2\3\0\1\2\3"
+
+        bs @=? $$(TH.liftTyped $ LBS.pack [0,1,2,3,0,1,2,3])
+#endif
+    ]
+
+  , testGroup "short"
+    [ testCase "normal" $ do
+        let bs :: SBS.ShortByteString
+            bs = "foobar"
+
+        bs @=? $(TH.lift $ SBS.pack [102,111,111,98,97,114])
+
+    , testCase "binary" $ do
+        let bs :: SBS.ShortByteString
+            bs = "\0\1\2\3\0\1\2\3"
+
+        bs @=? $(TH.lift $ SBS.pack [0,1,2,3,0,1,2,3])
+
+#if MIN_VERSION_template_haskell(2,16,0)
+    , testCase "typed" $ do
+        let bs :: SBS.ShortByteString
+            bs = "\0\1\2\3\0\1\2\3"
+
+        bs @=? $$(TH.liftTyped $ SBS.pack [0,1,2,3,0,1,2,3])
+#endif
+    ]
+  ]


### PR DESCRIPTION
WIP, have to add SBS instance still.

Builds on top of #390, because there is better "primtiive" to pack `Addr#`, we can do better then is currently done in
https://hackage.haskell.org/package/th-lift-instances-0.1.18/docs/src/Instances.TH.Lift.html#line-281