### PR TITLE
Combine all tests into a unified test suite

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -134,66 +134,35 @@ library
   includes:          fpstring.h
   install-includes:  fpstring.h
 
-test-suite prop-compiled
+test-suite bytestring-tests
   type:             exitcode-stdio-1.0
-  main-is:          Properties.hs
-  other-modules:    QuickCheckUtils
+  main-is:          Main.hs
+  other-modules:    Builder
+                    Data.ByteString.Builder.Prim.TestUtils
+                    Data.ByteString.Builder.Prim.Tests
+                    Data.ByteString.Builder.Tests
+                    IsValidUtf8
+                    LazyHClose
+                    Lift
+                    Properties
                     Properties.ByteString
                     Properties.ByteStringChar8
                     Properties.ByteStringLazy
                     Properties.ByteStringLazyChar8
-  hs-source-dirs:   tests
-  include-dirs:     tests/Properties
-  build-depends:    base, bytestring, ghc-prim, deepseq,
-                    tasty, tasty-quickcheck
-  ghc-options:      -fwarn-unused-binds
-                    -threaded -rtsopts
-  default-language: Haskell2010
-
-test-suite lazy-hclose
-  type:             exitcode-stdio-1.0
-  main-is:          LazyHClose.hs
-  hs-source-dirs:   tests
-  build-depends:    base, bytestring, ghc-prim, deepseq,
-                    tasty, tasty-quickcheck
-  ghc-options:      -fwarn-unused-binds
-                    -threaded -rtsopts
-  default-language: Haskell2010
-
-test-suite test-builder
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   tests/builder
-  main-is:          TestSuite.hs
-  other-modules:    Data.ByteString.Builder.Prim.TestUtils
-                    Data.ByteString.Builder.Prim.Tests
-                    Data.ByteString.Builder.Tests
-  build-depends:    base, bytestring, ghc-prim,
+                    QuickCheckUtils
+  hs-source-dirs:   tests,
+                    tests/builder
+  build-depends:    base,
+                    bytestring,
                     deepseq,
-                    transformers               >= 0.3,
+                    ghc-prim,
+                    QuickCheck,
                     tasty,
-                    tasty-quickcheck
-  ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
-  default-language: Haskell2010
-
-test-suite bytestring-th
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   tests
-  main-is:          bytestring-th.hs
-  other-extensions: TemplateHaskell
-  build-depends:    base, bytestring, template-haskell, tasty, tasty-quickcheck
-  ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
-  default-language: Haskell2010
-
-test-suite is-valid-utf8
-  type:             exitcode-stdio-1.0
-  hs-source-dirs:   tests/is-valid-utf8
-  main-is:          Main.hs
-  build-depends:    base, 
-                    bytestring, 
-                    tasty, 
-                    tasty-quickcheck, 
-                    QuickCheck
-  ghc-options:      -Wall -fwarn-tabs -threaded -rtsopts
+                    tasty-quickcheck,
+                    template-haskell,
+                    transformers >= 0.3
+  ghc-options:      -fwarn-unused-binds
+                    -threaded -rtsopts
   default-language: Haskell2010
 
 benchmark bytestring-bench

--- a/tests/Builder.hs
+++ b/tests/Builder.hs
@@ -1,14 +1,11 @@
-module Main where
+module Builder (testSuite) where
 
 import qualified Data.ByteString.Builder.Tests
 import qualified Data.ByteString.Builder.Prim.Tests
-import           Test.Tasty (defaultMain, TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 
-main :: IO ()
-main = defaultMain $ testGroup "All" tests
-
-tests :: [TestTree]
-tests =
+testSuite :: TestTree
+testSuite = testGroup "Builder"
   [ testGroup "Data.ByteString.Builder"
        Data.ByteString.Builder.Tests.tests
 

--- a/tests/IsValidUtf8.hs
+++ b/tests/IsValidUtf8.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Main (main) where
+module IsValidUtf8 (testSuite) where
 
 import Data.Bits (shiftR, (.&.), shiftL)
 import Data.ByteString (ByteString)
@@ -12,11 +12,11 @@ import Test.QuickCheck (Property, forAll, (===))
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary, shrink))
 import Test.QuickCheck.Gen (oneof, Gen, choose, vectorOf, listOf1, sized, resize,
                             elements)
-import Test.Tasty (defaultMain, testGroup, adjustOption, TestTree)
+import Test.Tasty (testGroup, adjustOption, TestTree)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckTests)
 
-main :: IO ()
-main = defaultMain . testGroup "UTF-8 validation" $ [
+testSuite :: TestTree
+testSuite = testGroup "UTF-8 validation" $ [
   adjustOption (max testCount) . testProperty "Valid UTF-8" $ goValid,
   adjustOption (max testCount) . testProperty "Invalid UTF-8" $ goInvalid,
   testGroup "Regressions" checkRegressions

--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -1,4 +1,4 @@
-module Main (main) where
+module LazyHClose (testSuite) where
 
 import Control.Monad (void, forM_)
 import Data.ByteString.Internal (toForeignPtr)
@@ -6,7 +6,7 @@ import Foreign.C.String (withCString)
 import Foreign.ForeignPtr (finalizeForeignPtr)
 import System.IO (openFile, openTempFile, hClose, hPutStrLn, IOMode(..))
 import System.Posix.Internals (c_unlink)
-import Test.Tasty (defaultMain, testGroup, withResource)
+import Test.Tasty (TestTree, testGroup, withResource)
 import Test.Tasty.QuickCheck (testProperty, ioProperty)
 
 import qualified Data.ByteString            as S
@@ -17,8 +17,8 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 n :: Int
 n = 1000
 
-main :: IO ()
-main = defaultMain $ withResource
+testSuite :: TestTree
+testSuite = withResource
   (do (fn, h) <- openTempFile "." "lazy-hclose-test.tmp"; hPutStrLn h "x"; hClose h; pure fn)
   removeFile $ \fn' ->
     testGroup "LazyHClose"

--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -6,59 +6,59 @@ import Foreign.C.String (withCString)
 import Foreign.ForeignPtr (finalizeForeignPtr)
 import System.IO (openFile, openTempFile, hClose, hPutStrLn, IOMode(..))
 import System.Posix.Internals (c_unlink)
+import Test.Tasty (defaultMain, testGroup, withResource)
+import Test.Tasty.QuickCheck (testProperty, ioProperty)
 
 import qualified Data.ByteString            as S
 import qualified Data.ByteString.Char8      as S8
 import qualified Data.ByteString.Lazy       as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 
+n :: Int
+n = 1000
+
 main :: IO ()
-main = do
-    let n = 1000
-    (fn, h) <- openTempFile "." "lazy-hclose-test.tmp"
-    hPutStrLn h "x"
-    hClose h
+main = defaultMain $ withResource
+  (do (fn, h) <- openTempFile "." "lazy-hclose-test.tmp"; hPutStrLn h "x"; hClose h; pure fn)
+  removeFile $ \fn' ->
+    testGroup "LazyHClose"
+    [ testProperty "Testing resource leaks for Strict.readFile" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        r <- S.readFile fn
+        appendFile fn "" -- will fail, if fn has not been closed yet
 
-    ------------------------------------------------------------------------
-    -- readFile tests
+    , testProperty "Testing resource leaks for Lazy.readFile" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        r <- L.readFile fn
+        L.length r `seq` return ()
+        appendFile fn "" -- will fail, if fn has not been closed yet
 
-    putStrLn "Testing resource leaks for Strict.readFile"
-    forM_ [1..n] $ const $ do
-         r <- S.readFile fn
-         appendFile fn "" -- will fail, if fn has not been closed yet
+    , testProperty "Testing resource leaks when converting lazy to strict" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        let release c = finalizeForeignPtr fp where (fp,_,_) = toForeignPtr c
+        r <- L.readFile fn
+        mapM_ release (L.toChunks r)
+        appendFile fn "" -- will fail, if fn has not been closed yet
 
-    putStrLn "Testing resource leaks for Lazy.readFile"
-    forM_ [1..n] $ const $ do
-         r <- L.readFile fn
-         L.length r `seq` return ()
-         appendFile fn "" -- will fail, if fn has not been closed yet
+    , testProperty "Testing strict hGetContents" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        h <- openFile fn ReadMode
+        r <- S.hGetContents h
+        S.last r `seq` return ()
+        appendFile fn "" -- will fail, if fn has not been closed yet
 
-    -- manage the resources explicitly.
-    putStrLn "Testing resource leaks when converting lazy to strict"
-    forM_ [1..n] $ const $ do
-         let release c = finalizeForeignPtr fp where (fp,_,_) = toForeignPtr c
-         r <- L.readFile fn
-         mapM_ release (L.toChunks r)
-         appendFile fn "" -- will fail, if fn has not been closed yet
-
-    ------------------------------------------------------------------------
-    -- hGetContents tests
-
-    putStrLn "Testing strict hGetContents"
-    forM_ [1..n] $ const $ do
-         h <- openFile fn ReadMode
-         r <- S.hGetContents h
-         S.last r `seq` return ()
-         appendFile fn "" -- will fail, if fn has not been closed yet
-
-    putStrLn "Testing lazy hGetContents"
-    forM_ [1..n] $ const $ do
-         h <- openFile fn ReadMode
-         r <- L.hGetContents h
-         L.last r `seq` return ()
-         appendFile fn "" -- will fail, if fn has not been closed yet
-
-    removeFile fn
+    , testProperty "Testing lazy hGetContents" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        h <- openFile fn ReadMode
+        r <- L.hGetContents h
+        L.last r `seq` return ()
+        appendFile fn "" -- will fail, if fn has not been closed yet
+    ]
 
 removeFile :: String -> IO ()
 removeFile fn = void $ withCString fn c_unlink

--- a/tests/Lift.hs
+++ b/tests/Lift.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Main (main) where
+module Lift (testSuite) where
 
-import           Test.Tasty (defaultMain, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty, (===))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
 import qualified Language.Haskell.TH.Syntax as TH
 
-main :: IO ()
-main = defaultMain $ testGroup "bytestring-th"
+testSuite :: TestTree
+testSuite = testGroup "Lift"
   [ testGroup "strict"
     [ testProperty "normal" $
         let bs = "foobar" :: BS.ByteString in

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,0 +1,18 @@
+module Main (main) where
+
+import Test.Tasty
+
+import qualified Builder
+import qualified IsValidUtf8
+import qualified LazyHClose
+import qualified Lift
+import qualified Properties
+
+main :: IO ()
+main = defaultMain $ testGroup "All"
+  [ Builder.testSuite
+  , IsValidUtf8.testSuite
+  , LazyHClose.testSuite
+  , Lift.testSuite
+  , Properties.testSuite
+  ]

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 
+module Properties (testSuite) where
+
 import Foreign.C.String (withCString)
 import Foreign.Storable
 import Foreign.ForeignPtr
@@ -472,8 +474,8 @@ explosiveTail = (`L.append` error "Tail of this byte string is undefined!")
 ------------------------------------------------------------------------
 -- The entry point
 
-main :: IO ()
-main = defaultMain $ testGroup "All"
+testSuite :: TestTree
+testSuite = testGroup "Properties"
   [ testGroup "StrictWord8" PropBS.tests
   , testGroup "StrictChar8" PropBS8.tests
   , testGroup "LazyWord8"   PropBL.tests


### PR DESCRIPTION
So that we link only one executable. Besides being more manageable, it should also hopefully alleviate Windows linking issues.

I left `tests/builder` folder in place to avoid conflicts with #365.