### PR TITLE
Add functionality for toConstr on Data instance

### DIFF
--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -136,7 +136,7 @@ import Data.Char                (ord)
 import Data.Word
 
 import Data.Typeable            (Typeable)
-import Data.Data                (Data(..), mkNoRepType)
+import Data.Data                (Data(..), mkNoRepType, mkConstr ,mkDataType, Constr, DataType, Fixity(Prefix))
 
 import GHC.Base                 (nullAddr#,realWorld#,unsafeChr)
 import GHC.Exts                 (IsList(..))
@@ -309,9 +309,15 @@ instance IsString ByteString where
 
 instance Data ByteString where
   gfoldl f z txt = z packBytes `f` unpackBytes txt
-  toConstr _     = error "Data.ByteString.ByteString.toConstr"
+  toConstr _     = packConstr
   gunfold _ _    = error "Data.ByteString.ByteString.gunfold"
   dataTypeOf _   = mkNoRepType "Data.ByteString.ByteString"
+
+packConstr :: Constr
+packConstr = mkConstr byteStringDataType "pack" [] Prefix
+
+byteStringDataType :: DataType
+byteStringDataType = mkDataType "Data.ByteString" [packConstr]
 
 -- | @since 0.11.2.0
 instance TH.Lift ByteString where

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -65,7 +65,7 @@ import Control.DeepSeq  (NFData, rnf)
 import Data.String      (IsString(..))
 
 import Data.Typeable            (Typeable)
-import Data.Data                (Data(..), mkNoRepType)
+import Data.Data                (Data(..), mkNoRepType, mkConstr ,mkDataType, Constr, DataType, Fixity(Prefix))
 
 import GHC.Exts                 (IsList(..))
 
@@ -126,9 +126,15 @@ instance IsString ByteString where
 
 instance Data ByteString where
   gfoldl f z txt = z packBytes `f` unpackBytes txt
-  toConstr _     = error "Data.ByteString.Lazy.ByteString.toConstr"
+  toConstr _     = packConstr
   gunfold _ _    = error "Data.ByteString.Lazy.ByteString.gunfold"
   dataTypeOf _   = mkNoRepType "Data.ByteString.Lazy.ByteString"
+
+packConstr :: Constr
+packConstr = mkConstr byteStringDataType "pack" [] Prefix
+
+byteStringDataType :: DataType
+byteStringDataType = mkDataType "Data.ByteString.Lazy.ByteString" [packConstr]
 
 ------------------------------------------------------------------------
 -- Packing and unpacking from lists

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -179,7 +179,14 @@ import Data.Bits
   , (.|.)
   )
 import Data.Data
-  ( Data(..) )
+  ( Data(..)
+  , mkNoRepType
+  , mkConstr
+  , mkDataType
+  , Constr
+  , DataType
+  , Fixity(Prefix)
+  )
 import Data.Monoid
   ( Monoid(..) )
 import Data.Semigroup
@@ -287,7 +294,7 @@ newtype ShortByteString =
   { unShortByteString :: ByteArray
   -- ^ @since 0.12.0.0
   }
-  deriving (Eq, TH.Lift, Data, NFData)
+  deriving (Eq, TH.Lift, NFData)
 
 -- | Prior to @bytestring-0.12@ 'SBS' was a genuine constructor of 'ShortByteString',
 -- but now it is a bundled pattern synonym, provided as a compatibility shim.
@@ -335,6 +342,18 @@ instance GHC.Exts.IsList ShortByteString where
 -- e.g. "枯朶に烏のとまりけり秋の暮" becomes �6k�nh~�Q��n�
 instance IsString ShortByteString where
     fromString = packChars
+
+instance Data ShortByteString where
+  gfoldl f z txt = z packBytes `f` unpackBytes txt
+  toConstr _     = packConstr
+  gunfold _ _    = error "Data.ByteString.Short.ShortByteString.gunfold"
+  dataTypeOf _   = mkNoRepType "Data.ByteString.Short.ShortByteString"
+
+packConstr :: Constr
+packConstr = mkConstr byteStringDataType "pack" [] Prefix
+
+byteStringDataType :: DataType
+byteStringDataType = mkDataType "Data.ByteString.Short.ShortByteString" [packConstr]
 
 ------------------------------------------------------------------------
 -- Simple operations

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -177,7 +177,8 @@ test-suite bytestring-tests
                     tasty,
                     tasty-quickcheck >= 0.8.1,
                     template-haskell,
-                    transformers >= 0.3
+                    transformers >= 0.3,
+                    syb
   ghc-options:      -fwarn-unused-binds
                     -threaded -rtsopts
   default-language: Haskell2010

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -94,7 +94,8 @@ prop_lines_lazy2 =
 
 prop_strip x = C.strip x == (C.dropSpace . C.reverse . C.dropSpace . C.reverse) x
 
-prop_toConstr =  True ==> "pack" == ((showConstr . toConstr) "pack")
+prop_toConstr :: P.ByteString -> Property
+prop_toConstr bs = True ==> "pack" == ((showConstr  . toConstr) bs)
 
 class (Bounded a, Integral a, Show a) => RdInt a where
     rdIntC :: C.ByteString -> Maybe (a, C.ByteString)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -99,11 +99,11 @@ prop_strip x = C.strip x == (C.dropSpace . C.reverse . C.dropSpace . C.reverse) 
 prop_toConstr :: P.ByteString -> Property
 prop_toConstr bs = True ==> "(pack)" == ((showConstr  . toConstr) bs)
 
-pror_gshow_empty :: P.ByteString -> Property
-pror_gshow_empty b = (not . null . Char8.unpack) b ==> (not . null . gshow) b
+prop_gshow_empty :: P.ByteString -> Property
+prop_gshow_empty b = (not . null . Char8.unpack) b ==> (not . null . gshow) b
 
-pror_gshow_equal :: P.ByteString -> Property
-pror_gshow_equal b = True ==> read_bs b == read_string b
+prop_gshow_equal :: P.ByteString -> Property
+prop_gshow_equal b = True ==> read_bs b == read_string b
     where
         read_bs :: P.ByteString -> [(P.ByteString, String)]
         read_bs = gread . gshow
@@ -720,8 +720,8 @@ misc_tests =
     , testProperty "readNaturalSafe"   prop_readNaturalSafe
     , testProperty "readNaturalUnsafe" prop_readNaturalUnsafe
     , testProperty "instance Data toConstr" prop_toConstr
-    , testProperty "gshow empty" pror_gshow_empty
-    , testProperty "gshow equal" pror_gshow_equal
+    , testProperty "gshow empty" prop_gshow_empty
+    , testProperty "gshow equal" prop_gshow_equal
     ]
 
 strictness_checks =

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -97,7 +97,7 @@ prop_lines_lazy2 =
 prop_strip x = C.strip x == (C.dropSpace . C.reverse . C.dropSpace . C.reverse) x
 
 prop_toConstr :: P.ByteString -> Property
-prop_toConstr bs = True ==> "(pack)" == ((showConstr  . toConstr) bs)
+prop_toConstr bs = True ==> "pack" == ((showConstr  . toConstr) bs)
 
 prop_gshow_empty :: P.ByteString -> Property
 prop_gshow_empty b = (not . null . Char8.unpack) b ==> (not . null . gshow) b
@@ -109,6 +109,9 @@ prop_gshow_equal b = True ==> read_bs b == read_string b
         read_bs = gread . gshow
         read_string :: P.ByteString -> [(P.ByteString, String)]
         read_string = gread . Char8.unpack
+
+prop_gshow_string :: P.ByteString -> Property
+prop_gshow_string b = True ==> (gshow . Char8.pack) "A" == "(pack ((:) (65) ([])))"
 
 class (Bounded a, Integral a, Show a) => RdInt a where
     rdIntC :: C.ByteString -> Maybe (a, C.ByteString)
@@ -722,6 +725,7 @@ misc_tests =
     , testProperty "instance Data toConstr" prop_toConstr
     , testProperty "gshow empty" prop_gshow_empty
     , testProperty "gshow equal" prop_gshow_equal
+    , testProperty "gshow string" prop_gshow_string
     ]
 
 strictness_checks =

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -28,6 +28,7 @@ import System.Posix.Internals (c_unlink)
 
 import qualified Data.List as List
 import Data.Char
+import Data.Data (toConstr, showConstr)
 import Data.Word
 import Data.Maybe
 import Data.Either (isLeft)
@@ -92,6 +93,8 @@ prop_lines_lazy2 =
     head (tail (LC.lines (LC.append (LC.pack "a\nb\n") undefined))) == LC.pack "b"
 
 prop_strip x = C.strip x == (C.dropSpace . C.reverse . C.dropSpace . C.reverse) x
+
+prop_toConstr =  True ==> "pack" == ((showConstr . toConstr) "pack")
 
 class (Bounded a, Integral a, Show a) => RdInt a where
     rdIntC :: C.ByteString -> Maybe (a, C.ByteString)
@@ -702,6 +705,7 @@ misc_tests =
     , testProperty "readIntegerUnsafe" prop_readIntegerUnsafe
     , testProperty "readNaturalSafe"   prop_readNaturalSafe
     , testProperty "readNaturalUnsafe" prop_readNaturalUnsafe
+    , testProperty "instance Data toConstr" prop_toConstr
     ]
 
 strictness_checks =

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -45,7 +45,6 @@ import qualified Data.ByteString.Builder.Internal   as BI
 import qualified Data.ByteString.Builder.Prim       as BP
 import           Data.ByteString.Builder.Prim.TestUtils
 
-import           Data.Data (toConstr, showConstr)
 import           Control.Exception (evaluate)
 import           System.IO (openTempFile, hPutStr, hClose, hSetBinaryMode, hSetEncoding, utf8, hSetNewlineMode, noNewlineTranslation)
 import           Foreign (ForeignPtr, withForeignPtr, castPtr)
@@ -68,7 +67,6 @@ tests =
   , testPut
   , testRunBuilder
   , testWriteFile
-  , testToConstr
   ] ++
   testsEncodingToBuilder ++
   testsBinary ++
@@ -437,6 +435,7 @@ test_encodeUnfoldrB =
       where
         go []     = Nothing
         go (c:cs) = Just (c, cs)
+
 
 ------------------------------------------------------------------------------
 -- Testing the Put monad
@@ -989,9 +988,3 @@ testsUtf8 =
   [ testBuilderConstr "charUtf8" charUtf8_list charUtf8
   , testBuilderConstr "stringUtf8" (foldMap charUtf8_list) stringUtf8
   ]
-
-testToConstr :: TestTree
-testToConstr = compareImpls "toConstr" s (showConstr . toConstr)
-  where
-    s :: S.ByteString -> String
-    s _ = "pack"

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -45,6 +45,7 @@ import qualified Data.ByteString.Builder.Internal   as BI
 import qualified Data.ByteString.Builder.Prim       as BP
 import           Data.ByteString.Builder.Prim.TestUtils
 
+import           Data.Data (toConstr, showConstr)
 import           Control.Exception (evaluate)
 import           System.IO (openTempFile, hPutStr, hClose, hSetBinaryMode, hSetEncoding, utf8, hSetNewlineMode, noNewlineTranslation)
 import           Foreign (ForeignPtr, withForeignPtr, castPtr)
@@ -67,6 +68,7 @@ tests =
   , testPut
   , testRunBuilder
   , testWriteFile
+  , testToConstr
   ] ++
   testsEncodingToBuilder ++
   testsBinary ++
@@ -435,7 +437,6 @@ test_encodeUnfoldrB =
       where
         go []     = Nothing
         go (c:cs) = Just (c, cs)
-
 
 ------------------------------------------------------------------------------
 -- Testing the Put monad
@@ -988,3 +989,9 @@ testsUtf8 =
   [ testBuilderConstr "charUtf8" charUtf8_list charUtf8
   , testBuilderConstr "stringUtf8" (foldMap charUtf8_list) stringUtf8
   ]
+
+testToConstr :: TestTree
+testToConstr = compareImpls "toConstr" s (showConstr . toConstr)
+  where
+    s :: S.ByteString -> String
+    s _ = "pack"


### PR DESCRIPTION
PR attempting to fix #513. 

As discussed in the issue, I used the `Data.Text` implementation to copy from. I found the PR where the `toConstr` function was [implemented](https://github.com/haskell/text/pull/74), but it did not include any tests to help me write some for this PR. I just used the use case for the `gshow` function.

I looked at the implementation of [gshow](https://github.com/dreixel/syb/blob/f741a437f18768f71586eeb47ffb43c0915f331b/src/Data/Generics/Text.hs#L44) and saw that it was calling `showConstr . toConstr`. I added line to the tests and it seems to work fine. 