### PR TITLE
Remove Ubuntu 16.04 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
           ghc: 'latest'
         - os: macOS-latest
           ghc: 'latest'
-        - os: ubuntu-16.04 # testing that cbits are compatible with gcc-5
-          ghc: 'latest'
     steps:
     - uses: actions/checkout@v2
     - uses: haskell/actions/setup@v1


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners, Ubuntu 16.04 runner is no longer provided.