### PR TITLE
Eliminate redundant dependency on libgcc_s on Windows

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -139,7 +139,7 @@ library
   -- * https://gitlab.haskell.org/ghc/ghc/-/issues/20525#note_385580
   -- * https://gitlab.haskell.org/ghc/ghc/-/issues/19417
   if os(windows)
-    extra-libraries:  gcc_s gcc
+    extra-libraries:  gcc
 
   include-dirs:      include
   includes:          fpstring.h


### PR DESCRIPTION
This dependency causes an unnecessary dynamic dependency on Windows,
resulting in GHC #21196.

Fixes #497.