### PR TITLE
de-list documentation

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -695,7 +695,7 @@ minimum xs@(BS x l)
 -- | The 'mapAccumL' function behaves like a combination of 'map' and
 -- 'foldl'; it applies a function to each element of a ByteString,
 -- passing an accumulating parameter from left to right, and returning a
--- final value of this accumulator together with the new list.
+-- final value of this accumulator together with the new ByteString.
 mapAccumL :: (acc -> Word8 -> (acc, Word8)) -> acc -> ByteString -> (acc, ByteString)
 mapAccumL f acc = \(BS fp len) -> unsafeDupablePerformIO $ unsafeWithForeignPtr fp $ \a -> do
                -- see fold inlining

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1176,7 +1176,7 @@ split w (BS x l) = loop 0
 
 -- | The 'group' function takes a ByteString and returns a list of
 -- ByteStrings such that the concatenation of the result is equal to the
--- argument.  Moreover, each sublist in the result contains only equal
+-- argument.  Moreover, each string in the result contains only equal
 -- elements.  For example,
 --
 -- > group "Mississippi" = ["M","i","ss","i","ss","i","pp","i"]

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -437,7 +437,7 @@ minimum = w2c . B.minimum
 -- | The 'mapAccumL' function behaves like a combination of 'map' and
 -- 'foldl'; it applies a function to each element of a ByteString,
 -- passing an accumulating parameter from left to right, and returning a
--- final value of this accumulator together with the new list.
+-- final value of this accumulator together with the new ByteString.
 mapAccumL :: (acc -> Char -> (acc, Char)) -> acc -> ByteString -> (acc, ByteString)
 mapAccumL f = B.mapAccumL (\acc w -> case f acc (w2c w) of (acc', c) -> (acc', c2w c))
 

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1070,7 +1070,7 @@ split w (Chunk c0 cs0) = comb [] (S.split w c0) cs0
 
 -- | The 'group' function takes a ByteString and returns a list of
 -- ByteStrings such that the concatenation of the result is equal to the
--- argument.  Moreover, each sublist in the result contains only equal
+-- argument.  Moreover, each string in the result contains only equal
 -- elements.  For example,
 --
 -- > group "Mississippi" = ["M","i","ss","i","ss","i","pp","i"]


### PR DESCRIPTION
In the same spirit as #509, I found a few more places where lists snuck into the docstrings where they should be strings or ByteString.