### PR TITLE
Use official Docker images for arm64

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,18 +13,38 @@ steps:
     - cabal new-test
 ---
 kind: pipeline
-name: arm64
+name: arm64-ghc8.10
 platform: { os: linux, arch: arm64 }
 steps:
 - name: Test
-  image: buildpack-deps:focal
+  image: haskell:8.10
   commands:
-    - export LC_ALL=C.UTF-8
     - uname -a # check platform
     - getconf LONG_BIT # check bitness
-    - apt-get update -y
-    - apt-get install -y ghc cabal-install
-    - cabal --version
+    - cabal update
+    - cabal new-test
+---
+kind: pipeline
+name: arm64-ghc9.0
+platform: { os: linux, arch: arm64 }
+steps:
+- name: Test
+  image: haskell:9.0
+  commands:
+    - uname -a # check platform
+    - getconf LONG_BIT # check bitness
+    - cabal update
+    - cabal new-test
+---
+kind: pipeline
+name: arm64-ghc9.2
+platform: { os: linux, arch: arm64 }
+steps:
+- name: Test
+  image: haskell:9.2
+  commands:
+    - uname -a # check platform
+    - getconf LONG_BIT # check bitness
     - cabal update
     - cabal new-test
 ---


### PR DESCRIPTION
Thanks to @AlistairB there are now official Docker images for arm64, covering GHC 8.10, 9.0 and 9.2. 

I suspect the failure in GHC 9.2.1 build is caused by known issues with arm code generator, so this PR will remain a draft until GHC 9.2.2. 