### PR TITLE
Export ‘unsafeIndex’ on short bytestrings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 * [New sized and/or unsigned variants of `readInt` and `readInteger`](https://github.com/haskell/bytestring/pull/438)
 * [`readInt` returns `Nothing`, if the sequence of digits cannot be represented by an `Int`, instead of overflowing silently](https://github.com/haskell/bytestring/pull/309)
 * [Remove `zipWith` rewrite rule](https://github.com/haskell/bytestring/pull/387)
+* [Export `unsafeIndex` for ShortByteString which had been accidentally removed in v0.11.3.0](https://github.com/haskell/bytestring/pull/532)
+
 
 [0.12.0.0]: https://github.com/haskell/bytestring/compare/0.11.3.0...0.12.0.0
 

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -138,6 +138,7 @@ module Data.ByteString.Short.Internal (
     count,
     findIndex,
     findIndices,
+    unsafeIndex,
 
     -- * Low level operations
     createFromPtr,
@@ -394,6 +395,7 @@ indexMaybe sbs i
 (!?) = indexMaybe
 {-# INLINE (!?) #-}
 
+-- | /O(1)/ Unsafe indexing without bounds checking.
 unsafeIndex :: ShortByteString -> Int -> Word8
 unsafeIndex sbs = indexWord8Array (asBA sbs)
 


### PR DESCRIPTION
I noticed the function got removed in 731caea but there's no trace of that in the changelog, which probably makes it an accidental omission.