### PR TITLE
Add lower bound for tasty-quickcheck

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -169,7 +169,7 @@ test-suite bytestring-tests
                     ghc-prim,
                     QuickCheck,
                     tasty,
-                    tasty-quickcheck,
+                    tasty-quickcheck >= 0.8.1,
                     template-haskell,
                     transformers >= 0.3
   ghc-options:      -fwarn-unused-binds


### PR DESCRIPTION
Otherwise with `tasty-quickcheck-0.8.0.3` we get
```
[ 8 of 15] Compiling QuickCheckUtils [Test.Tasty.QuickCheck changed]

tests/QuickCheckUtils.hs:107:32: error:
    Not in scope: type constructor or class ‘Gen’
    |
107 | sizedShortByteString :: Int -> Gen SB.ShortByteString
    |                                ^^^
```