### PR TITLE
Fix detection of endianness in test suite

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -160,8 +160,6 @@ test-suite test-builder
                     tasty,
                     tasty-hunit,
                     tasty-quickcheck
-  if impl(ghc < 8.4)
-    build-depends:  ghc-byteorder
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
   default-language: Haskell2010
 


### PR DESCRIPTION
Tested with 

```sh
apt install -y docker.io
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
docker run --rm -i -t s390x/ubuntu
```

and then in s390x virtual machine:

```sh
apt update
apt install -y ghc cabal-install git
git clone https://github.com/haskell/bytestring
cd bytestring/
cabal new-update
cabal -j1 new-test test:test-builder
```

In an emulated environment it takes three hours to build, so at some point it appeared faster to scrap `dlist` dependency than build it :)