### PR TITLE
Implement `readNatural` plus `readInt` and `readWord` for 8, 16, 32, 64 bit and native machine bit sizes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 [0.12.0.0] — Unreleased
 
+* [New sized and/or unsigned variants of `readInt` and `readInteger`](https://github.com/haskell/bytestring/pull/438)
 * [`readInt` returns `Nothing`, if the sequence of digits cannot be represented by an `Int`, instead of overflowing silently](https://github.com/haskell/bytestring/pull/309)
 * [Remove `zipWith` rewrite rule](https://github.com/haskell/bytestring/pull/387)
 

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -92,13 +92,7 @@ module Data.ByteString.Internal (
 
         -- * Exported compatibility shim
         plusForeignPtr,
-        unsafeWithForeignPtr,
-
-        -- * Internal constants
-        intmaxQuot10,
-        intmaxRem10,
-        intminQuot10,
-        intminRem10
+        unsafeWithForeignPtr
   ) where
 
 import Prelude hiding (concat, null)
@@ -785,22 +779,6 @@ isSpaceChar8 = isSpaceWord8 . c2w
 
 overflowError :: String -> a
 overflowError fun = error $ "Data.ByteString." ++ fun ++ ": size overflow"
-
--- | Bounds for Word# multiplication by 10 without overflow, and
--- absolute values of Int bounds.
-intmaxWord, intminWord, intmaxQuot10, intmaxRem10, intminQuot10, intminRem10 :: Word
-intmaxWord = fromIntegral (maxBound :: Int)
-{-# INLINE intmaxWord #-}
-intminWord = fromIntegral (negate (minBound :: Int))
-{-# INLINE intminWord #-}
-intmaxQuot10 = intmaxWord `quot` 10
-{-# INLINE intmaxQuot10 #-}
-intmaxRem10 = intmaxWord `rem` 10
-{-# INLINE intmaxRem10 #-}
-intminQuot10 = intminWord `quot` 10
-{-# INLINE intminQuot10 #-}
-intminRem10 = intminWord `rem` 10
-{-# INLINE intminRem10 #-}
 
 ------------------------------------------------------------------------
 

--- a/Data/ByteString/Lazy/ReadInt.hs
+++ b/Data/ByteString/Lazy/ReadInt.hs
@@ -1,0 +1,264 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- This file is also included by "Data.ByteString.ReadInt", after defining
+-- "BYTESTRING_STRICT".  The two modules share much of their code, but
+-- the lazy version adds an outer loop over the chunks.
+
+#ifdef BYTESTRING_STRICT
+module Data.ByteString.ReadInt
+#else
+module Data.ByteString.Lazy.ReadInt
+#endif
+    ( readInt
+    , readInt8
+    , readInt16
+    , readInt32
+    , readWord
+    , readWord8
+    , readWord16
+    , readWord32
+    , readInt64
+    , readWord64
+    ) where
+
+import qualified Data.ByteString.Internal as BI
+#ifdef BYTESTRING_STRICT
+import Data.ByteString
+#else
+import Data.ByteString.Lazy
+import Data.ByteString.Lazy.Internal
+#endif
+import Data.Bits (FiniteBits, isSigned)
+import Data.ByteString.Internal (pattern BS, plusForeignPtr)
+import Data.Int
+import Data.Word
+import Foreign.ForeignPtr (ForeignPtr)
+import Foreign.Ptr (minusPtr, plusPtr)
+import Foreign.Storable (Storable(..))
+
+----- Public API
+
+-- | Try to read a signed 'Int' value from the 'ByteString', returning
+-- @Just (val, str)@ on success, where @val@ is the value read and @str@ is the
+-- rest of the input string.  If the sequence of digits decodes to a value
+-- larger than can be represented by an 'Int', the returned value will be
+-- 'Nothing'.
+--
+-- 'readInt' does not ignore leading whitespace, the value must start
+-- immediately at the beginning of the input string.
+--
+-- ==== __Examples__
+-- >>> readInt "-1729 sum of cubes"
+-- Just (-1729," sum of cubes")
+-- >>> readInt "+1: readInt also accepts a leading '+'"
+-- Just (1, ": readInt also accepts a leading '+'")
+-- >>> readInt "not a decimal number"
+-- Nothing
+-- >>> readInt "12345678901234567890 overflows maxBound"
+-- Nothing
+-- >>> readInt "-12345678901234567890 underflows minBound"
+-- Nothing
+--
+readInt :: ByteString -> Maybe (Int, ByteString)
+readInt = _read
+
+-- | A variant of 'readInt' specialised to 'Int32'.
+readInt32 :: ByteString -> Maybe (Int32, ByteString)
+readInt32 = _read
+
+-- | A variant of 'readInt' specialised to 'Int16'.
+readInt16 :: ByteString -> Maybe (Int16, ByteString)
+readInt16 = _read
+
+-- | A variant of 'readInt' specialised to 'Int8'.
+readInt8 :: ByteString -> Maybe (Int8, ByteString)
+readInt8 = _read
+
+-- | Try to read a 'Word' value from the 'ByteString', returning
+-- @Just (val, str)@ on success, where @val@ is the value read and @str@ is the
+-- rest of the input string.  If the sequence of digits decodes to a value
+-- larger than can be represented by a 'Word', the returned value will be
+-- 'Nothing'.
+--
+-- 'readWord' does not ignore leading whitespace, the value must start with a
+-- decimal digit immediately at the beginning of the input string.  Leading @+@
+-- signs are not accepted.
+--
+-- ==== __Examples__
+-- >>> readWord "1729 sum of cubes"
+-- Just (1729," sum of cubes")
+-- >>> readWord "+1729 has an explicit sign"
+-- Nothing
+-- >>> readWord "not a decimal number"
+-- Nothing
+-- >>> readWord "98765432109876543210 overflows maxBound"
+-- Nothing
+--
+readWord :: ByteString -> Maybe (Word, ByteString)
+readWord = _read
+
+-- | A variant of 'readWord' specialised to 'Word32'.
+readWord32 :: ByteString -> Maybe (Word32, ByteString)
+readWord32 = _read
+
+-- | A variant of 'readWord' specialised to 'Word16'.
+readWord16 :: ByteString -> Maybe (Word16, ByteString)
+readWord16 = _read
+
+-- | A variant of 'readWord' specialised to 'Word8'.
+readWord8 :: ByteString -> Maybe (Word8, ByteString)
+readWord8 = _read
+
+-- | A variant of 'readInt' specialised to 'Int64'.
+readInt64 :: ByteString -> Maybe (Int64, ByteString)
+readInt64 = _read
+
+-- | A variant of 'readWord' specialised to 'Word64'.
+readWord64 :: ByteString -> Maybe (Word64, ByteString)
+readWord64 = _read
+
+-- | Polymorphic Int*/Word* reader
+_read :: forall a. (Integral a, FiniteBits a, Bounded a)
+      => ByteString  -> Maybe (a, ByteString)
+{-# INLINE _read #-}
+_read
+    | isSigned @a 0
+      = \ bs -> signed bs >>= \ (r, s, d1) -> _readDecimal r s d1
+    | otherwise
+      -- When the input is @16^n-1@, as is the case with 'maxBound' for
+      -- all the Word* types, the last decimal digit of 'maxBound' is 5.
+      = \ bs -> unsigned 5 bs >>= \ (r, s, d1) -> _readDecimal r s d1
+  where
+    -- Returns:
+    --  * Mod 10 min/max bound remainder
+    --  * 2nd and later digits
+    --  * 1st digit
+    --
+    -- When the input is @8*16^n-1@, as is the case with 'maxBound' for
+    -- all the Int* types, the last decimal digit of 'maxBound' is 7.
+    --
+    signed :: ByteString -> Maybe (Word64, ByteString, Word64)
+    signed bs = do
+        (w, s) <- uncons bs
+        let d1 = fromDigit w
+        if | d1 <= 9   -> Just (7, s, d1) -- leading digit
+           | w == 0x2d -> unsigned 8 s    -- minus sign
+           | w == 0x2b -> unsigned 7 s    -- plus sign
+           | otherwise -> Nothing         -- not a number
+
+    unsigned :: Word64 -> ByteString -> Maybe (Word64, ByteString, Word64)
+    unsigned r bs = do
+        (w, s) <- uncons bs
+        let d1 = fromDigit w
+        if | d1 <= 9   -> Just (r, s, d1) -- leading digit
+           | otherwise -> Nothing         -- not a number
+
+----- Fixed-width unsigned reader
+
+-- | Intermediate result from scanning a chunk, final output is
+-- converted to the requested type once all chunks are processed.
+--
+data Result = Overflow
+            | Result !Int    -- number of bytes (digits) read
+                     !Word64 -- accumulator value
+
+_readDecimal :: forall a. (Integral a, Bounded a)
+             => Word64     -- ^ abs(maxBound/minBound) `mod` 10
+             -> ByteString -- ^ Input string
+             -> Word64     -- ^ First digit value
+             -> Maybe (a, ByteString)
+{-# INLINE _readDecimal #-}
+_readDecimal !r = consume
+  where
+    consume :: ByteString -> Word64 -> Maybe (a, ByteString)
+#ifdef BYTESTRING_STRICT
+    consume (BS fp len) a = case _digits q r fp len a of
+        Result used acc
+            | used == len
+              -> convert acc empty
+            | otherwise
+              -> convert acc $ BS (fp `plusForeignPtr` used) (len - used)
+        _   -> Nothing
+#else
+    -- All done
+    consume Empty acc = convert acc Empty
+    -- Process next chunk
+    consume (Chunk (BS fp len) cs) acc
+        = case _digits q r fp len acc of
+            Result used acc'
+                | used == len
+                  -- process remaining chunks
+                  -> consume cs acc'
+                | otherwise
+                  -- ran into a non-digit
+                  -> convert acc' $
+                     Chunk (BS (fp `plusForeignPtr` used) (len - used)) cs
+            _     -> Nothing
+#endif
+    convert :: Word64 -> ByteString -> Maybe (a, ByteString)
+    convert !acc rest =
+        let !i = case r of
+                -- minBound @Int* `mod` 10 == 8
+                8 -> negate $ fromIntegral @Word64 @a acc
+                _ -> fromIntegral @Word64 @a acc
+         in Just (i, rest)
+
+    -- The quotient of 'maxBound' divided by 10 is needed for
+    -- overflow checks, once the accumulator exceeds this value
+    -- no further digits can be added.  If equal, the last digit
+    -- must not exceed the `r` value (max/min bound `mod` 10).
+    --
+    q = fromIntegral @a @Word64 maxBound `div` 10
+
+----- Per chunk decoder
+
+-- | Process as many digits as we can, returning the additional
+-- number of digits found and the updated accumulator.  If the
+-- accumulator would overflow return 'Overflow'.
+--
+_digits :: Word64           -- ^ maximum non-overflow value `div` 10
+        -> Word64           -- ^ maximum non-overflow vavlue `mod` 10
+        -> ForeignPtr Word8 -- ^ Input buffer
+        -> Int              -- ^ Input length
+        -> Word64           -- ^ Accumulated value of leading digits
+        -> Result           -- ^ Bytes read and final accumulator,
+                            -- or else overflow indication
+{-# INLINE _digits #-}
+_digits !q !r fp len a = BI.accursedUnutterablePerformIO $
+    BI.unsafeWithForeignPtr fp $ \ ptr -> do
+        let end = ptr `plusPtr` len
+        go ptr end ptr a
+  where
+    go !start !end = loop
+      where
+        loop !ptr !acc = getDigit >>= \ !d ->
+            if | d > 9
+                 -> return $ Result (ptr `minusPtr` start) acc
+               | acc < q || acc == q && d <= r
+                 -> loop (ptr `plusPtr` 1) (acc * 10 + d)
+               | otherwise
+                 -> return Overflow
+          where
+            getDigit :: IO Word64
+            getDigit
+                | ptr /= end = fromDigit <$> peek ptr
+                | otherwise  = pure 10  -- End of input
+            {-# NOINLINE getDigit #-}
+            -- 'getDigit' makes it possible to implement a single success
+            -- exit point from the loop.  If instead we return 'Result'
+            -- from multiple places, when '_digits' is inlined we get (at
+            -- least GHC 8.10 through 9.2) for each exit path a separate
+            -- join point implementing the continuation code.  GHC ticket
+            -- <https://gitlab.haskell.org/ghc/ghc/-/issues/20739>.
+            --
+            -- The NOINLINE pragma is required to avoid inlining branches
+            -- that would restore multiple exit points.
+
+fromDigit :: Word8 -> Word64
+{-# INLINE fromDigit #-}
+fromDigit = \ !w -> fromIntegral w - 0x30 -- i.e. w - '0'

--- a/Data/ByteString/Lazy/ReadNat.hs
+++ b/Data/ByteString/Lazy/ReadNat.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- This file is included by "Data.ByteString.ReadInt", after defining
+-- "BYTESTRING_STRICT".  The two modules are largely identical, except for the
+-- choice of ByteString type and the loops in `readNatural`, where the lazy
+-- version needs to nest the inner loop inside a loop over the constituent
+-- chunks.
+
+#ifdef BYTESTRING_STRICT
+module Data.ByteString.ReadNat
+#else
+module Data.ByteString.Lazy.ReadNat
+#endif
+    ( readInteger
+    , readNatural
+    ) where
+
+import qualified Data.ByteString.Internal as BI
+#ifdef BYTESTRING_STRICT
+import Data.ByteString
+#else
+import Data.ByteString.Lazy
+import Data.ByteString.Lazy.Internal
+#endif
+import Data.Bits (finiteBitSize)
+import Data.ByteString.Internal (pattern BS, plusForeignPtr)
+import Data.Word
+import Foreign.ForeignPtr (ForeignPtr)
+import Foreign.Ptr (Ptr, minusPtr, plusPtr)
+import Foreign.Storable (Storable(..))
+import Numeric.Natural (Natural)
+
+----- Public API
+
+-- | 'readInteger' reads an 'Integer' from the beginning of the 'ByteString'.
+-- If there is no 'Integer' at the beginning of the string, it returns
+-- 'Nothing', otherwise it just returns the 'Integer' read, and the rest of
+-- the string.
+--
+-- 'readInteger' does not ignore leading whitespace, the value must start
+-- immediately at the beginning of the input string.
+--
+-- ==== __Examples__
+-- >>> readInteger "-000111222333444555666777888999 all done"
+-- Just (-111222333444555666777888999," all done")
+-- >>> readInteger "+1: readInteger also accepts a leading '+'"
+-- Just (1, ": readInteger also accepts a leading '+'")
+-- >>> readInteger "not a decimal number"
+-- Nothing
+--
+readInteger :: ByteString -> Maybe (Integer, ByteString)
+readInteger = \ bs -> do
+    (w, s) <- uncons bs
+    let d = fromDigit w
+    if | d <=    9 -> unsigned d s -- leading digit
+       | w == 0x2d -> negative s   -- minus sign
+       | w == 0x2b -> positive s   -- plus sign
+       | otherwise -> Nothing      -- not a number
+  where
+    unsigned :: Word -> ByteString -> Maybe (Integer, ByteString)
+    unsigned d s =
+         let (!n, rest) = _readDecimal d s
+             !i = toInteger n
+          in Just (i, rest)
+
+    positive :: ByteString -> Maybe (Integer, ByteString)
+    positive bs = do
+        (w, s) <- uncons bs
+        let d = fromDigit w
+        if | d <=    9 -> unsigned d s
+           | otherwise -> Nothing
+
+    negative :: ByteString -> Maybe (Integer, ByteString)
+    negative bs = do
+        (w, s) <- uncons bs
+        let d = fromDigit w
+        if | d >     9 -> Nothing
+           | otherwise -> let (n, rest) = _readDecimal d s
+                              !i = negate $ toInteger n
+                           in Just (i, rest)
+
+-- | 'readNatural' reads a 'Natural' number from the beginning of the
+-- 'ByteString'.  If there is no 'Natural' number at the beginning of the
+-- string, it returns 'Nothing', otherwise it just returns the number read, and
+-- the rest of the string.
+--
+-- 'readNatural' does not ignore leading whitespace, the value must start with
+-- a decimal digit immediately at the beginning of the input string.  Leading
+-- @+@ signs are not accepted.
+--
+-- ==== __Examples__
+-- >>> readNatural "000111222333444555666777888999 all done"
+-- Just (111222333444555666777888999," all done")
+-- >>> readNatural "+000111222333444555666777888999 explicit sign"
+-- Nothing
+-- >>> readNatural "not a decimal number"
+-- Nothing
+--
+readNatural :: ByteString -> Maybe (Natural, ByteString)
+readNatural bs = do
+    (w, s) <- uncons bs
+    let d = fromDigit w
+    if | d <=    9 -> Just $! _readDecimal d s
+       | otherwise -> Nothing
+
+----- Internal implementation
+
+-- | Intermediate result from scanning a chunk, final output is
+-- obtained via `convert` after all the chunks are processed.
+--
+data Result = Result !Int      -- Bytes consumed
+                     !Word     -- Value of LSW
+                     !Int      -- Digits in LSW
+                     [Natural] -- Little endian MSW list
+
+_readDecimal :: Word -> ByteString -> (Natural, ByteString)
+_readDecimal =
+    -- Having read one digit, we're about to read the 2nd So the digit count
+    -- up to 'safeLog' starts at 2.
+    consume [] 2
+  where
+    consume :: [Natural] -> Int -> Word -> ByteString
+            -> (Natural, ByteString)
+#ifdef BYTESTRING_STRICT
+    consume ns cnt acc (BS fp len) =
+        -- Having read one digit, we're about to read the 2nd
+        -- So the digit count up to 'safeLog' starts at 2.
+        case natdigits fp len acc cnt ns of
+            Result used acc' cnt' ns'
+                | used == len
+                  -> convert acc' cnt' ns' $ empty
+                | otherwise
+                  -> convert acc' cnt' ns' $
+                     BS (fp `plusForeignPtr` used) (len - used)
+#else
+    -- All done
+    consume ns cnt acc Empty = convert acc cnt ns Empty
+    -- Process next chunk
+    consume ns cnt acc (Chunk (BS fp len) cs)
+        = case natdigits fp len acc cnt ns of
+            Result used acc' cnt' ns'
+                | used == len -- process more chunks
+                  -> consume ns' cnt' acc' cs
+                | otherwise   -- ran into a non-digit
+                  -> let c = Chunk (BS (fp `plusForeignPtr` used) (len - used)) cs
+                      in convert acc' cnt' ns' c
+#endif
+    convert !acc !cnt !ns rest =
+        let !n = combine acc cnt ns
+         in (n, rest)
+
+    -- | Merge least-significant word with reduction of of little-endian tail.
+    --
+    -- The input is:
+    --
+    -- * Least significant digits as a 'Word' (LSW)
+    -- * The number of digits that went into the LSW
+    -- * All the remaining digit groups ('safeLog' digits each),
+    --   in little-endian order
+    --
+    -- The result is obtained by pairwise recursive combining of all the
+    -- full size digit groups, followed by multiplication by @10^cnt@ and
+    -- addition of the LSW.
+    combine :: Word      -- ^ value of LSW
+            -> Int       -- ^ count of digits in LSW
+            -> [Natural] -- ^ tail elements (base @10^'safeLog'@)
+            -> Natural
+    {-# INLINE combine #-}
+    combine !acc !_   [] = wordToNatural acc
+    combine !acc !cnt ns =
+        wordToNatural (10^cnt) * combine1 safeBase ns + wordToNatural acc
+
+    -- | Recursive reduction of little-endian sequence of 'Natural'-valued
+    -- /digits/ in base @base@ (a power of 10).  The base is squared after
+    -- each round.  This shows better asymptotic performance than one word
+    -- at a time multiply-add folds.  See:
+    -- <https://gmplib.org/manual/Multiplication-Algorithms>
+    --
+    combine1 :: Natural -> [Natural] -> Natural
+    combine1 _    [n] = n
+    combine1 base ns  = combine1 (base * base) (combine2 base ns)
+
+    -- | One round pairwise merge of numbers in base @base@.
+    combine2 :: Natural -> [Natural] -> [Natural]
+    combine2 base (n:m:ns) = let !t = m * base + n in t : combine2 base ns
+    combine2 _    ns       = ns
+
+-- The intermediate representation is a little-endian sequence in base
+-- @10^'safeLog'@, prefixed by an initial element in base @10^cnt@ for some
+-- @cnt@ between 1 and 'safeLog'.  The final result is obtained by recursive
+-- pairwise merging of the tail followed by a final multiplication by @10^cnt@
+-- and addition of the head.
+--
+natdigits :: ForeignPtr Word8 -- ^ Input chunk
+          -> Int              -- ^ Chunk length
+          -> Word             -- ^ accumulated element
+          -> Int              -- ^ partial digit count
+          -> [Natural]        -- ^ accumulated MSB elements
+          -> Result
+{-# INLINE natdigits #-}
+natdigits fp len = \ acc cnt ns ->
+    BI.accursedUnutterablePerformIO $
+        BI.unsafeWithForeignPtr fp $ \ ptr -> do
+            let end = ptr `plusPtr` len
+            go ptr end acc cnt ns ptr
+  where
+    go !start !end = loop
+      where
+        loop :: Word -> Int -> [Natural] -> Ptr Word8 -> IO Result
+        loop !acc !cnt ns !ptr = getDigit >>= \ !d ->
+            if | d > 9
+                 -> return $ Result (ptr `minusPtr` start) acc cnt ns
+               | cnt < safeLog
+                 -> loop (10*acc + d) (cnt+1) ns $ ptr `plusPtr` 1
+               | otherwise
+                 -> let !acc' = wordToNatural acc
+                     in loop d 1 (acc' : ns) $ ptr `plusPtr` 1
+          where
+            getDigit | ptr /= end = fromDigit <$> peek ptr
+                     | otherwise  = pure 10  -- End of input
+            {-# NOINLINE getDigit #-}
+            -- 'getDigit' makes it possible to implement a single success
+            -- exit point from the loop.  If instead we return 'Result'
+            -- from multiple places, when 'natdigits' is inlined we get (at
+            -- least GHC 8.10 through 9.2) for each exit path a separate
+            -- join point implementing the continuation code.  GHC ticket
+            -- <https://gitlab.haskell.org/ghc/ghc/-/issues/20739>.
+            --
+            -- The NOINLINE pragma is required to avoid inlining branches
+            -- that would restore multiple exit points.
+
+----- Misc functions
+
+-- | Largest decimal digit count that never overflows the accumulator
+-- The base 10 logarithm of 2 is ~0.30103, therefore 2^n has at least
+-- @1 + floor (0.3 n)@ decimal digits.  Therefore @floor (0.3 n)@,
+-- digits cannot overflow the upper bound of an @n-bit@ word.
+--
+safeLog :: Int
+safeLog = 3 * finiteBitSize @Word 0 `div` 10
+
+-- | 10-power base for little-endian sequence of ~Word-sized "digits"
+safeBase :: Natural
+safeBase = 10 ^ safeLog
+
+fromDigit :: Word8 -> Word
+{-# INLINE fromDigit #-}
+fromDigit = \ !w -> fromIntegral w - 0x30 -- i.e. w - '0'
+
+wordToNatural :: Word -> Natural
+{-# INLINE wordToNatural #-}
+wordToNatural  = fromIntegral

--- a/Data/ByteString/ReadInt.hs
+++ b/Data/ByteString/ReadInt.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE CPP #-}
+#define BYTESTRING_STRICT
+#include "Lazy/ReadInt.hs"

--- a/Data/ByteString/ReadNat.hs
+++ b/Data/ByteString/ReadNat.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE CPP #-}
+#define BYTESTRING_STRICT
+#include "Lazy/ReadNat.hs"

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -42,6 +42,7 @@ import BenchBoundsCheckFusion
 import BenchCount
 import BenchCSV
 import BenchIndices
+import BenchReadInt
 
 ------------------------------------------------------------------------------
 -- Benchmark support
@@ -467,4 +468,5 @@ main = do
     , benchCount
     , benchCSV
     , benchIndices
+    , benchReadInt
     ]

--- a/bench/BenchReadInt.hs
+++ b/bench/BenchReadInt.hs
@@ -1,0 +1,144 @@
+-- |
+-- Copyright   : (c) 2021 Viktor Dukhovni
+-- License     : BSD3-style (see LICENSE)
+--
+-- Maintainer  : Viktor Dukhovni <ietf-dane@dukhovni.org>
+--
+-- Benchmark readInt and variants, readWord and variants,
+-- readInteger and readNatural
+
+{-# LANGUAGE
+    CPP
+  , BangPatterns
+  , OverloadedStrings
+  , TypeApplications
+  , ScopedTypeVariables
+  #-}
+
+module BenchReadInt (benchReadInt) where
+
+import qualified Data.ByteString.Builder               as B
+import qualified Data.ByteString.Char8                 as S
+import qualified Data.ByteString.Lazy.Char8            as L
+import Test.Tasty.Bench
+import Data.Int
+import Data.Word
+import Numeric.Natural
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup((<>)))
+#endif
+import Data.Monoid (mconcat)
+
+------------------------------------------------------------------------------
+-- Benchmark
+------------------------------------------------------------------------------
+
+-- Sum space-separated integers in a ByteString.
+loopS :: Integral a
+      => (S.ByteString -> Maybe (a, S.ByteString)) -> S.ByteString -> a
+loopS rd = go 0
+  where
+    go !acc !bs = case rd bs of
+        Just (i, t) -> case S.uncons t of
+            Just (_, t') -> go (acc + i) t'
+            Nothing      -> acc + i
+        Nothing          -> acc
+
+-- Sum space-separated integers in a ByteString.
+loopL :: Integral a
+      => (L.ByteString -> Maybe (a, L.ByteString)) -> L.ByteString -> a
+loopL rd = go 0
+  where
+    go !acc !bs = case rd bs of
+        Just (i, t) -> case L.uncons t of
+            Just (_, t') -> go (acc + i) t'
+            Nothing      -> acc + i
+        Nothing          -> acc
+
+benchReadInt :: Benchmark
+benchReadInt = bgroup "Read Integral"
+    [ bgroup "Strict"
+        [ bench "ReadInt"     $ nf (loopS S.readInt)     intS
+        , bench "ReadInt8"    $ nf (loopS S.readInt8)    int8S
+        , bench "ReadInt16"   $ nf (loopS S.readInt16)   int16S
+        , bench "ReadInt32"   $ nf (loopS S.readInt32)   int32S
+        , bench "ReadInt64"   $ nf (loopS S.readInt64)   int64S
+        , bench "ReadWord"    $ nf (loopS S.readWord)    wordS
+        , bench "ReadWord8"   $ nf (loopS S.readWord8)   word8S
+        , bench "ReadWord16"  $ nf (loopS S.readWord16)  word16S
+        , bench "ReadWord32"  $ nf (loopS S.readWord32)  word32S
+        , bench "ReadWord64"  $ nf (loopS S.readWord64)  word64S
+        , bench "ReadInteger" $ nf (loopS S.readInteger) bignatS
+        , bench "ReadNatural" $ nf (loopS S.readNatural) bignatS
+        , bench "ReadInteger small" $ nf (loopS S.readInteger) intS
+        , bench "ReadNatural small" $ nf (loopS S.readNatural) wordS
+        ]
+
+    , bgroup "Lazy"
+        [ bench "ReadInt"     $ nf (loopL L.readInt)     intL
+        , bench "ReadInt8"    $ nf (loopL L.readInt8)    int8L
+        , bench "ReadInt16"   $ nf (loopL L.readInt16)   int16L
+        , bench "ReadInt32"   $ nf (loopL L.readInt32)   int32L
+        , bench "ReadInt64"   $ nf (loopL L.readInt64)   int64L
+        , bench "ReadWord"    $ nf (loopL L.readWord)    wordL
+        , bench "ReadWord8"   $ nf (loopL L.readWord8)   word8L
+        , bench "ReadWord16"  $ nf (loopL L.readWord16)  word16L
+        , bench "ReadWord32"  $ nf (loopL L.readWord32)  word32L
+        , bench "ReadWord64"  $ nf (loopL L.readWord64)  word64L
+        , bench "ReadInteger" $ nf (loopL L.readInteger) bignatL
+        , bench "ReadNatural" $ nf (loopL L.readNatural) bignatL
+        , bench "ReadInteger small" $ nf (loopL L.readInteger) intL
+        , bench "ReadNatural small" $ nf (loopL L.readNatural) wordL
+        ]
+    ]
+  where
+    mkWordL :: forall a. (Integral a, Bounded a)
+            => (a -> B.Builder) -> L.ByteString
+    mkWordL f = B.toLazyByteString b
+      where b = mconcat [f i <> B.char8 ' ' | i <- [n-255..n]]
+            n = maxBound @a
+    mkWordS f = S.toStrict $ mkWordL f
+
+    mkIntL :: forall a. (Integral a, Bounded a)
+           => (a -> B.Builder) -> L.ByteString
+    mkIntL f = B.toLazyByteString b
+      where b = mconcat [f (i + 128) <> B.char8 ' ' | i <- [n-255..n]]
+            n = maxBound @a
+    mkIntS f = S.toStrict $ mkIntL f
+
+    wordS, word8S, word16S, word32S, word64S :: S.ByteString
+    !wordS = mkWordS B.wordDec
+    !word8S = mkWordS B.word8Dec
+    !word16S = mkWordS B.word16Dec
+    !word32S = mkWordS B.word32Dec
+    !word64S = mkWordS B.word64Dec
+
+    intS, int8S, int16S, int32S, int64S :: S.ByteString
+    !intS =  mkIntS B.intDec
+    !int8S = mkIntS B.int8Dec
+    !int16S = mkIntS B.int16Dec
+    !int32S = mkIntS B.int32Dec
+    !int64S = mkIntS B.int64Dec
+
+    word8L, word16L, word32L, word64L :: L.ByteString
+    !wordL = mkWordL B.wordDec
+    !word8L = mkWordL B.word8Dec
+    !word16L = mkWordL B.word16Dec
+    !word32L = mkWordL B.word32Dec
+    !word64L = mkWordL B.word64Dec
+
+    intL, int8L, int16L, int32L, int64L :: L.ByteString
+    !intL =  mkIntL B.intDec
+    !int8L = mkIntL B.int8Dec
+    !int16L = mkIntL B.int16Dec
+    !int32L = mkIntL B.int32Dec
+    !int64L = mkIntL B.int64Dec
+
+    bignatL :: L.ByteString
+    !bignatL = B.toLazyByteString b
+      where b = mconcat [B.integerDec (powpow i) <> B.char8 ' ' | i <- [0..13]]
+            powpow :: Word -> Integer
+            powpow n = 2^(2^n :: Word)
+
+    bignatS :: S.ByteString
+    !bignatS = S.toStrict bignatL

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -100,6 +100,10 @@ library
                      Data.ByteString.Builder.RealFloat.Internal
                      Data.ByteString.Builder.RealFloat.TableGenerator
                      Data.ByteString.Lazy.Internal.Deque
+                     Data.ByteString.Lazy.ReadInt
+                     Data.ByteString.Lazy.ReadNat
+                     Data.ByteString.ReadInt
+                     Data.ByteString.ReadNat
 
   default-language:  Haskell2010
   other-extensions:  CPP,
@@ -176,6 +180,7 @@ benchmark bytestring-bench
                     BenchCount
                     BenchCSV
                     BenchIndices
+                    BenchReadInt
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
   default-language: Haskell2010


### PR DESCRIPTION
Some applications want to read either unsigned or explicitly 64-bit integers
(e.g. warp).  Provide the missing interfaces.  Based on a suggestion by @Bodigrim the code has been moved to a single module enabling simpler maintenance and reduced duplication. A very helpful nudge...