### PR TITLE
Rewrite intercalate in a more direct way

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1227,25 +1227,6 @@ intercalate (BS fSepPtr sepLen) (BS fhPtr hLen : t) =
   totalLen = List.foldl' (\acc (BS _ chunkLen) -> acc + chunkLen + sepLen) hLen t
 {-# INLINE [1] intercalate #-}
 
-{-# RULES
-"ByteString specialise intercalate c -> intercalateByte" forall c s1 s2 .
-    intercalate (singleton c) [s1, s2] = intercalateWithByte c s1 s2
-  #-}
-
--- | /O(n)/ intercalateWithByte. An efficient way to join to two ByteStrings
--- with a char. Around 4 times faster than the generalised join.
---
-intercalateWithByte :: Word8 -> ByteString -> ByteString -> ByteString
-intercalateWithByte c f@(BS ffp l) g@(BS fgp m) = unsafeCreate len $ \ptr ->
-    unsafeWithForeignPtr ffp $ \fp ->
-    unsafeWithForeignPtr fgp $ \gp -> do
-        memcpy ptr fp l
-        poke (ptr `plusPtr` l) c
-        memcpy (ptr `plusPtr` (l + 1)) gp m
-    where
-      len = length f + length g + 1
-{-# INLINE intercalateWithByte #-}
-
 -- ---------------------------------------------------------------------
 -- Indexing ByteStrings
 

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -376,6 +376,11 @@ main = do
       [ bench "intersperse" $ whnf (S.intersperse 32) byteStringData
       , bench "intersperse (unaligned)" $ whnf (S.intersperse 32) (S.drop 1 byteStringData)
       ]
+    , bgroup "intercalate"
+      [ bench "intercalate (large)" $ whnf (S.intercalate $ S8.pack " and also ") (replicate 300 (S8.pack "expression"))
+      , bench "intercalate (small)" $ whnf (S.intercalate $ S8.pack "&") (replicate 30 (S8.pack "foo"))
+      , bench "intercalate (tiny)" $ whnf (S.intercalate $ S8.pack "&") (S8.pack <$> ["foo", "bar", "baz"])
+      ]
     , bgroup "partition"
       [
         bgroup "strict"


### PR DESCRIPTION
One thing that seems suspicious was that there's supposedly efficient `intercalateWithByte`, but it only works on two strings.

This PR takes the approach from `intercalateWithByte` to `intercalate`. Unfortunately there are not any benchmarks for either function so I don't know where the performance claims of `intercalateWithByte` come from.