### PR TITLE
Do not depend on tasty-hunit in tests

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -171,7 +171,6 @@ test-suite test-builder
                     deepseq,
                     transformers               >= 0.3,
                     tasty,
-                    tasty-hunit,
                     tasty-quickcheck
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
   default-language: Haskell2010
@@ -181,7 +180,7 @@ test-suite bytestring-th
   hs-source-dirs:   tests
   main-is:          bytestring-th.hs
   other-extensions: TemplateHaskell
-  build-depends:    base, bytestring, template-haskell, tasty, tasty-hunit
+  build-depends:    base, bytestring, template-haskell, tasty, tasty-quickcheck
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
   default-language: Haskell2010
 
@@ -192,7 +191,6 @@ test-suite is-valid-utf8
   build-depends:    base, 
                     bytestring, 
                     tasty, 
-                    tasty-hunit,
                     tasty-quickcheck, 
                     QuickCheck
   ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts

--- a/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
@@ -82,7 +82,6 @@ import           Numeric (showHex)
 import           System.IO.Unsafe (unsafePerformIO)
 
 import           Test.Tasty
-import           Test.Tasty.HUnit (assertBool, testCase)
 import           Test.Tasty.QuickCheck (Arbitrary(..), testProperty)
 
 #include <ghcautoconf.h>
@@ -96,8 +95,8 @@ testBoundedProperty :: forall a. (Arbitrary a, Show a, Bounded a)
                     => String -> (a -> Bool) -> TestTree
 testBoundedProperty name p = testGroup name
   [ testProperty name p
-  , testCase (name ++ " minBound") $ assertBool "minBound" (p (minBound :: a))
-  , testCase (name ++ " maxBound") $ assertBool "minBound" (p (maxBound :: a))
+  , testProperty (name ++ " minBound") (p (minBound :: a))
+  , testProperty (name ++ " maxBound") (p (maxBound :: a))
   ]
 
 -- | Quote a 'String' nicely.

--- a/tests/bytestring-th.hs
+++ b/tests/bytestring-th.hs
@@ -4,7 +4,7 @@
 module Main (main) where
 
 import           Test.Tasty (defaultMain, testGroup)
-import           Test.Tasty.HUnit (testCase, (@=?))
+import           Test.Tasty.QuickCheck (testProperty, (===))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
@@ -13,71 +13,50 @@ import qualified Language.Haskell.TH.Syntax as TH
 main :: IO ()
 main = defaultMain $ testGroup "bytestring-th"
   [ testGroup "strict"
-    [ testCase "normal" $ do
-        let bs :: BS.ByteString
-            bs = "foobar"
+    [ testProperty "normal" $
+        let bs = "foobar" :: BS.ByteString in
+        bs === $(TH.lift $ BS.pack [102,111,111,98,97,114])
 
-        bs @=? $(TH.lift $ BS.pack [102,111,111,98,97,114])
-
-    , testCase "binary" $ do
-        let bs :: BS.ByteString
-            bs = "\0\1\2\3\0\1\2\3"
-
-        bs @=? $(TH.lift $ BS.pack [0,1,2,3,0,1,2,3])
+    , testProperty "binary" $
+        let bs = "\0\1\2\3\0\1\2\3" :: BS.ByteString in
+        bs === $(TH.lift $ BS.pack [0,1,2,3,0,1,2,3])
 
 #if MIN_VERSION_template_haskell(2,16,0)
-    , testCase "typed" $ do
-        let bs :: BS.ByteString
-            bs = "\0\1\2\3\0\1\2\3"
-
-        bs @=? $$(TH.liftTyped $ BS.pack [0,1,2,3,0,1,2,3])
+    , testProperty "typed" $
+        let bs = "\0\1\2\3\0\1\2\3" :: BS.ByteString in
+        bs === $$(TH.liftTyped $ BS.pack [0,1,2,3,0,1,2,3])
 #endif
     ]
 
   , testGroup "lazy"
-    [ testCase "normal" $ do
-        let bs :: LBS.ByteString
-            bs = "foobar"
+    [ testProperty "normal" $
+        let bs = "foobar" :: LBS.ByteString in
+        bs === $(TH.lift $ LBS.pack [102,111,111,98,97,114])
 
-        bs @=? $(TH.lift $ LBS.pack [102,111,111,98,97,114])
-
-    , testCase "binary" $ do
-        let bs :: LBS.ByteString
-            bs = "\0\1\2\3\0\1\2\3"
-
-        -- print $ LBS.unpack bs
-        -- print $ LBS.unpack $(TH.lift $ LBS.pack [0,1,2,3,0,1,2,3])
-
-        bs @=? $(TH.lift $ LBS.pack [0,1,2,3,0,1,2,3])
+    , testProperty "binary" $
+        let bs = "\0\1\2\3\0\1\2\3" :: LBS.ByteString in
+        bs === $(TH.lift $ LBS.pack [0,1,2,3,0,1,2,3])
 
 #if MIN_VERSION_template_haskell(2,16,0)
-    , testCase "typed" $ do
-        let bs :: LBS.ByteString
-            bs = "\0\1\2\3\0\1\2\3"
-
-        bs @=? $$(TH.liftTyped $ LBS.pack [0,1,2,3,0,1,2,3])
+    , testProperty "typed" $
+        let bs = "\0\1\2\3\0\1\2\3" :: LBS.ByteString in
+        bs === $$(TH.liftTyped $ LBS.pack [0,1,2,3,0,1,2,3])
 #endif
     ]
 
   , testGroup "short"
-    [ testCase "normal" $ do
-        let bs :: SBS.ShortByteString
-            bs = "foobar"
+    [ testProperty "normal" $
+        let bs = "foobar" :: SBS.ShortByteString in
+        bs === $(TH.lift $ SBS.pack [102,111,111,98,97,114])
 
-        bs @=? $(TH.lift $ SBS.pack [102,111,111,98,97,114])
-
-    , testCase "binary" $ do
-        let bs :: SBS.ShortByteString
-            bs = "\0\1\2\3\0\1\2\3"
-
-        bs @=? $(TH.lift $ SBS.pack [0,1,2,3,0,1,2,3])
+    , testProperty "binary" $
+        let bs = "\0\1\2\3\0\1\2\3" :: SBS.ShortByteString in
+        bs === $(TH.lift $ SBS.pack [0,1,2,3,0,1,2,3])
 
 #if MIN_VERSION_template_haskell(2,16,0)
-    , testCase "typed" $ do
-        let bs :: SBS.ShortByteString
-            bs = "\0\1\2\3\0\1\2\3"
-
-        bs @=? $$(TH.liftTyped $ SBS.pack [0,1,2,3,0,1,2,3])
+    , testProperty "typed" $
+        let bs = "\0\1\2\3\0\1\2\3" :: SBS.ShortByteString in
+        bs === $$(TH.liftTyped $ SBS.pack [0,1,2,3,0,1,2,3])
 #endif
     ]
   ]

--- a/tests/is-valid-utf8/Main.hs
+++ b/tests/is-valid-utf8/Main.hs
@@ -13,7 +13,6 @@ import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary, shrink))
 import Test.QuickCheck.Gen (oneof, Gen, choose, vectorOf, listOf1, sized, resize,
                             elements)
 import Test.Tasty (defaultMain, testGroup, adjustOption, TestTree)
-import Test.Tasty.HUnit (testCase, assertBool)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckTests)
 
 main :: IO ()
@@ -34,15 +33,12 @@ main = defaultMain . testGroup "UTF-8 validation" $ [
 
 checkRegressions :: [TestTree]
 checkRegressions = [
-  testCase "Too high code point" go
+  testProperty "Too high code point" $ not $ B.isValidUtf8 tooHigh
   ]
   where
-    go :: IO ()
-    go = assertBool "\\244\\176\\181\\139 is too high to be valid" .
-         not . B.isValidUtf8 $ tooHigh
     tooHigh :: ByteString
     tooHigh = fromList $ replicate 56 48 ++ -- 56 ASCII zeroes
-                         [244, 176, 181, 139] ++ -- our invalid sequence
+                         [244, 176, 181, 139] ++ -- our invalid sequence too high to be valid
                          (take 68 . cycle $ [194, 162]) -- 68 cent symbols
 
 -- Helpers


### PR DESCRIPTION
Similar to #420, we can shave a dependency (in fact two: `tasty-hunit` + `call-stack`) to speed up builds a tiny bit. I'm experimenting with `bytestring` under an emulated s390x machine, and every little helps.