### PR TITLE
Remove upper bound on dlist (outdated)

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -156,7 +156,7 @@ test-suite test-builder
                     Data.ByteString.Builder.Tests
   build-depends:    base, bytestring, ghc-prim,
                     deepseq,
-                    dlist                      >= 0.5 && < 0.9,
+                    dlist                      >= 0.5,
                     transformers               >= 0.3,
                     tasty,
                     tasty-hunit,


### PR DESCRIPTION
Remove upper bound on `dlist` (outdated).

The predominant style seems to not have bounds, so I removed the upper bound rather than replacing it by < 1.1.
(Maintainers: check whether this is indeed within the spirit of this package.)

Build with the latest `dlist`, dlist-1.0.  The changes in dlist-1.0 (removal of eliminator `list`, change of `tail`) do not affect the use of dlist in `bytestring`, namely in the `test-builder` test-suite.