### PR TITLE
Remove ARM 32bit job

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,18 +1,4 @@
 kind: pipeline
-name: arm
-platform: { os: linux, arch: arm }
-steps:
-- name: Test
-  image: elmanhasa/haskell-base
-  commands:
-    - export LC_ALL=C.UTF-8
-    - uname -a # check platform
-    - getconf LONG_BIT # check bitness
-    - cabal --version
-    - cabal update
-    - cabal new-test
----
-kind: pipeline
 name: arm64-ghc8.10
 platform: { os: linux, arch: arm64 }
 steps:


### PR DESCRIPTION
Seems drone.io no longer offers 32-bit ARM machines.