### PR TITLE
Lazier unlines

### DIFF
--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -282,7 +282,7 @@ import Data.ByteString.ReadNat
 import Data.Char    ( isSpace )
 -- See bytestring #70
 import GHC.Char (eqChar)
-import qualified Data.List as List (intersperse)
+import qualified Data.List as List (concatMap)
 
 import System.IO    (Handle,stdout)
 import Foreign
@@ -968,9 +968,7 @@ lines (BS x l) = go x l
 -- | 'unlines' is an inverse operation to 'lines'.  It joins lines,
 -- after appending a terminating newline to each.
 unlines :: [ByteString] -> ByteString
-unlines [] = empty
-unlines ss = concat (List.intersperse nl ss) `append` nl -- half as much space
-    where nl = singleton '\n'
+unlines = concat . List.concatMap (\x -> [x, singleton '\n'])
 
 -- | 'words' breaks a ByteString up into a list of words, which
 -- were delimited by Chars representing white space.

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -911,9 +911,7 @@ lines (Chunk c0 cs0) = loop0 c0 cs0
 -- | 'unlines' is an inverse operation to 'lines'.  It joins lines,
 -- after appending a terminating newline to each.
 unlines :: [ByteString] -> ByteString
-unlines [] = empty
-unlines ss = concat (List.intersperse nl ss) `append` nl -- half as much space
-    where nl = singleton '\n'
+unlines = concat . List.concatMap (\x -> [x, singleton '\n'])
 
 -- | 'words' breaks a ByteString up into a list of words, which
 -- were delimited by Chars representing white space. And

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -23,6 +23,7 @@ import           Prelude                               hiding (words)
 import qualified Data.ByteString                       as S
 import qualified Data.ByteString.Char8                 as S8
 import qualified Data.ByteString.Lazy                  as L
+import qualified Data.ByteString.Lazy.Char8            as L8
 
 import           Data.ByteString.Builder
 import           Data.ByteString.Builder.Extra         (byteStringCopy,
@@ -469,6 +470,7 @@ main = do
       [ bench "map (+1) large" $ nf (S.map (+ 1)) largeTraversalInput
       , bench "map (+1) small" $ nf (S.map (+ 1)) smallTraversalInput
       ]
+    , bench "lazy-unlines" $ nf L8.unlines (map (L8.pack . show) intData)
     , benchBoundsCheckFusion
     , benchCount
     , benchCSV

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -470,7 +470,10 @@ main = do
       [ bench "map (+1) large" $ nf (S.map (+ 1)) largeTraversalInput
       , bench "map (+1) small" $ nf (S.map (+ 1)) smallTraversalInput
       ]
-    , bench "lazy-unlines" $ nf L8.unlines (map (L8.pack . show) intData)
+    , bgroup "unlines"
+      [ bench "lazy"   $ nf L8.unlines (map (L8.pack . show) intData)
+      , bench "strict" $ nf S8.unlines (map (S8.pack . show) intData)
+      ]
     , benchBoundsCheckFusion
     , benchCount
     , benchCSV

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -649,6 +649,7 @@ strictness_checks =
         D.take (D.length xs + 1) (D.scanl (+.) '\NUL' (explosiveTail (xs <> D.singleton '\SOH'))) === (D.pack . fmap (D.foldr (+.) '\NUL') . D.inits) xs
     , testProperty "scanl1 is lazy" $ \ xs -> D.length xs > 0 ==> let char1 +. char2 = toEnum (fromEnum char1 + fromEnum char2) in
         D.take (D.length xs) (D.scanl1 (+.) (explosiveTail (xs <> D.singleton '\SOH'))) === (D.pack . fmap (D.foldr1 (+.)) . tail . D.inits) xs
+    , testProperty "unlines is lazy" $ \ xs -> D.take (D.length xs + 1) (D.unlines (xs : error "Tail of this list is undefined!")) === xs `D.snoc` '\n'
     ]
   ]
 


### PR DESCRIPTION
Fixes #476 

Benchmark results:

before:
```
  lazy-unlines: OK (0.30s)
    547  μs ±  34 μs, 3.2 MB allocated,  23 KB copied,  38 MB peak memory
```

after:

```
  lazy-unlines: OK (0.20s)
    354  μs ±  24 μs, 2.0 MB allocated,  23 KB copied,  38 MB peak memory
```