### PR TITLE
intercalate-related cleanup

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1225,7 +1225,7 @@ intercalate (BS fSepPtr sepLen) (BS fhPtr hLen : t) =
   where
   totalLen = List.foldl' (\acc chunk -> acc +! sepLen +! length chunk) hLen t
   (+!) = checkedAdd "intercalate"
-
+{-# INLINABLE intercalate #-}
 
 -- ---------------------------------------------------------------------
 -- Indexing ByteStrings

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1224,7 +1224,8 @@ intercalate (BS fSepPtr sepLen) (BS fhPtr hLen : t) =
             go (destPtr' `plusPtr` chunkLen) chunks
       go (dstPtr0 `plusPtr` hLen) t
   where
-  totalLen = List.foldl' (\acc (BS _ chunkLen) -> acc + chunkLen + sepLen) hLen t
+  totalLen = List.foldl' (\acc chunk -> acc +! sepLen +! length chunk) hLen t
+  (+!) = checkedAdd "intercalate"
 {-# INLINE [1] intercalate #-}
 
 -- ---------------------------------------------------------------------

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -277,9 +277,7 @@ import GHC.Word hiding (Word8)
 -- | /O(1)/ Convert a 'Word8' into a 'ByteString'
 singleton :: Word8 -> ByteString
 singleton c = unsafeCreate 1 $ \p -> poke p c
-{-# INLINE [1] singleton #-}
-
--- Inline [1] for intercalate rule
+{-# INLINE singleton #-}
 
 --
 -- XXX The use of unsafePerformIO in allocating functions (unsafeCreate) is critical!
@@ -1226,7 +1224,7 @@ intercalate (BS fSepPtr sepLen) (BS fhPtr hLen : t) =
   where
   totalLen = List.foldl' (\acc chunk -> acc +! sepLen +! length chunk) hLen t
   (+!) = checkedAdd "intercalate"
-{-# INLINE [1] intercalate #-}
+
 
 -- ---------------------------------------------------------------------
 -- Indexing ByteStrings

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1208,6 +1208,7 @@ groupBy k xs = case uncons xs of
 -- argument between each element of the list.
 intercalate :: ByteString -> [ByteString] -> ByteString
 intercalate _ [] = mempty
+intercalate _ [x] = x -- This branch exists for laziness, not speed
 intercalate (BS fSepPtr sepLen) (BS fhPtr hLen : t) =
   unsafeCreate totalLen $ \dstPtr0 ->
     unsafeWithForeignPtr fSepPtr $ \sepPtr -> do


### PR DESCRIPTION
With #459 merged, the size-related arithmetic in `intercalate` now needs its own overflow-detection separate from that in `concat`, and the INLINE phase markers related to the removed `intercalateWithByte` rule are no longer necessary.