### PR TITLE
Add GHC 9.2 RC1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2.0.20210821']
         include:
         - os: windows-latest
           ghc: 'latest'
@@ -49,6 +49,8 @@ jobs:
         cabal sdist -z -o .
         cabal get bytestring-*.tar.gz
         cd bytestring-*/
+        echo packages:. > cabal.project
+        echo allow-newer:splitmix:base >> cabal.project
         bld() { cabal build bytestring:tests --enable-tests --enable-benchmarks; }
         bld || bld || bld
         cabal test --enable-tests --enable-benchmarks --test-show-details=direct all -j1
@@ -57,4 +59,6 @@ jobs:
         cd bytestring-*/
         cabal bench --enable-tests --enable-benchmarks --benchmark-option=-l all
     - name: Haddock
-      run: cabal haddock
+      run: |
+        cd bytestring-*/
+        cabal haddock


### PR DESCRIPTION
It appears #365 is not compatible with an upcoming GHC 9.2. It would be better to learn it earlier, so adding a CI configuration.