### PR TITLE
Builders: Implement non-host endianess writes using a single write.

### DIFF
--- a/Data/ByteString/Builder/Prim/Binary.hs
+++ b/Data/ByteString/Builder/Prim/Binary.hs
@@ -83,18 +83,14 @@ word16BE :: FixedPrim Word16
 #ifdef WORDS_BIGENDIAN
 word16BE = word16Host
 #else
-word16BE = fixedPrim 2 $ \w p -> do
-    poke p               (fromIntegral (shiftR w 8) :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral w                :: Word8)
+word16BE = byteSwap16 >$< word16Host
 #endif
 
 -- | Encoding 'Word16's in little endian format.
 {-# INLINE word16LE #-}
 word16LE :: FixedPrim Word16
 #ifdef WORDS_BIGENDIAN
-word16LE = fixedPrim 2 $ \w p -> do
-    poke p               (fromIntegral w                :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral (shiftR w 8) :: Word8)
+word16LE = byteSwap16 >$< word16Host
 #else
 word16LE = word16Host
 #endif
@@ -105,22 +101,14 @@ word32BE :: FixedPrim Word32
 #ifdef WORDS_BIGENDIAN
 word32BE = word32Host
 #else
-word32BE = fixedPrim 4 $ \w p -> do
-    poke p               (fromIntegral (shiftR w 24) :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral (shiftR w 16) :: Word8)
-    poke (p `plusPtr` 2) (fromIntegral (shiftR w  8) :: Word8)
-    poke (p `plusPtr` 3) (fromIntegral w                 :: Word8)
+word32BE = byteSwap32 >$< word32Host
 #endif
 
 -- | Encoding 'Word32's in little endian format.
 {-# INLINE word32LE #-}
 word32LE :: FixedPrim Word32
 #ifdef WORDS_BIGENDIAN
-word32LE = fixedPrim 4 $ \w p -> do
-    poke p               (fromIntegral w                 :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral (shiftR w  8) :: Word8)
-    poke (p `plusPtr` 2) (fromIntegral (shiftR w 16) :: Word8)
-    poke (p `plusPtr` 3) (fromIntegral (shiftR w 24) :: Word8)
+word32LE = byteSwap32 >$< word32Host
 #else
 word32LE = word32Host
 #endif
@@ -134,64 +122,14 @@ word64BE :: FixedPrim Word64
 #ifdef WORDS_BIGENDIAN
 word64BE = word64Host
 #else
-#if WORD_SIZE_IN_BITS < 64
---
--- To avoid expensive 64 bit shifts on 32 bit machines, we cast to
--- Word32, and write that
---
-word64BE =
-    fixedPrim 8 $ \w p -> do
-        let a = fromIntegral (shiftR w 32) :: Word32
-            b = fromIntegral w                 :: Word32
-        poke p               (fromIntegral (shiftR a 24) :: Word8)
-        poke (p `plusPtr` 1) (fromIntegral (shiftR a 16) :: Word8)
-        poke (p `plusPtr` 2) (fromIntegral (shiftR a  8) :: Word8)
-        poke (p `plusPtr` 3) (fromIntegral a                 :: Word8)
-        poke (p `plusPtr` 4) (fromIntegral (shiftR b 24) :: Word8)
-        poke (p `plusPtr` 5) (fromIntegral (shiftR b 16) :: Word8)
-        poke (p `plusPtr` 6) (fromIntegral (shiftR b  8) :: Word8)
-        poke (p `plusPtr` 7) (fromIntegral b                 :: Word8)
-#else
-word64BE = fixedPrim 8 $ \w p -> do
-    poke p               (fromIntegral (shiftR w 56) :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral (shiftR w 48) :: Word8)
-    poke (p `plusPtr` 2) (fromIntegral (shiftR w 40) :: Word8)
-    poke (p `plusPtr` 3) (fromIntegral (shiftR w 32) :: Word8)
-    poke (p `plusPtr` 4) (fromIntegral (shiftR w 24) :: Word8)
-    poke (p `plusPtr` 5) (fromIntegral (shiftR w 16) :: Word8)
-    poke (p `plusPtr` 6) (fromIntegral (shiftR w  8) :: Word8)
-    poke (p `plusPtr` 7) (fromIntegral w                 :: Word8)
-#endif
+word64BE = byteSwap64 >$< word64Host
 #endif
 
 -- | Encoding 'Word64's in little endian format.
 {-# INLINE word64LE #-}
 word64LE :: FixedPrim Word64
 #ifdef WORDS_BIGENDIAN
-#if WORD_SIZE_IN_BITS < 64
-word64LE =
-    fixedPrim 8 $ \w p -> do
-        let b = fromIntegral (shiftR w 32) :: Word32
-            a = fromIntegral w                 :: Word32
-        poke (p)             (fromIntegral a                 :: Word8)
-        poke (p `plusPtr` 1) (fromIntegral (shiftR a  8) :: Word8)
-        poke (p `plusPtr` 2) (fromIntegral (shiftR a 16) :: Word8)
-        poke (p `plusPtr` 3) (fromIntegral (shiftR a 24) :: Word8)
-        poke (p `plusPtr` 4) (fromIntegral b                 :: Word8)
-        poke (p `plusPtr` 5) (fromIntegral (shiftR b  8) :: Word8)
-        poke (p `plusPtr` 6) (fromIntegral (shiftR b 16) :: Word8)
-        poke (p `plusPtr` 7) (fromIntegral (shiftR b 24) :: Word8)
-#else
-word64LE = fixedPrim 8 $ \w p -> do
-    poke p               (fromIntegral w                 :: Word8)
-    poke (p `plusPtr` 1) (fromIntegral (shiftR w  8) :: Word8)
-    poke (p `plusPtr` 2) (fromIntegral (shiftR w 16) :: Word8)
-    poke (p `plusPtr` 3) (fromIntegral (shiftR w 24) :: Word8)
-    poke (p `plusPtr` 4) (fromIntegral (shiftR w 32) :: Word8)
-    poke (p `plusPtr` 5) (fromIntegral (shiftR w 40) :: Word8)
-    poke (p `plusPtr` 6) (fromIntegral (shiftR w 48) :: Word8)
-    poke (p `plusPtr` 7) (fromIntegral (shiftR w 56) :: Word8)
-#endif
+word64LE = byteSwap64 >$< word64Host
 #else
 word64LE = word64Host
 #endif


### PR DESCRIPTION
We do this by swapping the byte order in memory before we write.

This speeds up int64BE by about a factor of three on my machine (skylake).

`int16BE` hardly changes, i guess the write buffer is not a bottle neck for 16bit words. But beyond that it makes a large difference.

Before
```
    int16BE (10000):                                          OK (0.54s)
      7.68 μs ± 215 ns
    int32BE (10000):                                          OK (0.43s)
      11.6 μs ± 342 ns
    int64BE (10000):                                          OK (0.42s)
      22.7 μs ± 669 ns
    word16BE (10000):                                         OK (0.55s)
      7.68 μs ± 218 ns
    word32BE (10000):                                         OK (0.42s)
      11.6 μs ± 355 ns
    word64BE (10000):                                         OK (0.42s)
      22.7 μs ± 728 ns
    floatBE (10000):                                          OK (0.52s)
      14.6 μs ± 392 ns
    doubleBE (10000):                                         OK (0.47s)
      25.7 μs ± 689 ns
```
After
```
    int16BE (10000):                                          OK (0.53s)
      7.69 μs ± 223 ns
    int32BE (10000):                                          OK (0.30s)
      7.84 μs ± 397 ns
    int64BE (10000):                                          OK (0.29s)
      7.20 μs ± 590 ns
    word16BE (10000):                                         OK (0.55s)
      7.67 μs ± 217 ns
    word32BE (10000):                                         OK (0.30s)
      7.83 μs ± 393 ns
    word64BE (10000):                                         OK (0.29s)
      7.21 μs ± 595 ns
    floatBE (10000):                                          OK (0.34s)
      8.98 μs ± 328 ns
    doubleBE (10000):                                         OK (0.23s)
      10.8 μs ± 664 ns
```