### PR TITLE
Improve memory-safety of Semigroup instances

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -129,7 +129,9 @@ module Data.ByteString.Builder.Internal (
 import           Control.Arrow (second)
 
 #if !(MIN_VERSION_base(4,11,0))
-import           Data.Semigroup (Semigroup((<>)))
+import           Data.Semigroup (Semigroup((<>), stimes), stimesMonoid)
+#else
+import           Data.Semigroup (Semigroup(stimes), stimesMonoid)
 #endif
 
 import qualified Data.ByteString               as S
@@ -385,6 +387,7 @@ append (Builder b1) (Builder b2) = Builder $ b1 . b2
 instance Semigroup Builder where
   {-# INLINE (<>) #-}
   (<>) = append
+  stimes = stimesMonoid
 
 instance Monoid Builder where
   {-# INLINE mempty #-}

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -131,7 +131,6 @@ import           Control.Arrow (second)
 #if !(MIN_VERSION_base(4,11,0))
 import           Data.Semigroup (Semigroup((<>)))
 #endif
-import           Data.Semigroup (Semigroup(stimes), stimesMonoid)
 
 import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal      as S
@@ -386,7 +385,6 @@ append (Builder b1) (Builder b2) = Builder $ b1 . b2
 instance Semigroup Builder where
   {-# INLINE (<>) #-}
   (<>) = append
-  stimes = stimesMonoid
 
 instance Monoid Builder where
   {-# INLINE mempty #-}

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -129,10 +129,9 @@ module Data.ByteString.Builder.Internal (
 import           Control.Arrow (second)
 
 #if !(MIN_VERSION_base(4,11,0))
-import           Data.Semigroup (Semigroup((<>), stimes), stimesMonoid)
-#else
-import           Data.Semigroup (Semigroup(stimes), stimesMonoid)
+import           Data.Semigroup (Semigroup((<>)))
 #endif
+import           Data.Semigroup (Semigroup(stimes), stimesMonoid)
 
 import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal      as S

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -841,15 +841,16 @@ overflowError fun = throw $ SizeOverflowException msg
 -- | Add two non-negative numbers.
 -- Calls 'overflowError' on overflow.
 checkedAdd :: String -> Int -> Int -> Int
+{-# INLINE checkedAdd #-}
 checkedAdd fun x y
   | r >= 0    = r
   | otherwise = overflowError fun
   where r = assert (min x y >= 0) $ x + y
-{-# INLINE checkedAdd #-}
 
 -- | Multiplies two non-negative numbers.
 -- Calls 'overflowError' on overflow.
 checkedMultiply :: String -> Int -> Int -> Int
+{-# INLINE checkedMultiply #-}
 checkedMultiply fun !x@(I# x#) !y@(I# y#) = assert (min x y >= 0) $
 #if TIMES_INT_2_AVAILABLE
   case timesInt2# x# y# of
@@ -867,6 +868,7 @@ checkedMultiply fun !x@(I# x#) !y@(I# y#) = assert (min x y >= 0) $
 -- | Attempts to convert an 'Integer' value to an 'Int', returning
 -- 'Nothing' if doing so would result in an overflow.
 checkedIntegerToInt :: Integer -> Maybe Int
+{-# INLINE checkedIntegerToInt #-}
 -- We could use Data.Bits.toIntegralSized, but this hand-rolled
 -- version is currently a bit faster as of GHC 9.2.
 -- It's even faster to just match on the Integer constructors, but

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -739,7 +739,7 @@ concat = \bss0 -> goLen0 bss0 bss0
 -- specializations are reasonably small.
 stimesPolymorphic :: Integral a => a -> ByteString -> ByteString
 {-# INLINABLE stimesPolymorphic #-}
-stimesPolymorphic nRaw bs = case checkedIntegerToInt n of
+stimesPolymorphic nRaw = \ !bs -> case checkedIntegerToInt n of
   Just nInt
     | nInt >= 0  -> stimesNonNegativeInt nInt bs
     | otherwise  -> stimesNegativeErr

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -864,7 +864,13 @@ checkedMultiply fun !x@(I# x#) !y@(I# y#) = assert (min x y >= 0) $
 #endif
 
 
+-- | Attempts to convert an 'Integer' value to an 'Int', returning
+-- 'Nothing' if doing so would result in an overflow.
 checkedIntegerToInt :: Integer -> Maybe Int
+-- We could use Data.Bits.toIntegralSized, but this hand-rolled
+-- version is currently a bit faster as of GHC 9.2.
+-- It's even faster to just match on the Integer constructors, but
+-- we'd still need a fallback implementation for integer-simple.
 checkedIntegerToInt x
   | x == toInteger res = Just res
   | otherwise = Nothing

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -715,7 +715,7 @@ concat = \bss0 -> goLen0 bss0 bss0
 
 -- | Repeats the given ByteString n times.
 times :: Integral a => a -> ByteString -> ByteString
-times n_raw (BS fp len)
+times nRaw (BS fp len)
   | n < 0 = error "stimes: non-negative multiplier expected"
   | n == 0 = mempty
   | n == 1 = BS fp len
@@ -729,11 +729,11 @@ times n_raw (BS fp len)
       memcpy destptr p len
       fillFrom destptr len
   where
-    n = toInteger n_raw -- don't mess with lawless Integral instances
+    n = toInteger nRaw -- don't mess with lawless Integral instances
     sizeInteger = toInteger len * n
-    size = if  sizeInteger <= toInteger (maxBound :: Int)
-      then  fromInteger sizeInteger
-      else  overflowError "stimes"
+    size = if sizeInteger <= toInteger (maxBound :: Int)
+      then fromInteger sizeInteger
+      else overflowError "stimes"
 
     fillFrom :: Ptr Word8 -> Int -> IO ()
     fillFrom destptr copied

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -307,11 +307,11 @@ toStrict = \cs -> goLen0 cs cs
     goLen1 _   bs Empty = bs
     goLen1 cs0 bs (Chunk (S.BS _ 0) cs) = goLen1 cs0 bs cs
     goLen1 cs0 (S.BS _ bl) (Chunk (S.BS _ cl) cs) =
-        goLen cs0 (S.checkedAdd "Lazy.concat" bl cl) cs
+        goLen cs0 (S.checkedAdd "Lazy.toStrict" bl cl) cs
 
     -- General case, just find the total length we'll need
     goLen cs0 !total (Chunk (S.BS _ cl) cs) =
-      goLen cs0 (S.checkedAdd "Lazy.concat" total cl) cs
+      goLen cs0 (S.checkedAdd "Lazy.toStrict" total cl) cs
     goLen cs0 total Empty =
       S.unsafeCreate total $ \ptr -> goCopy cs0 ptr
 

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -57,8 +57,7 @@ import qualified Data.ByteString.Internal as BS
 
 import Data.Typeable    (Typeable)
 import Data.Data        (Data(..), mkNoRepType)
-import Data.Semigroup   (Semigroup((<>), sconcat, stimes), stimesMonoid)
-import Data.List.NonEmpty (NonEmpty((:|)))
+import Data.Semigroup   (Semigroup((<>)))
 import Data.Monoid      (Monoid(..))
 import Data.String      (IsString(..))
 import Control.DeepSeq  (NFData(..))
@@ -158,9 +157,7 @@ instance Ord ShortByteString where
     compare = compareBytes
 
 instance Semigroup ShortByteString where
-    (<>) = append
-    sconcat (x :| xs) = concat (x : xs)
-    stimes = stimesMonoid
+    (<>)    = append
 
 instance Monoid ShortByteString where
     mempty  = empty
@@ -449,10 +446,10 @@ concat sbss =
 
     copy :: MBA s -> Int -> [ShortByteString] -> ST s ()
     copy !_   !_   []                           = return ()
-    copy !dst !off (src : srcs) = do
+    copy !dst !off (src : sbss) = do
       let !len = length src
       copyByteArray (asBA src) 0 dst off len
-      copy dst (off + len) srcs
+      copy dst (off + len) sbss
 
 
 ------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ of `ByteString` values from smaller pieces during binary serialization.
 Requirements:
 
   * Cabal 1.10 or greater
-  * GHC 7.0 or greater
+  * GHC 8.0 or greater
 
 ### Authors
 

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -16,6 +16,7 @@ module Main (main) where
 
 import           Data.Foldable                         (foldMap)
 import           Data.Monoid
+import           Data.Semigroup
 import           Data.String
 import           Test.Tasty.Bench
 import           Prelude                               hiding (words)
@@ -407,6 +408,11 @@ main = do
         ]
       ]
     , bgroup "sort" $ map (\s -> bench (S8.unpack s) $ nf S.sort s) sortInputs
+    , bgroup "stimes" $ let  st = stimes :: Int -> S.ByteString -> S.ByteString
+     in
+      [ bench "strict (tiny)" $ whnf (st 4) (S8.pack "test")
+      , bench "strict (large)" $ whnf (st 50) byteStringData
+      ]
     , bgroup "words"
       [ bench "lorem ipsum" $ nf S8.words loremIpsum
       , bench "one huge word" $ nf S8.words byteStringData

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -287,8 +287,11 @@ prop_stimesOverflowScary bs =
     n = P.length bs
     reps = maxBound @Word `quot` fromIntegral @Int @Word n + 1
 
-concat32bitOverflow :: (Int -> a) -> ([a] -> a) -> (a -> Int) -> Property
-concat32bitOverflow replicateLike concatLike lengthLike = let
+prop_stimesOverflowEmpty = forAll (choose (0, maxBound @Word)) $ \n ->
+  stimes n mempty === mempty @P.ByteString
+
+concat32bitOverflow :: (Int -> a) -> ([a] -> a) -> Property
+concat32bitOverflow replicateLike concatLike = let
   intBits = finiteBitSize @Int 0
   largeBS = concatLike $ replicate (bit 14) $ replicateLike (bit 17)
   in if intBits /= 32
@@ -297,15 +300,15 @@ concat32bitOverflow replicateLike concatLike lengthLike = let
 
 prop_32bitOverflow_Strict_mconcat :: Property
 prop_32bitOverflow_Strict_mconcat =
-  concat32bitOverflow (`P.replicate` 0) mconcat P.length
+  concat32bitOverflow (`P.replicate` 0) mconcat
 
 prop_32bitOverflow_Lazy_toStrict :: Property
 prop_32bitOverflow_Lazy_toStrict =
-  concat32bitOverflow (`P.replicate` 0) (L.toStrict . L.fromChunks) P.length
+  concat32bitOverflow (`P.replicate` 0) (L.toStrict . L.fromChunks)
 
 prop_32bitOverflow_Short_mconcat :: Property
 prop_32bitOverflow_Short_mconcat =
-  concat32bitOverflow makeShort mconcat Short.length
+  concat32bitOverflow makeShort mconcat
   where makeShort n = Short.toShort $ P.replicate n 0
 
 
@@ -647,6 +650,7 @@ overflow_tests =
     , testProperty "checkedMul" prop_checkedMul
     , testProperty "StrictByteString stimes (basic)" prop_stimesOverflowBasic
     , testProperty "StrictByteString stimes (scary)" prop_stimesOverflowScary
+    , testProperty "StrictByteString stimes (empty)" prop_stimesOverflowEmpty
     , testProperty "StrictByteString mconcat" prop_32bitOverflow_Strict_mconcat
     , testProperty "LazyByteString toStrict"  prop_32bitOverflow_Lazy_toStrict
     , testProperty "ShortByteString mconcat"  prop_32bitOverflow_Short_mconcat

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -251,10 +251,10 @@ expectSizeOverflow val = ioProperty $ do
   isLeft <$> try @P.SizeOverflowException (evaluate val)
 
 prop_checkedAdd = forAll (vectorOf 2 nonNeg) $ \[x, y] -> if oflo x y
-  then  expectSizeOverflow (P.checkedAdd "" x y)
-  else  property $ P.checkedAdd "" x y == x + y
-  where  nonNeg = choose (0, (maxBound @Int))
-         oflo x y = toInteger x + toInteger y /= toInteger (x + y)
+  then expectSizeOverflow (P.checkedAdd "" x y)
+  else property $ P.checkedAdd "" x y == x + y
+  where nonNeg = choose (0, (maxBound @Int))
+        oflo x y = toInteger x + toInteger y /= toInteger (x + y)
 
 multCompl :: Int -> Gen Int
 multCompl x = choose (0, fromInteger @Int maxc)
@@ -265,13 +265,13 @@ multCompl x = choose (0, fromInteger @Int maxc)
   where maxc = toInteger (maxBound @Int) * 5 `quot` max 5 (abs $ toInteger x)
 
 prop_checkedMul = forAll genScale $ \scale ->
-  forAll (genVal scale) $ \x -> (x >= 0) ==>
+  forAll (genVal scale) $ \x ->
     forAll (multCompl x) $ \y -> if oflo x y
-      then  expectSizeOverflow (P.checkedMul "" x y)
-      else  property $ P.checkedMul "" x y == x * y
-  where  genScale = choose (0, finiteBitSize @Int 0 - 1)
-         genVal scale = choose (0, 2 * bit scale - 1)
-         oflo x y = toInteger x * toInteger y /= toInteger (x * y)
+      then expectSizeOverflow (P.checkedMul "" x y)
+      else property $ P.checkedMul "" x y == x * y
+  where genScale = choose (0, finiteBitSize @Int 0 - 1)
+        genVal scale = choose (0, bit scale - 1)
+        oflo x y = toInteger x * toInteger y /= toInteger (x * y)
 
 prop_stimesOverflowBasic bs = forAll (multCompl len) $ \n ->
   toInteger n * toInteger len > maxInt ==> expectSizeOverflow (stimes n bs)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -256,7 +256,12 @@ prop_stimesOverflowBasic bs = forAll genPosInt $ \n ->
   where
     maxInt = toInteger @Int (maxBound @Int)
     len    = toInteger @Int (P.length bs)
+
     maxReps = maxInt * 5 `quot` max 5 len
+    -- This choice creates result lengths roughly in the range
+    -- [0..5*(maxBound @Int)], which results in a roughly even split
+    -- between positive and negative overflowed Int results.
+    -- But other choices can probably work well, too.
     genPosInt = chooseInt (1, fromInteger @Int maxReps)
 
 prop_stimesOverflowScary bs =

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -254,7 +254,7 @@ prop_checkedAdd = forAll (vectorOf 2 nonNeg) $ \[x, y] -> if oflo x y
   then expectSizeOverflow (P.checkedAdd "" x y)
   else property $ P.checkedAdd "" x y == x + y
   where nonNeg = choose (0, (maxBound @Int))
-        oflo x y = toInteger x + toInteger y /= toInteger (x + y)
+        oflo x y = toInteger x + toInteger y /= toInteger @Int (x + y)
 
 multCompl :: Int -> Gen Int
 multCompl x = choose (0, fromInteger @Int maxc)
@@ -264,14 +264,14 @@ multCompl x = choose (0, fromInteger @Int maxc)
   -- producing a fair number of non-overflowing products.
   where maxc = toInteger (maxBound @Int) * 5 `quot` max 5 (abs $ toInteger x)
 
-prop_checkedMul = forAll genScale $ \scale ->
+prop_checkedMultiply = forAll genScale $ \scale ->
   forAll (genVal scale) $ \x ->
     forAll (multCompl x) $ \y -> if oflo x y
-      then expectSizeOverflow (P.checkedMul "" x y)
-      else property $ P.checkedMul "" x y == x * y
+      then expectSizeOverflow (P.checkedMultiply "" x y)
+      else property $ P.checkedMultiply "" x y == x * y
   where genScale = choose (0, finiteBitSize @Int 0 - 1)
         genVal scale = choose (0, bit scale - 1)
-        oflo x y = toInteger x * toInteger y /= toInteger (x * y)
+        oflo x y = toInteger x * toInteger y /= toInteger @Int (x * y)
 
 prop_stimesOverflowBasic bs = forAll (multCompl len) $ \n ->
   toInteger n * toInteger len > maxInt ==> expectSizeOverflow (stimes n bs)
@@ -647,7 +647,7 @@ io_tests =
 
 overflow_tests =
     [ testProperty "checkedAdd" prop_checkedAdd
-    , testProperty "checkedMul" prop_checkedMul
+    , testProperty "checkedMultiply" prop_checkedMultiply
     , testProperty "StrictByteString stimes (basic)" prop_stimesOverflowBasic
     , testProperty "StrictByteString stimes (scary)" prop_stimesOverflowScary
     , testProperty "StrictByteString stimes (empty)" prop_stimesOverflowEmpty

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -262,7 +262,7 @@ prop_stimesOverflowBasic bs = forAll genPosInt $ \n ->
     -- [0..5*(maxBound @Int)], which results in a roughly even split
     -- between positive and negative overflowed Int results.
     -- But other choices can probably work well, too.
-    genPosInt = chooseInt (1, fromInteger @Int maxReps)
+    genPosInt = choose (1, fromInteger @Int maxReps)
 
 prop_stimesOverflowScary bs =
   -- "Scary" because this test will cause heap corruption


### PR DESCRIPTION
After making [this comment](https://github.com/haskell/bytestring/pull/410#issuecomment-979268852), I was a bit disappointed to discover that the existing `Semigroup` instances for `StrictByteString` and `ShortByteString` were also memory-unsafe in the presence of `Int` overflow. Here's a quick pass adding some overflow checks where they are necessary, along with a couple of other related small improvements.