### PR TITLE
__get_cpuid_count was introduced in gcc 6.3

### DIFF
--- a/cbits/fpstring.c
+++ b/cbits/fpstring.c
@@ -38,7 +38,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#if defined(__x86_64__) && (__GNUC__ >= 6 || defined(__clang_major__)) && !defined(__STDC_NO_ATOMICS__)
+#if defined(__x86_64__) && (__GNUC__ >= 7 || __GNUC__ == 6 && __GNUC_MINOR__ >= 3 || defined(__clang_major__)) && !defined(__STDC_NO_ATOMICS__)
 #include <stdatomic.h>
 #define USE_SIMD_COUNT
 #endif

--- a/cbits/is-valid-utf8.c
+++ b/cbits/is-valid-utf8.c
@@ -38,7 +38,7 @@ SUCH DAMAGE.
 #include <emmintrin.h>
 #include <immintrin.h>
 #include <cpuid.h>
-#if (__GNUC__ >= 6 || defined(__clang_major__)) && !defined(__STDC_NO_ATOMICS__)
+#if (__GNUC__ >= 7 || __GNUC__ == 6 && __GNUC_MINOR__ >= 3 || defined(__clang_major__)) && !defined(__STDC_NO_ATOMICS__)
 #include <tmmintrin.h>
 #include <stdatomic.h>
 #else


### PR DESCRIPTION
Closes #504. 

See https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/ChangeLog;h=06ebfb1a548abc36a464ec713c33232c3c872baf;hb=91c632c88994dca583bcd94e39cd3eba1506ecfe and https://github.com/haskell/text/pull/407