### PR TITLE
Data.ByteString.Char8: Fix doc comment for dropWhileEnd.

### DIFF
--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -536,7 +536,7 @@ dropWhile f = B.dropWhile (f . w2c)
     dropWhile isSpace = dropSpace
   #-}
 
--- | 'dropWhile' @p xs@ returns the prefix remaining after 'takeWhileEnd' @p
+-- | 'dropWhileEnd' @p xs@ returns the prefix remaining after 'takeWhileEnd' @p
 -- xs@.
 --
 -- @since 0.10.12.0


### PR DESCRIPTION
The documentation comment for `dropWhileEnd` in `Data/ByteString/Char8.hs` refers to `dropWhileEnd` as `dropWhile`.  This fixes that.
