### PR TITLE
Remove two bad accursedUnutterablePerformIO uses

### DIFF
--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -407,7 +407,7 @@ indexError sbs i =
 -- | @since 0.11.2.0
 unsafePackLenLiteral :: Int -> Addr# -> ShortByteString
 unsafePackLenLiteral len addr# =
-    accursedUnutterablePerformIO $ createFromPtr (Ptr addr#) len
+    unsafeDupablePerformIO $ createFromPtr (Ptr addr#) len
 
 ------------------------------------------------------------------------
 -- Internal utils


### PR DESCRIPTION
One of these was demonstrated by haskell/aeson#967 and [GHC issue 22204](https://gitlab.haskell.org/ghc/ghc/-/issues/22204).

I took the liberty of auditing the rest of our use-sites for `accursedUnutterablePerformIO`. The uses I haven't removed in this commit perform only read effects, which are at least less dangerous.