### PR TITLE
Bugfix: Correct minimum required bounds for serializing cstring and cstringUtf8

### DIFF
--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -679,7 +679,7 @@ cstring =
     step !addr !k br@(BufferRange op0@(Ptr op0#) ope)
       | W8# ch == 0 = k br
       | op0 == ope =
-          return $ bufferFull defaultChunkSize op0 (step addr k)
+          return $ bufferFull 1 op0 (step addr k)
       | otherwise = do
           IO $ \s -> case writeWord8OffAddr# op0# 0# ch s of
                        s' -> (# s', () #)
@@ -700,7 +700,7 @@ cstringUtf8 =
     step !addr !k br@(BufferRange op0@(Ptr op0#) ope)
       | W8# ch == 0 = k br
       | op0 == ope =
-          return $ bufferFull defaultChunkSize op0 (step addr k)
+          return $ bufferFull 1 op0 (step addr k)
         -- NULL is encoded as 0xc0 0x80
       | W8# ch == 0xc0
       , W8# (indexWord8OffAddr# addr 1#) == 0x80 = do


### PR DESCRIPTION
I think this was an oversight in https://github.com/haskell/bytestring/commit/155bf8ae5d25c1cac33a0a5021c1709fbd8e23e7

The bufferFull signal takes the _minimum_ number of required space to make progress. Instead, the defaultChunkSize was used. I can't prove it yet but I have a hunch this is causing https://github.com/yesodweb/wai/issues/894. It looks like defaultChunkSize is 32k. A Warp buffer is something around 16k thus it will always hit the bufferFull signal when writing a cstring/cstringUtf8 requiring a bigger buffer which then makes Warp error out.

Pinging @bgamari as he is the author of the aforementioned patch and @basvandijk, maybe you can try out this fix and see whether it's fixing your issue?