### PR TITLE
Remove outdated comments on Windows extra-libraries

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -135,9 +135,6 @@ library
   -- DNDEBUG disables asserts in cbits/
   cc-options:        -std=c11 -DNDEBUG=1
  
-  -- Required, due to the following issues:
-  -- * https://gitlab.haskell.org/ghc/ghc/-/issues/20525#note_385580
-  -- * https://gitlab.haskell.org/ghc/ghc/-/issues/19417
   if os(windows)
     extra-libraries:  gcc
 


### PR DESCRIPTION
Follow-up to #500, which removed the gcc_s extra-library dependency.