### PR TITLE
Avoid Prelude.head and Prelude.tail

### DIFF
--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1433,7 +1433,7 @@ unzip ls = (pack (List.map fst ls), pack (List.map snd ls))
 inits :: ByteString -> [ByteString]
 inits = (Empty :) . inits'
   where inits' Empty        = []
-        inits' (Chunk c cs) = List.map (`Chunk` Empty) (List.tail (S.inits c))
+        inits' (Chunk c cs) = List.map (`Chunk` Empty) (List.drop 1 (S.inits c))
                            ++ List.map (Chunk c) (inits' cs)
 
 -- | /O(n)/ Return all final segments of the given 'ByteString', longest first.

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -13,7 +13,7 @@ module Data.ByteString.Lazy.Internal.Deque (
 
 import qualified Data.ByteString as S
 import Data.Int (Int64)
-import Prelude hiding (head, length, null)
+import Prelude hiding (head, tail, length, null)
 
 -- A `S.ByteString` Deque used as an accumulator for lazy
 -- Bytestring operations

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -268,14 +268,11 @@ main = do
             P.primMapLazyByteStringFixed P.word8
         ]
       , bgroup "ByteString insertion" $
-          let dataName = " byteStringChunks" ++
-                         show (S.length (head byteStringChunksData)) ++ "Data"
-          in
-            [ benchB ("foldMap byteStringInsert" ++ dataName) byteStringChunksData
+            [ benchB "foldMap byteStringInsert" byteStringChunksData
                 (foldMap byteStringInsert)
-            , benchB ("foldMap byteString" ++ dataName) byteStringChunksData
+            , benchB "foldMap byteString" byteStringChunksData
                 (foldMap byteString)
-            , benchB ("foldMap byteStringCopy" ++ dataName) byteStringChunksData
+            , benchB "foldMap byteStringCopy" byteStringChunksData
                 (foldMap byteStringCopy)
             ]
 

--- a/bench/BenchIndices.hs
+++ b/bench/BenchIndices.hs
@@ -15,7 +15,7 @@ import           Data.Maybe                            (listToMaybe)
 import           Data.Monoid
 import           Data.String
 import           Test.Tasty.Bench
-import           Prelude                               hiding (words)
+import           Prelude                               hiding (words, head, tail)
 import           Data.Word                             (Word8)
 
 import qualified Data.ByteString                       as S
@@ -54,8 +54,8 @@ benchIndices = bgroup "Indices"
         , bench "ElemIndex"   $ nf (S.elemIndex     nl)  absurdlong
         ]
     , bgroup "ByteString strict second index" $
-        [ bench "FindIndices" $ nf (listToMaybe . tail . S.findIndices (== nl)) absurdlong
-        , bench "ElemIndices" $ nf (listToMaybe . tail . S.elemIndices     nl)  absurdlong
+        [ bench "FindIndices" $ nf (listToMaybe . drop 1 . S.findIndices (== nl)) absurdlong
+        , bench "ElemIndices" $ nf (listToMaybe . drop 1 . S.elemIndices     nl)  absurdlong
         , bench "FindIndex"   $ nf bench_find_index_second absurdlong
         , bench "ElemIndex"   $ nf bench_elem_index_second absurdlong
         ]

--- a/bench/BenchShort.hs
+++ b/bench/BenchShort.hs
@@ -12,7 +12,7 @@ import           Data.Maybe                            (listToMaybe)
 import           Data.Monoid
 import           Data.String
 import           Test.Tasty.Bench
-import           Prelude                               hiding (words)
+import           Prelude                               hiding (words, head, tail)
 
 import           Data.ByteString.Short                 (ShortByteString)
 import qualified Data.ByteString.Short                 as S
@@ -228,8 +228,8 @@ benchShort = bgroup "ShortByteString"
         , bench "ElemIndex"   $ nf (S.elemIndex     nl)  absurdlong
         ]
     , bgroup "ShortByteString strict second index" $
-        [ bench "FindIndices" $ nf (listToMaybe . tail . S.findIndices (== nl)) absurdlong
-        , bench "ElemIndices" $ nf (listToMaybe . tail . S.elemIndices     nl)  absurdlong
+        [ bench "FindIndices" $ nf (listToMaybe . drop 1 . S.findIndices (== nl)) absurdlong
+        , bench "ElemIndices" $ nf (listToMaybe . drop 1 . S.elemIndices     nl)  absurdlong
         , bench "FindIndex"   $ nf bench_find_index_second absurdlong
         , bench "ElemIndex"   $ nf bench_elem_index_second absurdlong
         ]

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -82,10 +82,8 @@ prop_unsafeTail xs = not (P.null xs) ==> P.tail xs === P.unsafeTail xs
 prop_unsafeLast xs = not (P.null xs) ==> P.last xs === P.unsafeLast xs
 prop_unsafeInit xs = not (P.null xs) ==> P.init xs === P.unsafeInit xs
 
-prop_lines_lazy1 =
-    take 1 (LC.lines (LC.append (LC.pack "a\nb\n") undefined)) === [LC.pack "a"]
-prop_lines_lazy2 =
-    take 1 (drop 1 (LC.lines (LC.append (LC.pack "a\nb\n") undefined))) === [LC.pack "b"]
+prop_lines_lazy =
+    take 2 (LC.lines (LC.append (LC.pack "a\nb\n") undefined)) === [LC.pack "a", LC.pack "b"]
 
 prop_strip x = C.strip x == (C.dropSpace . C.reverse . C.dropSpace . C.reverse) x
 
@@ -685,8 +683,7 @@ misc_tests =
     , testProperty "unsafeInit"     prop_unsafeInit
     , testProperty "unsafeIndex"    prop_unsafeIndexBB
 
-    , testProperty "lines_lazy1"    prop_lines_lazy1
-    , testProperty "lines_lazy2"    prop_lines_lazy2
+    , testProperty "lines_lazy"     prop_lines_lazy
     , testProperty "strip"          prop_strip
     , testProperty "isSpace"        prop_isSpaceWord8
 

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -13,6 +13,7 @@
 
 module Properties (testSuite) where
 
+import Prelude hiding (head, tail)
 import Foreign.C.String (withCString)
 import Foreign.Storable
 import Foreign.ForeignPtr
@@ -76,20 +77,15 @@ prop_unsafeIndexBB xs =
 prop_bijectionBB  (Char8 c) = (P.w2c . P.c2w) c == id c
 prop_bijectionBB'        w  = (P.c2w . P.w2c) w == id w
 
-prop_head2BB xs    = (not (null xs)) ==> head xs   == (P.unsafeHead . P.pack) xs
-
-prop_tail1BB xs    = (not (null xs)) ==> tail xs    == (P.unpack . P.unsafeTail. P.pack) xs
-
-prop_last1BB xs    = (not (null xs)) ==> last xs    == (P.unsafeLast . P.pack) xs
-
-prop_init1BB xs     =
-    (not (null xs)) ==>
-    init xs    == (P.unpack . P.unsafeInit . P.pack) xs
+prop_unsafeHead xs = not (P.null xs) ==> P.head xs === P.unsafeHead xs
+prop_unsafeTail xs = not (P.null xs) ==> P.tail xs === P.unsafeTail xs
+prop_unsafeLast xs = not (P.null xs) ==> P.last xs === P.unsafeLast xs
+prop_unsafeInit xs = not (P.null xs) ==> P.init xs === P.unsafeInit xs
 
 prop_lines_lazy1 =
-    head (LC.lines (LC.append (LC.pack "a\nb\n") undefined)) == LC.pack "a"
+    take 1 (LC.lines (LC.append (LC.pack "a\nb\n") undefined)) === [LC.pack "a"]
 prop_lines_lazy2 =
-    head (tail (LC.lines (LC.append (LC.pack "a\nb\n") undefined))) == LC.pack "b"
+    take 1 (drop 1 (LC.lines (LC.append (LC.pack "a\nb\n") undefined))) === [LC.pack "b"]
 
 prop_strip x = C.strip x == (C.dropSpace . C.reverse . C.dropSpace . C.reverse) x
 
@@ -683,10 +679,10 @@ misc_tests =
     , testProperty "w2c . c2w"      prop_bijectionBB
     , testProperty "c2w . w2c"      prop_bijectionBB'
 
-    , testProperty "unsafeHead"     prop_head2BB
-    , testProperty "unsafeTail"     prop_tail1BB
-    , testProperty "unsafeLast"     prop_last1BB
-    , testProperty "unsafeInit"     prop_init1BB
+    , testProperty "unsafeHead"     prop_unsafeHead
+    , testProperty "unsafeTail"     prop_unsafeTail
+    , testProperty "unsafeLast"     prop_unsafeLast
+    , testProperty "unsafeInit"     prop_unsafeInit
     , testProperty "unsafeIndex"    prop_unsafeIndexBB
 
     , testProperty "lines_lazy1"    prop_lines_lazy1
@@ -717,7 +713,7 @@ strictness_checks =
     , testProperty "scanl is lazy" $ \ xs ->
         L.take (L.length xs + 1) (L.scanl (+) 0 (explosiveTail (xs <> L.singleton 1))) === (L.pack . fmap (L.foldr (+) 0) . L.inits) xs
     , testProperty "scanl1 is lazy" $ \ xs -> L.length xs > 0 ==>
-        L.take (L.length xs) (L.scanl1 (+) (explosiveTail (xs <> L.singleton 1))) === (L.pack . fmap (L.foldr1 (+)) . tail . L.inits) xs
+        L.take (L.length xs) (L.scanl1 (+) (explosiveTail (xs <> L.singleton 1))) === (L.pack . fmap (L.foldr1 (+)) . drop 1 . L.inits) xs
     ]
   , testGroup "Lazy Char"
     [ testProperty "foldr is lazy" $ \ xs ->
@@ -731,7 +727,7 @@ strictness_checks =
     , testProperty "scanl is lazy" $ \ xs -> let char1 +. char2 = toEnum (fromEnum char1 + fromEnum char2) in
         D.take (D.length xs + 1) (D.scanl (+.) '\NUL' (explosiveTail (xs <> D.singleton '\SOH'))) === (D.pack . fmap (D.foldr (+.) '\NUL') . D.inits) xs
     , testProperty "scanl1 is lazy" $ \ xs -> D.length xs > 0 ==> let char1 +. char2 = toEnum (fromEnum char1 + fromEnum char2) in
-        D.take (D.length xs) (D.scanl1 (+.) (explosiveTail (xs <> D.singleton '\SOH'))) === (D.pack . fmap (D.foldr1 (+.)) . tail . D.inits) xs
+        D.take (D.length xs) (D.scanl1 (+.) (explosiveTail (xs <> D.singleton '\SOH'))) === (D.pack . fmap (D.foldr1 (+.)) . drop 1 . D.inits) xs
     , testProperty "unlines is lazy" $ \ xs -> D.take (D.length xs + 1) (D.unlines (xs : error "Tail of this list is undefined!")) === xs `D.snoc` '\n'
     ]
   ]

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -59,6 +59,7 @@ import qualified Data.ByteString.Lazy.Internal as B (invariant)
 #define BYTESTRING_TYPE B.ByteString
 #endif
 
+import Prelude hiding (head, tail)
 import Data.Int
 import Numeric.Natural (Natural)
 
@@ -474,11 +475,15 @@ tests =
     \x -> let n = 2^31 in (B.unpack *** B.unpack) (B.splitAt n x) === List.genericSplitAt n (B.unpack x)
 
   , testProperty "head" $
-    \x -> not (B.null x) ==> B.head x === head (B.unpack x)
+    \x -> case B.unpack x of
+      []     -> property True
+      hd : _ -> B.head x === hd
   , testProperty "last" $
     \x -> not (B.null x) ==> B.last x === last (B.unpack x)
   , testProperty "tail" $
-    \x -> not (B.null x) ==> B.unpack (B.tail x) === tail (B.unpack x)
+    \x -> case B.unpack x of
+      []     -> property True
+      _ : tl -> B.unpack (B.tail x) === tl
   , testProperty "tail length" $
     \x -> not (B.null x) ==> B.length x === 1 + B.length (B.tail x)
   , testProperty "init" $

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -114,4 +114,3 @@ instance Arbitrary SB.ShortByteString where
 
 instance CoArbitrary SB.ShortByteString where
   coarbitrary s = coarbitrary (SB.unpack s)
-


### PR DESCRIPTION
This is to facilitate my work on https://github.com/haskell/core-libraries-committee/issues/87, but probably not bad even on its own. 

The only change in library's source code is 
```diff
-        inits' (Chunk c cs) = List.map (`Chunk` Empty) (List.tail (S.inits c))
+        inits' (Chunk c cs) = List.map (`Chunk` Empty) (List.drop 1 (S.inits c))
```
which could be nicer if we had #552 in place.