### PR TITLE
Implement 'unlines' directly

### DIFF
--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -965,8 +965,10 @@ lines (BS x l) = go x l
                     else return [BS f i]
 -}
 
--- | 'unlines' is a near-inverse operation to 'lines'.  It joins lines,
--- after appending a terminating newline to each.
+-- | 'unlines' joins lines, appending a terminating newline after each.
+--
+-- Equivalent to
+--     @'concat' . Data.List.concatMap (\\x -> [x, 'singleton' \'\\n'])@.
 unlines :: [ByteString] -> ByteString
 unlines = \li -> let
   totLen = List.foldl' (\acc s -> acc +! length s +! 1) 0 li

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -282,7 +282,7 @@ import Data.ByteString.ReadNat
 import Data.Char    ( isSpace )
 -- See bytestring #70
 import GHC.Char (eqChar)
-import qualified Data.List as List (concatMap)
+import qualified Data.List as List
 
 import System.IO    (Handle,stdout)
 import Foreign
@@ -965,10 +965,19 @@ lines (BS x l) = go x l
                     else return [BS f i]
 -}
 
--- | 'unlines' is an inverse operation to 'lines'.  It joins lines,
+-- | 'unlines' is a near-inverse operation to 'lines'.  It joins lines,
 -- after appending a terminating newline to each.
 unlines :: [ByteString] -> ByteString
-unlines = concat . List.concatMap (\x -> [x, singleton '\n'])
+unlines = \li -> let
+  totLen = List.foldl' (\acc s -> acc +! length s +! 1) 0 li
+  (+!) = checkedAdd "Char8.unlines"
+
+  go [] _ = pure ()
+  go (BS srcFP len : srcs) dest = do
+    unsafeWithForeignPtr srcFP $ \src -> memcpy dest src len
+    pokeElemOff dest len (c2w '\n')
+    go srcs $ dest `plusPtr` (len + 1)
+  in  unsafeCreate totLen (go li)
 
 -- | 'words' breaks a ByteString up into a list of words, which
 -- were delimited by Chars representing white space.

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -908,8 +908,10 @@ lines (Chunk c0 cs0) = loop0 c0 cs0
                 let !c' = revChunks (B.unsafeTake n c : line)
                  in c' : loop0 (B.unsafeDrop (n+1) c) cs
 
--- | 'unlines' is a near-inverse operation to 'lines'.  It joins lines,
--- after appending a terminating newline to each.
+-- | 'unlines' joins lines, appending a terminating newline after each.
+--
+-- Equivalent to
+--     @'concat' . Data.List.concatMap (\\x -> [x, 'singleton' \'\\n'])@.
 unlines :: [ByteString] -> ByteString
 unlines = List.foldr (\x t -> x `append` cons '\n' t) Empty
 

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -908,10 +908,10 @@ lines (Chunk c0 cs0) = loop0 c0 cs0
                 let !c' = revChunks (B.unsafeTake n c : line)
                  in c' : loop0 (B.unsafeDrop (n+1) c) cs
 
--- | 'unlines' is an inverse operation to 'lines'.  It joins lines,
+-- | 'unlines' is a near-inverse operation to 'lines'.  It joins lines,
 -- after appending a terminating newline to each.
 unlines :: [ByteString] -> ByteString
-unlines = concat . List.concatMap (\x -> [x, singleton '\n'])
+unlines = List.foldr (\x t -> x `append` cons '\n' t) Empty
 
 -- | 'words' breaks a ByteString up into a list of words, which
 -- were delimited by Chars representing white space. And


### PR DESCRIPTION
Closes #478.

I wanted to share some code between strict `unlines` and strict `intercalate`, but wasn't able to easily get the singleton-copying to rewrite to a `poke` or similar, resulting in a performance hit. I think this level of duplication is acceptable.

My idea to make `Lazy.concat` fuse with the existing lazy `unlines` definition was a slight improvement, but just writing the fused fold manually produced bigger gains. I think this is because now no attempt is made to iterate over a singleton.

Benchmark results:

master:
```
  unlines
    lazy:   OK (0.94s)
      854  μs ±  17 μs
    strict: OK (0.74s)
      688  μs ±  13 μs
```

topic branch:
```
  unlines
    lazy:   OK (19.72s)
      599  μs ± 4.7 μs
    strict: OK (68.04s)
      249  μs ±  18 μs
```