### PR TITLE
Add lazy dropEnd and friends

### DIFF
--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -700,7 +700,7 @@ take i cs0         = take' i cs0
 -- >>> takeEnd 4 "abc"
 -- "abc"
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 takeEnd :: Int64 -> ByteString -> ByteString
 takeEnd i _ | i <= 0 = Empty
 takeEnd i cs0        = takeEnd' i cs0
@@ -736,7 +736,7 @@ drop i cs0 = drop' i cs0
 -- >>> dropEnd 4 "abc"
 -- ""
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 dropEnd :: Int64 -> ByteString -> ByteString
 dropEnd i p | i <= 0 = p
 dropEnd i cs0 = dropEnd' i cs0
@@ -781,7 +781,7 @@ takeWhile f = takeWhile'
 --
 -- @'takeWhileEnd' p@ is equivalent to @'reverse' . 'takeWhile' p . 'reverse'@.
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 takeWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString
 takeWhileEnd f = takeWhileEnd'
   where takeWhileEnd' Empty = Empty
@@ -810,7 +810,7 @@ dropWhile f = dropWhile'
 --
 -- @'dropWhileEnd' p@ is equivalent to @'reverse' . 'dropWhile' p . 'reverse'@.
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 dropWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString
 dropWhileEnd f = dropWhileEnd'
   where dropWhileEnd' Empty = Empty
@@ -844,7 +844,7 @@ break f = break'
 --
 -- 'breakEnd' @p@ is equivalent to @'spanEnd' (not . p)@ and to @('takeWhileEnd' (not . p) &&& 'dropWhileEnd' (not . p))@.
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 breakEnd :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
 breakEnd  f = breakEnd'
   where breakEnd' Empty           = (Empty, Empty)
@@ -922,7 +922,7 @@ span p = break (not . p)
 -- >    ==
 -- > let (x, y) = span (not . isSpace) (reverse ps) in (reverse y, reverse x)
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 spanEnd :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
 spanEnd p = breakEnd (not . p)
 

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -739,7 +739,7 @@ drop i cs0 = drop' i cs0
 -- @since 0.11.2.0
 dropEnd :: Int64 -> ByteString -> ByteString
 dropEnd i p | i <= 0 = p
-dropEnd i p = go D.empty p
+dropEnd i p          = go D.empty p
   where go :: D.Deque -> ByteString -> ByteString
         go deque (Chunk c cs)
             | D.elemLength deque < i = go (D.snoc c deque) cs
@@ -757,7 +757,7 @@ dropEnd i p = go D.empty p
             Nothing                       -> (reverseChunks out, deque)
             Just (x, deque') | D.elemLength deque' >= i ->
                             getOutput (Chunk x out) deque'
-                             | otherwise  -> (reverseChunks out, deque)
+            _ -> (reverseChunks out, deque)
 
         -- reverse a `ByteString`s chunks, keeping all internal `S.ByteString`s
         -- unchanged
@@ -808,6 +808,9 @@ takeWhile f = takeWhile'
 --
 -- @'takeWhileEnd' p@ is equivalent to @'reverse' . 'takeWhile' p . 'reverse'@.
 --
+-- >>> takeWhileEnd even (Chunk (pack [1,2]) (Chunk (pack [3,4,6]) Empty))
+-- Chunk (pack [4,6]) Empty
+--
 -- @since 0.11.2.0
 takeWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString
 takeWhileEnd f = takeWhileEnd'
@@ -836,6 +839,9 @@ dropWhile f = dropWhile'
 -- satisfying the predicate and returns the remainder.
 --
 -- @'dropWhileEnd' p@ is equivalent to @'reverse' . 'dropWhile' p . 'reverse'@.
+--
+-- >>> dropWhileEnd even (Chunk (pack [1,2]) (Chunk (pack [3,4,6]) Empty))
+-- Chunk (pack [1,2]) (Chunk [3] Empty)
 --
 -- @since 0.11.2.0
 dropWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -811,13 +811,13 @@ dropWhile f = dropWhile'
 --
 -- @since 0.11.2.0
 dropWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString
-dropWhileEnd f = go [] 
-  where go acc (Chunk c cs) 
+dropWhileEnd f = go []
+  where go acc (Chunk c cs)
             | f (S.last c) = go (c : acc) cs
             | otherwise    = L.foldl (flip Chunk) (go [] cs) (c : acc)
         go acc Empty       = dropAcc acc
         dropAcc []         = Empty
-        dropAcc (x : xs)   = 
+        dropAcc (x : xs)   =
             case S.dropWhileEnd f x of
                  x' | S.null x' -> dropAcc xs
                     | otherwise -> L.foldl' (flip Chunk) Empty (x' : xs)
@@ -849,15 +849,15 @@ break f = break'
 breakEnd :: (Word8 -> Bool) -> ByteString -> (ByteString, ByteString)
 breakEnd  f = go []
   where go acc (Chunk c cs)
-            | f (S.last c) = L.foldl (flip $ BF.first . Chunk) (go [] cs) (c : acc) 
+            | f (S.last c) = L.foldl (flip $ BF.first . Chunk) (go [] cs) (c : acc)
             | otherwise = go (c : acc) cs
         go acc Empty = dropAcc acc
         dropAcc [] = (Empty, Empty)
-        dropAcc (x : xs) = 
+        dropAcc (x : xs) =
             case S.breakEnd f x of
                  (x', x'') | S.null x' -> let (y, y') = dropAcc xs
                                            in (y, y' `append` fromStrict x)
-                           | otherwise -> 
+                           | otherwise ->
                                 L.foldl' (flip $ BF.first . Chunk) (fromStrict x', fromStrict x'') xs
 
 

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -231,10 +231,10 @@ import qualified Data.ByteString        as P  (ByteString) -- type name only
 import qualified Data.ByteString        as S  -- S for strict (hmm...)
 import qualified Data.ByteString.Internal as S
 import qualified Data.ByteString.Unsafe as S
+import qualified Data.ByteString.Lazy.Internal.Deque as D
 import Data.ByteString.Lazy.Internal
 
 import Control.Monad            (mplus)
-import Data.Maybe               (listToMaybe)
 import Data.Word                (Word8)
 import Data.Int                 (Int64)
 import System.IO                (Handle,openBinaryFile,stdin,stdout,withBinaryFile,IOMode(..)
@@ -739,29 +739,41 @@ drop i cs0 = drop' i cs0
 -- @since 0.11.2.0
 dropEnd :: Int64 -> ByteString -> ByteString
 dropEnd i p | i <= 0 = p
-dropEnd i p = go [] [] 0 0 p
-  where go hss tss acc h (Chunk c cs)
-            | h >= acc - i  = go hss (c : tss) (acc + len c) h cs
-            | otherwise =
-              let (output, hss', tss', acc') = getOutput [] hss (c : tss) ( acc + len c)
-                in L.foldl (flip chunk) (go hss' tss' acc' (hLen hss') cs) output
-        go hss tss _ _ Empty = dropChunks (tss ++ L.reverse hss) (fromIntegral i)
+dropEnd i p = go D.empty p
+  where go deque (Chunk c cs)
+            | D.elemLength deque < i = go (D.snoc c deque) cs
+            | otherwise          =
+                  let (output, deque') = getOutput [] (D.snoc c deque)
+                    in L.foldl (flip chunk) (go deque' cs) output
+        go deque Empty           = dropElements deque (fromIntegral i)
 
         len c = fromIntegral (S.length c)
-        hLen cs = maybe 0 len (listToMaybe cs)
 
-        getOutput out [] [] acc = (out, [], [], acc)
-        getOutput out [] bss acc = getOutput out (L.reverse bss) [] acc
-        getOutput out (x:xs) bss acc =
-            if len x <= acc - i - len x
-               then getOutput (x:out) xs bss (acc - len x)
-               else (out, x:xs, bss, acc)
+        -- get all `S.ByteString` from the front of the accumulating deque
+        -- for which we know they won't be dropped
+        getOutput out deque =
+            case D.popFront deque of
+                 (Nothing, deque') -> (out, deque')
+                 (Just x, deque')  ->
+                    if len x <= D.elemLength deque' - i
+                       then getOutput (x:out) deque'
+                       else (out, deque)
 
-        dropChunks [] _ = Empty
-        dropChunks (c : cs) n =
-            case S.length c of
-                 l | l <= fromIntegral n -> dropChunks cs (fromIntegral n - l)
-                   | otherwise -> L.foldl' (flip chunk) Empty (S.dropEnd (fromIntegral n) c : cs)
+        -- drop n elements from the rear of the accumulating `deque`
+        dropElements deque n
+            | D.null deque = Empty
+            | otherwise    =
+                let (x, deque') = D.popRear deque
+                  in case x of
+                     Nothing              -> Empty
+                     Just x'| len x' <= n -> dropElements deque' (n - len x')
+                            | otherwise   ->
+                                fromDeque (D.snoc (S.dropEnd n x') deque')
+
+        -- build a lazy ByteString from an accumulating `deque`
+        fromDeque deque =
+            L.foldr chunk Empty (D.front deque) `append`
+            L.foldl' (flip chunk) Empty (D.rear deque)
 
 -- | /O(n\/c)/ 'splitAt' @n xs@ is equivalent to @('take' n xs, 'drop' n xs)@.
 splitAt :: Int64 -> ByteString -> (ByteString, ByteString)

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -808,8 +808,9 @@ takeWhile f = takeWhile'
 --
 -- @'takeWhileEnd' p@ is equivalent to @'reverse' . 'takeWhile' p . 'reverse'@.
 --
--- >>> takeWhileEnd even (Chunk (pack [1,2]) (Chunk (pack [3,4,6]) Empty))
--- Chunk (pack [4,6]) Empty
+-- >>> {-# LANGUAGE OverloadedLists #-)
+-- >>> takeWhileEnd even [1,2,3,4,6]
+-- [4,6]
 --
 -- @since 0.11.2.0
 takeWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString
@@ -840,8 +841,9 @@ dropWhile f = dropWhile'
 --
 -- @'dropWhileEnd' p@ is equivalent to @'reverse' . 'dropWhile' p . 'reverse'@.
 --
--- >>> dropWhileEnd even (Chunk (pack [1,2]) (Chunk (pack [3,4,6]) Empty))
--- Chunk (pack [1,2]) (Chunk [3] Empty)
+-- >>> {-# LANGUAGE OverloadedLists #-)
+-- >>> dropWhileEnd even [1,2,3,4,6]
+-- [1,2,3]
 --
 -- @since 0.11.2.0
 dropWhileEnd :: (Word8 -> Bool) -> ByteString -> ByteString

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -841,11 +841,11 @@ dropWhileEnd f = go []
   where go acc (Chunk c cs)
             | f (S.last c) = go (c : acc) cs
             | otherwise    = L.foldl (flip Chunk) (go [] cs) (c : acc)
-        go acc Empty       = dropAcc acc
-        dropAcc []         = Empty
-        dropAcc (x : xs)   =
+        go acc Empty       = dropElements acc
+        dropElements []         = Empty
+        dropElements (x : xs)   =
             case S.dropWhileEnd f x of
-                 x' | S.null x' -> dropAcc xs
+                 x' | S.null x' -> dropElements xs
                     | otherwise -> L.foldl' (flip Chunk) Empty (x' : xs)
 
 -- | Similar to 'P.break',
@@ -877,11 +877,11 @@ breakEnd  f = go []
   where go acc (Chunk c cs)
             | f (S.last c) = L.foldl (flip $ BF.first . Chunk) (go [] cs) (c : acc)
             | otherwise = go (c : acc) cs
-        go acc Empty = dropAcc acc
-        dropAcc [] = (Empty, Empty)
-        dropAcc (x : xs) =
+        go acc Empty = dropElements acc
+        dropElements [] = (Empty, Empty)
+        dropElements (x : xs) =
             case S.breakEnd f x of
-                 (x', x'') | S.null x' -> let (y, y') = dropAcc xs
+                 (x', x'') | S.null x' -> let (y, y') = dropElements xs
                                            in (y, y' `append` fromStrict x)
                            | otherwise ->
                                 L.foldl' (flip $ BF.first . Chunk) (fromStrict x', fromStrict x'') xs

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -742,7 +742,7 @@ dropEnd i p | i <= 0 = p
 dropEnd i p          = go D.empty p
   where go :: D.Deque -> ByteString -> ByteString
         go deque (Chunk c cs)
-            | D.elemLength deque < i = go (D.snoc c deque) cs
+            | D.byteLength deque < i = go (D.snoc c deque) cs
             | otherwise              =
                   let (output, deque') = getOutput empty (D.snoc c deque)
                     in foldrChunks Chunk (go deque' cs) output
@@ -755,7 +755,7 @@ dropEnd i p          = go D.empty p
         getOutput :: ByteString -> D.Deque -> (ByteString, D.Deque)
         getOutput out deque = case D.popFront deque of
             Nothing                       -> (reverseChunks out, deque)
-            Just (x, deque') | D.elemLength deque' >= i ->
+            Just (x, deque') | D.byteLength deque' >= i ->
                             getOutput (Chunk x out) deque'
             _ -> (reverseChunks out, deque)
 

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -467,7 +467,7 @@ takeWhile f = L.takeWhile (f . w2c)
 --
 -- @'takeWhileEnd' p@ is equivalent to @'reverse' . 'takeWhile' p . 'reverse'@.
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 takeWhileEnd :: (Char -> Bool) -> ByteString -> ByteString
 takeWhileEnd f = L.takeWhileEnd (f . w2c)
 {-# INLINE takeWhileEnd #-}
@@ -483,7 +483,7 @@ dropWhile f = L.dropWhile (f . w2c)
 --
 -- @'dropWhileEnd' p@ is equivalent to @'reverse' . 'dropWhile' p . 'reverse'@.
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 dropWhileEnd :: (Char -> Bool) -> ByteString -> ByteString
 dropWhileEnd f = L.dropWhileEnd (f . w2c)
 {-# INLINE dropWhileEnd #-}
@@ -497,7 +497,7 @@ break f = L.break (f . w2c)
 --
 -- breakEnd p == spanEnd (not.p)
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 breakEnd :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
 breakEnd f = L.breakEnd (f . w2c)
 {-# INLINE breakEnd #-}
@@ -519,7 +519,7 @@ span f = L.span (f . w2c)
 -- >    ==
 -- > let (x,y) = span (not.isSpace) (reverse ps) in (reverse y, reverse x)
 --
--- @since 0.11.1.1
+-- @since 0.11.2.0
 spanEnd :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
 spanEnd f = L.spanEnd (f . w2c)
 {-# INLINE spanEnd #-}

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -105,12 +105,18 @@ module Data.ByteString.Lazy.Char8 (
 
         -- ** Breaking strings
         take,
+        takeEnd,
         drop,
+        dropEnd,
         splitAt,
         takeWhile,
+        takeWhileEnd,
         dropWhile,
+        dropWhileEnd,
         span,
+        spanEnd,
         break,
+        breakEnd,
         group,
         groupBy,
         inits,
@@ -203,7 +209,7 @@ module Data.ByteString.Lazy.Char8 (
 import Data.ByteString.Lazy
         (fromChunks, toChunks
         ,empty,null,length,tail,init,append,reverse,transpose,cycle
-        ,concat,take,drop,splitAt,intercalate
+        ,concat,take,takeEnd,drop,dropEnd,splitAt,intercalate
         ,isPrefixOf,isSuffixOf,group,inits,tails,copy
         ,stripPrefix,stripSuffix
         ,hGetContents, hGet, hPut, getContents
@@ -456,21 +462,67 @@ takeWhile :: (Char -> Bool) -> ByteString -> ByteString
 takeWhile f = L.takeWhile (f . w2c)
 {-# INLINE takeWhile #-}
 
+-- | Returns the longest (possibly empty) suffix of elements
+-- satisfying the predicate.
+--
+-- @'takeWhileEnd' p@ is equivalent to @'reverse' . 'takeWhile' p . 'reverse'@.
+--
+-- @since 0.11.1.1
+takeWhileEnd :: (Char -> Bool) -> ByteString -> ByteString
+takeWhileEnd f = L.takeWhileEnd (f . w2c)
+{-# INLINE takeWhileEnd #-}
+
 -- | 'dropWhile' @p xs@ returns the suffix remaining after 'takeWhile' @p xs@.
 dropWhile :: (Char -> Bool) -> ByteString -> ByteString
 dropWhile f = L.dropWhile (f . w2c)
 {-# INLINE dropWhile #-}
+
+-- | Similar to 'P.dropWhileEnd',
+-- drops the longest (possibly empty) suffix of elements
+-- satisfying the predicate and returns the remainder.
+--
+-- @'dropWhileEnd' p@ is equivalent to @'reverse' . 'dropWhile' p . 'reverse'@.
+--
+-- @since 0.11.1.1
+dropWhileEnd :: (Char -> Bool) -> ByteString -> ByteString
+dropWhileEnd f = L.dropWhileEnd (f . w2c)
+{-# INLINE dropWhileEnd #-}
 
 -- | 'break' @p@ is equivalent to @'span' ('not' . p)@.
 break :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
 break f = L.break (f . w2c)
 {-# INLINE break #-}
 
+-- | 'breakEnd' behaves like 'break' but from the end of the 'ByteString'
+--
+-- breakEnd p == spanEnd (not.p)
+--
+-- @since 0.11.1.1
+breakEnd :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
+breakEnd f = L.breakEnd (f . w2c)
+{-# INLINE breakEnd #-}
+
 -- | 'span' @p xs@ breaks the ByteString into two segments. It is
 -- equivalent to @('takeWhile' p xs, 'dropWhile' p xs)@
 span :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
 span f = L.span (f . w2c)
 {-# INLINE span #-}
+
+-- | 'spanEnd' behaves like 'span' but from the end of the 'ByteString'.
+-- We have
+--
+-- > spanEnd (not.isSpace) "x y z" == ("x y ","z")
+--
+-- and
+--
+-- > spanEnd (not . isSpace) ps
+-- >    ==
+-- > let (x,y) = span (not.isSpace) (reverse ps) in (reverse y, reverse x)
+--
+-- @since 0.11.1.1
+spanEnd :: (Char -> Bool) -> ByteString -> (ByteString, ByteString)
+spanEnd f = L.spanEnd (f . w2c)
+{-# INLINE spanEnd #-}
 
 {-
 -- | 'breakChar' breaks its ByteString argument at the first occurence

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -1,3 +1,6 @@
+-- |
+-- A Deque used for accumulating `S.ByteString`s in the lazy
+-- version of `dropEnd`.
 module Data.ByteString.Lazy.Internal.Deque (
     Deque (..),
     empty,
@@ -18,7 +21,7 @@ data Deque = Deque
     { front :: [S.ByteString]
     , rear :: [S.ByteString]
     , -- | Accumulated length of deque's elements
-      elemLength :: Int64
+      elemLength :: !Int64
     }
 
 -- An empty Deque
@@ -55,8 +58,8 @@ popFront (Deque (x : xs) rs acc) = Just (x, Deque xs rs (acc - len x))
 -- Pop a `S.ByteString` from the rear of the `Deque`
 -- Returns the bytestring and the updated Deque, or Nothing if the Deque is empty
 -- O(1) , occasionally O(n)
-popRear :: Deque -> Maybe (S.ByteString, Deque)
+popRear :: Deque -> Maybe (Deque, S.ByteString)
 popRear (Deque fs [] acc) = case reverse fs of
     [] -> Nothing
-    x : xs -> Just (x, Deque [] xs (acc - len x))
-popRear (Deque fs (x : xs) acc) = Just (x, Deque fs xs (acc - len x))
+    x : xs -> Just (Deque [] xs (acc - len x),x)
+popRear (Deque fs (x : xs) acc) = Just (Deque fs xs (acc - len x),x)

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -1,0 +1,60 @@
+module Data.ByteString.Lazy.Internal.Deque (
+    Deque (..),
+    empty,
+    null,
+    cons,
+    snoc,
+    popFront,
+    popRear,
+) where
+
+import qualified Data.ByteString as S
+import Data.Int (Int64)
+import Prelude hiding (head, length, null)
+
+-- A `S.ByteString` Deque used as an accumulator for lazy
+-- Bytestring operations
+data Deque = Deque
+    { front :: [S.ByteString]
+    , rear :: [S.ByteString]
+    , -- | Accumulated length of deque's elements
+      elemLength :: Int64
+    }
+
+-- An empty Deque
+empty :: Deque
+empty = Deque [] [] 0
+
+-- Is the `Deque` empty?
+-- O(1)
+null :: Deque -> Bool
+null deque = elemLength deque == 0
+
+-- Add a `S.ByteString` to the front of the `Deque`
+-- O(1)
+cons :: S.ByteString -> Deque -> Deque
+cons x (Deque fs rs acc) = Deque (x : fs) rs (acc + len x)
+
+-- Add a `S.ByteString` to the rear of the `Deque`
+-- O(1)
+snoc :: S.ByteString -> Deque -> Deque
+snoc x (Deque fs rs acc) = Deque fs (x : rs) (acc + len x)
+
+len :: S.ByteString -> Int64
+len x = fromIntegral $ S.length x
+
+-- Pop a `S.ByteString` from the front of the `Deque`
+-- Returns the bytestring, or Nothing if the Deque is empty, and the updated Deque
+-- O(1) , occasionally O(n)
+popFront :: Deque -> (Maybe S.ByteString, Deque)
+popFront (Deque [] [] _) = (Nothing, empty)
+popFront (Deque [] rs acc) = popFront (Deque (reverse rs) [] acc)
+popFront (Deque (x : xs) rs acc) = (Just x, Deque xs rs (acc - len x))
+
+-- Pop a `S.ByteString` from the rear of the `Deque`
+-- Returns the bytestring, or Nothing if the Deque is empty, and the updated Deque
+-- O(1) , occasionally O(n)
+popRear :: Deque -> (Maybe S.ByteString, Deque)
+popRear (Deque [] [] _) = (Nothing, empty)
+popRear (Deque fs [] acc) = popRear (Deque [] (reverse fs) acc)
+popRear (Deque fs (x : xs) acc) = (Just x, Deque fs xs (acc - len x))

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -20,8 +20,8 @@ import Prelude hiding (head, length, null)
 data Deque = Deque
     { front :: [S.ByteString]
     , rear :: [S.ByteString]
-    , -- | Accumulated length of deque's elements
-      elemLength :: !Int64
+    , -- | Total length in bytes
+      byteLength :: !Int64
     }
 
 -- An empty Deque

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -1,6 +1,7 @@
--- |
--- A Deque used for accumulating `S.ByteString`s in the lazy
--- version of `dropEnd`.
+{- |
+ A Deque used for accumulating `S.ByteString`s in the lazy
+ version of `dropEnd`.
+-}
 module Data.ByteString.Lazy.Internal.Deque (
     Deque (..),
     empty,
@@ -31,7 +32,7 @@ empty = Deque [] [] 0
 -- Is the `Deque` empty?
 -- O(1)
 null :: Deque -> Bool
-null deque = elemLength deque == 0
+null deque = byteLength deque == 0
 
 -- Add a `S.ByteString` to the front of the `Deque`
 -- O(1)
@@ -61,5 +62,5 @@ popFront (Deque (x : xs) rs acc) = Just (x, Deque xs rs (acc - len x))
 popRear :: Deque -> Maybe (Deque, S.ByteString)
 popRear (Deque fs [] acc) = case reverse fs of
     [] -> Nothing
-    x : xs -> Just (Deque [] xs (acc - len x),x)
-popRear (Deque fs (x : xs) acc) = Just (Deque fs xs (acc - len x),x)
+    x : xs -> Just (Deque [] xs (acc - len x), x)
+popRear (Deque fs (x : xs) acc) = Just (Deque fs xs (acc - len x), x)

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -44,17 +44,19 @@ len :: S.ByteString -> Int64
 len x = fromIntegral $ S.length x
 
 -- Pop a `S.ByteString` from the front of the `Deque`
--- Returns the bytestring, or Nothing if the Deque is empty, and the updated Deque
+-- Returns the bytestring and the updated Deque, or Nothing if the Deque is empty
 -- O(1) , occasionally O(n)
-popFront :: Deque -> (Maybe S.ByteString, Deque)
-popFront (Deque [] [] _) = (Nothing, empty)
-popFront (Deque [] rs acc) = popFront (Deque (reverse rs) [] acc)
-popFront (Deque (x : xs) rs acc) = (Just x, Deque xs rs (acc - len x))
+popFront :: Deque -> Maybe (S.ByteString, Deque)
+popFront (Deque [] rs acc) = case reverse rs of
+    [] -> Nothing
+    x : xs -> Just (x, Deque xs [] (acc - len x))
+popFront (Deque (x : xs) rs acc) = Just (x, Deque xs rs (acc - len x))
 
 -- Pop a `S.ByteString` from the rear of the `Deque`
--- Returns the bytestring, or Nothing if the Deque is empty, and the updated Deque
+-- Returns the bytestring and the updated Deque, or Nothing if the Deque is empty
 -- O(1) , occasionally O(n)
-popRear :: Deque -> (Maybe S.ByteString, Deque)
-popRear (Deque [] [] _) = (Nothing, empty)
-popRear (Deque fs [] acc) = popRear (Deque [] (reverse fs) acc)
-popRear (Deque fs (x : xs) acc) = (Just x, Deque fs xs (acc - len x))
+popRear :: Deque -> Maybe (S.ByteString, Deque)
+popRear (Deque fs [] acc) = case reverse fs of
+    [] -> Nothing
+    x : xs -> Just (x, Deque [] xs (acc - len x))
+popRear (Deque fs (x : xs) acc) = Just (x, Deque fs xs (acc - len x))

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -90,6 +90,7 @@ library
                      Data.ByteString.Builder.Internal
                      Data.ByteString.Builder.Prim.Internal
   other-modules:     Data.ByteString.Builder.ASCII
+                     Data.ByteString.Lazy.Internal.Deque
                      Data.ByteString.Builder.Prim.ASCII
                      Data.ByteString.Builder.Prim.Binary
                      Data.ByteString.Builder.Prim.Internal.Base16

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -90,11 +90,11 @@ library
                      Data.ByteString.Builder.Internal
                      Data.ByteString.Builder.Prim.Internal
   other-modules:     Data.ByteString.Builder.ASCII
-                     Data.ByteString.Lazy.Internal.Deque
                      Data.ByteString.Builder.Prim.ASCII
                      Data.ByteString.Builder.Prim.Binary
                      Data.ByteString.Builder.Prim.Internal.Base16
                      Data.ByteString.Builder.Prim.Internal.Floating
+                     Data.ByteString.Lazy.Internal.Deque
 
   default-language:  Haskell2010
   other-extensions:  CPP,

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -277,6 +277,8 @@ tests =
     \x (toElem -> c) -> B.compareLength (B.snoc x c <> undefined) (B.length x) === GT
   , testProperty "compareLength 5" $
     \x n -> B.compareLength x n === compare (B.length x) n
+  , testProperty "dropWhileEnd lazy" $
+    \(toElem -> c) -> B.take 1 (B.dropWhileEnd (const False) (B.singleton c <> undefined)) === B.singleton c
 #endif
 
   , testProperty "length" $

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -277,6 +277,8 @@ tests =
     \x (toElem -> c) -> B.compareLength (B.snoc x c <> undefined) (B.length x) === GT
   , testProperty "compareLength 5" $
     \x n -> B.compareLength x n === compare (B.length x) n
+  , testProperty "dropEnd lazy" $
+    \(toElem -> c) -> B.take 1 (B.dropEnd 1 (B.singleton c <> B.singleton c <> undefined)) === B.singleton c
   , testProperty "dropWhileEnd lazy" $
     \(toElem -> c) -> B.take 1 (B.dropWhileEnd (const False) (B.singleton c <> undefined)) === B.singleton c
   , testProperty "breakEnd lazy" $

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -177,11 +177,12 @@ tests =
     \(toElem -> c) x -> (B.unpack *** B.unpack) (B.break (/= c) x) === break (/= c) (B.unpack x)
   , testProperty "break span" $
     \f x -> B.break f x === B.span (not . f) x
-#ifndef BYTESTRING_LAZY
   , testProperty "breakEnd" $
     \f x -> B.breakEnd f x === swap ((B.reverse *** B.reverse) (B.break f (B.reverse x)))
   , testProperty "breakEnd" $
     \f x -> B.breakEnd f x === B.spanEnd (not . f) x
+
+#ifndef BYTESTRING_LAZY
   , testProperty "break breakSubstring" $
     \(toElem -> c) x -> B.break (== c) x === B.breakSubstring (B.singleton c) x
   , testProperty "breakSubstring" $
@@ -248,7 +249,6 @@ tests =
     \x -> B.unpack (B.takeWhile isSpace x) === takeWhile isSpace (B.unpack x)
 #endif
 
-#ifndef BYTESTRING_LAZY
   , testProperty "dropEnd" $
     \n x -> B.dropEnd n x === B.take (B.length x - n) x
   , testProperty "dropWhileEnd" $
@@ -257,7 +257,6 @@ tests =
     \n x -> B.takeEnd n x === B.drop (B.length x - n) x
   , testProperty "takeWhileEnd" $
     \f x -> B.takeWhileEnd f x === B.reverse (B.takeWhile f (B.reverse x))
-#endif
 
 #ifdef BYTESTRING_LAZY
   , testProperty "invariant" $
@@ -350,10 +349,8 @@ tests =
     \(toElem -> c) x -> (B.unpack *** B.unpack) (B.span (== c) x) === span (== c) (B.unpack x)
   , testProperty "span /=" $
     \(toElem -> c) x -> (B.unpack *** B.unpack) (B.span (/= c) x) === span (/= c) (B.unpack x)
-#ifndef BYTESTRING_LAZY
   , testProperty "spanEnd" $
     \f x -> B.spanEnd f x === swap ((B.reverse *** B.reverse) (B.span f (B.reverse x)))
-#endif
   , testProperty "split" $
     \(toElem -> c) x -> map B.unpack (B.split c x) === split c (B.unpack x)
   , testProperty "split empty" $

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -279,6 +279,10 @@ tests =
     \x n -> B.compareLength x n === compare (B.length x) n
   , testProperty "dropWhileEnd lazy" $
     \(toElem -> c) -> B.take 1 (B.dropWhileEnd (const False) (B.singleton c <> undefined)) === B.singleton c
+  , testProperty "breakEnd lazy" $
+    \(toElem -> c) -> B.take 1 (fst $ B.breakEnd (const True) (B.singleton c <> undefined)) === B.singleton c
+  , testProperty "spanEnd lazy" $
+    \(toElem -> c) -> B.take 1 (fst $ B.spanEnd (const False) (B.singleton c <> undefined)) === B.singleton c
 #endif
 
   , testProperty "length" $

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -278,7 +278,7 @@ tests =
   , testProperty "compareLength 5" $
     \x n -> B.compareLength x n === compare (B.length x) n
   , testProperty "dropEnd lazy" $
-    \(toElem -> c) -> B.take 1 (B.dropEnd 1 (B.singleton c <> B.singleton c <> undefined)) === B.singleton c
+    \(toElem -> c) -> B.take 1 (B.dropEnd 1 (B.singleton c <> B.singleton c <> B.singleton c <> undefined)) === B.singleton c
   , testProperty "dropWhileEnd lazy" $
     \(toElem -> c) -> B.take 1 (B.dropWhileEnd (const False) (B.singleton c <> undefined)) === B.singleton c
   , testProperty "breakEnd lazy" $


### PR DESCRIPTION
Fixes #306.
Utilizes an eager strategy as described in the original issue. Chunks
are eagerly evaluated but the overall structure and pointers are kept
intact.