### PR TITLE
correct `drop` documentation

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -917,7 +917,7 @@ takeEnd n ps@(BS x len)
 {-# INLINE takeEnd #-}
 
 -- | /O(1)/ 'drop' @n xs@ returns the suffix of @xs@ after the first @n@
--- elements, or @[]@ if @n > 'length' xs@.
+-- elements, or 'empty' if @n > 'length' xs@.
 drop  :: Int -> ByteString -> ByteString
 drop n ps@(BS x l)
     | n <= 0    = ps

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -773,7 +773,7 @@ takeEnd i cs0        = takeEnd' i cs0
             | otherwise      = (0, Chunk (S.takeEnd (fromIntegral n) c) cs)
 
 -- | /O(n\/c)/ 'drop' @n xs@ returns the suffix of @xs@ after the first @n@
--- elements, or @[]@ if @n > 'length' xs@.
+-- elements, or 'empty' if @n > 'length' xs@.
 drop  :: Int64 -> ByteString -> ByteString
 drop i p | i <= 0 = p
 drop i cs0 = drop' i cs0

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -1037,7 +1037,7 @@ takeEnd n = \sbs -> let sl = length sbs
 takeWhileEnd :: (Word8 -> Bool) -> ShortByteString -> ShortByteString
 takeWhileEnd f = \sbs -> drop (findFromEndUntil (not . f) sbs) sbs
 
--- | /O(n)/ 'drop' @n@ @xs@ returns the suffix of @xs@ after the first n elements, or @[]@ if @n > 'length' xs@.
+-- | /O(n)/ 'drop' @n@ @xs@ returns the suffix of @xs@ after the first n elements, or 'empty' if @n > 'length' xs@.
 --
 -- Note: copies the entire byte array
 --


### PR DESCRIPTION
The inline doc for `drop  :: Int -> ByteString -> ByteString` states that it can return `[]`. 
This is mistaken, and is likely due to copying documentation from `Data.List`.