### PR TITLE
Break recursion in the (Monoid ByteString) instance

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -274,10 +274,6 @@ import GHC.Word hiding (Word8)
 -- -----------------------------------------------------------------------------
 -- Introducing and eliminating 'ByteString's
 
--- | /O(1)/ The empty 'ByteString'
-empty :: ByteString
-empty = mempty
-
 -- | /O(1)/ Convert a 'Word8' into a 'ByteString'
 singleton :: Word8 -> ByteString
 singleton c = unsafeCreate 1 $ \p -> poke p c

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -276,7 +276,7 @@ import GHC.Word hiding (Word8)
 
 -- | /O(1)/ The empty 'ByteString'
 empty :: ByteString
-empty = BS nullForeignPtr 0
+empty = mempty
 
 -- | /O(1)/ Convert a 'Word8' into a 'ByteString'
 singleton :: Word8 -> ByteString

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -260,7 +260,7 @@ import qualified Data.ByteString.Internal as B
 import qualified Data.ByteString.Unsafe as B
 
 -- Listy functions transparently exported
-import Data.ByteString (empty,null,length,tail,init,append
+import Data.ByteString (null,length,tail,init,append
                        ,inits,tails,reverse,transpose
                        ,concat,take,takeEnd,drop,dropEnd,splitAt
                        ,intercalate,sort,isPrefixOf,isSuffixOf

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -47,6 +47,7 @@ module Data.ByteString.Internal (
         unsafePackLiteral, unsafePackLenLiteral,
 
         -- * Low level imperative construction
+        empty,
         create,
         createUptoN,
         createUptoN',
@@ -235,7 +236,6 @@ instance Ord ByteString where
 
 instance Semigroup ByteString where
     (<>)    = append
-    {-# INLINABLE sconcat #-}
     sconcat (b:|bs) = concat (b:bs)
     stimes  = times
 
@@ -653,6 +653,7 @@ compareBytes (BS fp1 len1) (BS fp2 len2) =
                     x   -> x
 
 
+-- | /O(1)/ The empty 'ByteString'
 empty :: ByteString
 -- This enables bypassing #457 by not using (polymorphic) mempty in
 -- any definitions used by the (Monoid ByteString) instance

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -654,6 +654,8 @@ compareBytes (BS fp1 len1) (BS fp2 len2) =
 
 
 empty :: ByteString
+-- This enables bypassing #457 by not using (polymorphic) mempty in
+-- any definitions used by the (Monoid ByteString) instance
 empty = BS nullForeignPtr 0
 
 append :: ByteString -> ByteString -> ByteString

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -235,11 +235,12 @@ instance Ord ByteString where
 
 instance Semigroup ByteString where
     (<>)    = append
+    {-# INLINABLE sconcat #-}
     sconcat (b:|bs) = concat (b:bs)
     stimes  = times
 
 instance Monoid ByteString where
-    mempty  = BS nullForeignPtr 0
+    mempty  = empty
     mappend = (<>)
     mconcat = concat
 
@@ -651,6 +652,10 @@ compareBytes (BS fp1 len1) (BS fp2 len2) =
                     EQ  -> len1 `compare` len2
                     x   -> x
 
+
+empty :: ByteString
+empty = BS nullForeignPtr 0
+
 append :: ByteString -> ByteString -> ByteString
 append (BS _   0)    b                  = b
 append a             (BS _   0)    = a
@@ -680,7 +685,7 @@ concat = \bss0 -> goLen0 bss0 bss0
     -- closures which would result in unnecessary closure allocation.
   where
     -- It's still possible that the result is empty
-    goLen0 _    []                     = mempty
+    goLen0 _    []                     = empty
     goLen0 bss0 (BS _ 0     :bss)    = goLen0 bss0 bss
     goLen0 bss0 (bs           :bss)    = goLen1 bss0 bs bss
 
@@ -705,8 +710,8 @@ concat = \bss0 -> goLen0 bss0 bss0
 {-# NOINLINE concat #-}
 
 {-# RULES
-"ByteString concat [] -> mempty"
-   concat [] = mempty
+"ByteString concat [] -> empty"
+   concat [] = empty
 "ByteString concat [bs] -> bs" forall x.
    concat [x] = x
  #-}
@@ -715,9 +720,9 @@ concat = \bss0 -> goLen0 bss0 bss0
 times :: Integral a => a -> ByteString -> ByteString
 times n (BS fp len)
   | n < 0 = error "stimes: non-negative multiplier expected"
-  | n == 0 = mempty
+  | n == 0 = empty
   | n == 1 = BS fp len
-  | len == 0 = mempty
+  | len == 0 = empty
   | len == 1 = unsafeCreate size $ \destptr ->
     unsafeWithForeignPtr fp $ \p -> do
       byte <- peek p


### PR DESCRIPTION
This prevents the instance object from being used as a loop-breaker.
Fixes #457.