### PR TITLE
Speed up Data.ByteString.Short.unpack

### DIFF
--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -1128,7 +1128,7 @@ breakEnd p = \sbs -> splitAt (findFromEndUntil p sbs) sbs
 --
 -- @since 0.11.3.0
 break :: (Word8 -> Bool) -> ShortByteString -> (ShortByteString, ShortByteString)
-break = \p -> \sbs -> case findIndexOrLength p sbs of n -> (take n sbs, drop n sbs)
+break p = \sbs -> case findIndexOrLength p sbs of n -> (take n sbs, drop n sbs)
 {-# INLINE break #-}
 
 -- | Similar to 'Prelude.span',

--- a/bench/BenchShort.hs
+++ b/bench/BenchShort.hs
@@ -192,8 +192,12 @@ benchShort = bgroup "ShortByteString"
       ]
     , bgroup "folds"
       [ bgroup "strict"
-        [ bgroup "foldl'" $ map (\s -> bench (show $ S.length s) $
+        [ bgroup "foldl" $ map (\s -> bench (show $ S.length s) $
+            nf (S.foldl (\acc x -> acc + fromIntegral x) (0 :: Int)) s) foldInputs
+        , bgroup "foldl'" $ map (\s -> bench (show $ S.length s) $
             nf (S.foldl' (\acc x -> acc + fromIntegral x) (0 :: Int)) s) foldInputs
+        , bgroup "foldr" $ map (\s -> bench (show $ S.length s) $
+            nf (S.foldr (\x acc -> fromIntegral x + acc) (0 :: Int)) s) foldInputs
         , bgroup "foldr'" $ map (\s -> bench (show $ S.length s) $
             nf (S.foldr' (\x acc -> fromIntegral x + acc) (0 :: Int)) s) foldInputs
         , bgroup "foldr1'" $ map (\s -> bench (show $ S.length s) $


### PR DESCRIPTION
Following the discussion from https://github.com/haskell/bytestring/issues/524#issuecomment-1173126905

Before:

```
$ cabal run -w ghc-9.2.3 --enable-profiling bytestring-bench --ghc-options='-fcheck-prim-bounds -fno-ignore-asserts' -- -p 'unpack' +RTS -s
Up to date
All
  ShortByteString
    ShortByteString unpack
      unpack and look at first 100 elements: OK (0.87s)
        55.6 ms ± 4.8 ms,  66 MB allocated, 242 B  copied, 181 MB peak memory
      unpackLast:                          OK (0.99s)
        63.1 ms ± 5.2 ms,  66 MB allocated, 226 B  copied, 181 MB peak memory

All 2 tests passed (1.96s)
   2,246,950,896 bytes allocated in the heap
           7,568 bytes copied during GC
      71,372,544 bytes maximum residency (29 sample(s))
       1,339,648 bytes maximum slop
             181 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0        43 colls,     0 par    1.132s   1.136s     0.0264s    0.0535s
  Gen  1        29 colls,     0 par    0.319s   0.320s     0.0110s    0.0535s

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    0.551s  (  0.554s elapsed)
  GC      time    1.451s  (  1.457s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    0.000s  (  0.000s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time    2.003s  (  2.011s elapsed)

  %GC     time       0.0%  (0.0% elapsed)

  Alloc rate    4,075,230,737 bytes per MUT second

  Productivity  27.5% of total user, 27.5% of total elapsed
```

After

```
All
  ShortByteString
    ShortByteString unpack
      unpack and look at first 100 elements: OK (0.23s)
        1.38 μs ± 103 ns, 6.9 KB allocated,   0 B  copied,  47 MB peak memory
      unpackLast:                          OK (0.15s)
        22.6 ms ± 2.2 ms, 132 MB allocated, 436 B  copied,  47 MB peak memory

All 2 tests passed (0.41s)
   2,033,165,224 bytes allocated in the heap
           7,984 bytes copied during GC
       2,342,464 bytes maximum residency (21 sample(s))
         257,800 bytes maximum slop
              47 MiB total memory in use (1 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0        55 colls,     0 par    0.003s   0.003s     0.0000s    0.0022s
  Gen  1        21 colls,     0 par    0.025s   0.025s     0.0012s    0.0028s

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time    0.425s  (  0.428s elapsed)
  GC      time    0.028s  (  0.028s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    0.000s  (  0.000s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time    0.454s  (  0.456s elapsed)

  %GC     time       0.0%  (0.0% elapsed)

  Alloc rate    4,780,369,992 bytes per MUT second

  Productivity  93.8% of total user, 93.8% of total elapsed
```

I'm not sure what are the benefits of the old implementation. This one seems to be better in every regard and probably fuses better.