### PR TITLE
IO operations for `ShortByteString`

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1853,7 +1853,7 @@ mkBigPS _ pss = return $! concat (P.reverse pss)
 -- | Outputs a 'ByteString' to the specified 'Handle'.
 hPut :: Handle -> ByteString -> IO ()
 hPut _ (BS _  0) = return ()
-hPut h (BS ps l) = unsafeWithForeignPtr ps $ \p-> hPutBuf h p l
+hPut h (BS ps l) = unsafeWithForeignPtr ps $ \p -> hPutBuf h p l
 
 -- | Similar to 'hPut' except that it will never block. Instead it returns
 -- any tail that did not get written. This tail may be 'empty' in the case that

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -442,13 +442,13 @@ pin b@(SBS (BA# -> src)) =
     
 
 -- | Invariant: @arr@ must be pinned. This is not checked.
-withPinnedSBSPtr :: ShortByteString -> (Ptr a -> IO b) -> IO b
-withPinnedSBSPtr (SBS (BA# -> arr)) f = IO $ \s ->
+pinnedWithPtr :: ShortByteString -> (Ptr a -> IO b) -> IO b
+pinnedWithPtr (SBS (BA# -> arr)) f = IO $ \s ->
   case f (byteArrayContents arr) of
     IO action# -> keepAlive# arr s action#
     
-withSBSPtr :: ShortByteString -> (Ptr a -> IO b) -> IO b
-withSBSPtr arr = withPinnedSBSPtr $ pin arr
+withPtr :: ShortByteString -> (Ptr a -> IO b) -> IO b
+withPtr arr = pinnedWithPtr $ pin arr
 
 asBA :: ShortByteString -> BA
 asBA (SBS ba#) = BA# ba#
@@ -1980,7 +1980,7 @@ moduleError fun msg = error (moduleErrorMsg fun msg)
 -- with 'IO.hPutBuf'. The offset and length are used because we don't have slices of 'ByteArray' yet.
 -- The function is unsafe because the offset and length is not checked.
 unsafeHPutOff :: Handle -> ShortByteString -> Int -> Int -> IO ()
-unsafeHPutOff handle sbs off len = withSBSPtr sbs $ \p -> IO.hPutBuf handle (p `plusPtr` off) len
+unsafeHPutOff handle sbs off len = withPtr sbs $ \p -> IO.hPutBuf handle (p `plusPtr` off) len
 
 hPut :: Handle -> ShortByteString -> IO ()
 hPut h sbs = unsafeHPutOff h sbs 0 (length sbs)

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -442,13 +442,13 @@ pin b@(SBS (BA# -> src)) =
     
 
 -- | Invariant: @arr@ must be pinned. This is not checked.
-withPinnedSBS :: ShortByteString -> (Ptr a -> IO b) -> IO b
-withPinnedSBS (SBS (BA# -> arr)) f = IO $ \s ->
+withPinnedSBSPtr :: ShortByteString -> (Ptr a -> IO b) -> IO b
+withPinnedSBSPtr (SBS (BA# -> arr)) f = IO $ \s ->
   case f (byteArrayContents arr) of
     IO action# -> keepAlive# arr s action#
     
-withSBS :: ShortByteString -> (Ptr a -> IO b) -> IO b
-withSBS arr = withPinnedSBS $ pin arr
+withSBSPtr :: ShortByteString -> (Ptr a -> IO b) -> IO b
+withSBSPtr arr = withPinnedSBSPtr $ pin arr
 
 asBA :: ShortByteString -> BA
 asBA (SBS ba#) = BA# ba#
@@ -1980,7 +1980,7 @@ moduleError fun msg = error (moduleErrorMsg fun msg)
 -- with 'IO.hPutBuf'. The offset and length are used because we don't have slices of 'ByteArray' yet.
 -- The function is unsafe because the offset and length is not checked.
 unsafeHPutOff :: Handle -> ShortByteString -> Int -> Int -> IO ()
-unsafeHPutOff handle sbs off len = withSBS sbs $ \p -> IO.hPutBuf handle (p `plusPtr` off) len
+unsafeHPutOff handle sbs off len = withSBSPtr sbs $ \p -> IO.hPutBuf handle (p `plusPtr` off) len
 
 hPut :: Handle -> ShortByteString -> IO ()
 hPut h sbs = unsafeHPutOff h sbs 0 (length sbs)

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -586,7 +586,7 @@ unsafePlainToShortIO (BS (ForeignPtr (Ptr -> p) fpc) l) =
       let baseP = Ptr (mutableByteArrayContents# marr#)
       if baseP == p && l == I# (sizeofMutableByteArray# marr#)
         then pure $ SBS arr#
-        else error "Data.ByteString.Short.Internal: not a slice"
+        else error "Data.ByteString.Short.Internal: cannot be a slice"
     _ -> error "Data.ByteString.Short.Internal: must be PlainPtr"
 
 


### PR DESCRIPTION
Addresses #540. The functions mostly make use of `unsafePlainToShortIO` which performs a zero cost conversion between a `PlainForeignPtr` and `ShortByteString`, using some unsafe stuff that I hope is correct. For things like `hPut`, we make sure to `pin` the `ByteArray` before giving it to `hPutBuf`. Hopefully my `keepAlive#` usage is correct, which I copied from `withForeignPtr`. These operations should be useful for implementing utf8 IO in `text`, solving the [`readFile` problem](https://www.snoyman.com/blog/2016/12/beware-of-readfile/) with good performance.