### PR TITLE
IsString rules

### DIFF
--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -581,8 +581,8 @@ prop_short_mappend xs ys =
 prop_short_mconcat xss =
     mconcat xss == Short.unpack (mconcat (map Short.pack xss))
 
-prop_short_fromString s =
-    fromString s == Short.fromShort (fromString s)
+prop_short_fromString xs = expectFailure $
+    length (Short.unpack (fromString xs)) `seq` ()
 
 prop_short_show xs =
     show (Short.pack xs) == show (map P.w2c xs)

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -603,8 +603,8 @@ tests =
     \n x -> B.indexMaybe x (fromIntegral (n :: Int)) === x B.!? (fromIntegral n)
 
 #ifdef BYTESTRING_CHAR8
-  , testProperty "isString" $
-    \x -> x === fromString (B.unpack x)
+  , testProperty "isString" $ expectFailure $
+    \xs -> length (B.unpack (fromString xs)) `seq` ()
   , testRdInt @Int    "readInt"
   , testRdInt @Int8   "readInt8"
   , testRdInt @Int16  "readInt16"
@@ -658,8 +658,6 @@ tests =
 
 #ifndef BYTESTRING_CHAR8
   -- issue #393
-  , testProperty "fromString non-char8" $
-    \s -> fromString s == B.pack (map (fromIntegral . ord :: Char -> Word8) s)
   , testProperty "fromString literal" $
     fromString "\0\1\2\3\4" == B.pack [0,1,2,3,4]
 #endif


### PR DESCRIPTION
Closes #140 in line with design suggested at https://github.com/haskell/bytestring/issues/140#issuecomment-997282192

The idea is that users were never meant to use `IsString.fromString` directly, this method should be invoked only by `{-# LANGUAGE OverloadedStrings #-}` magic. This PR effectively enforces this limitation.

* In ghci `IsString.fromString = packCharsSafe`. This is a partial function,
  throwing errors on characters out of Latin1 range, but partiality is not a big
  deal for interactive sessions.
* For compiled programs:
  * For ASCII literals `IsString.fromString = packChars = unsafePackLiteral`,
    no runtime overhead and Core remains exactly the same as before.
  * For Unicode literals (and literals with `'\0'`) `IsString.fromString = packCharsSafe`.
    This incurs runtime overhead, but such thunk is evaluated only once in its life.
  * For dynamic strings (user input, etc.) `IsString.fromString = error`.
    This is to make runtime behaviour more robust (if it crashes, it crashes for
    any input) and avoids a danger of routines, which were tested only for ASCII
    inputs but suddenly receive Unicode and silently lose data.