### PR TITLE
Repair cbits on CentOS 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,21 @@ jobs:
           cabal update
           cabal run -w ghc-9.3.20220124 --ghc-options='-fcheck-prim-bounds -fno-ignore-asserts' bytestring-tests
       shell: bash
+
+  old-gcc:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:7
+    steps:
+    - name: install deps
+      run: |
+          yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 sh
+      shell: bash
+    - uses: actions/checkout@v2
+    - name: test
+      run: |
+          source ~/.ghcup/env
+          cabal update
+          cabal run bytestring-tests
+      shell: bash

--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -38,8 +38,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef __STDC_NO_ATOMICS__
+#if defined(__x86_64__) && (__GNUC__ >= 6 || defined(__clang_major__)) && !defined(__STDC_NO_ATOMICS__)
 #include <stdatomic.h>
+#define USE_SIMD_COUNT
 #endif
 
 /* copy a string in reverse */
@@ -114,9 +115,6 @@ size_t fps_count_naive(unsigned char *str, size_t len, unsigned char w) {
     return c;
 }
 
-#if defined(__x86_64__) && (__GNUC__ >= 6 || defined(__clang_major__)) && !defined(__STDC_NO_ATOMICS__)
-#define USE_SIMD_COUNT
-#endif
 
 #ifdef USE_SIMD_COUNT
 __attribute__((target("sse4.2")))


### PR DESCRIPTION
Closes #481. The approach is a bit heavy-handed (basically, CentOS 7 gets no SIMD UTF-8 stuff at all), but the fallback _should_ still be fairly fast. I've also implemented [Bodigrim's suggestion](https://github.com/haskell/bytestring/issues/481#issuecomment-1029464445) as part of this to ensure that `fpstring.c` can also build.

Ping for @hasufell and @Bodigrim.