### PR TITLE
Re-increase arity of stimesPolymorphic

### DIFF
--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -822,7 +822,7 @@ concat = \bss0 -> goLen0 bss0 bss0
 -- specializations are reasonably small.
 stimesPolymorphic :: Integral a => a -> ByteString -> ByteString
 {-# INLINABLE stimesPolymorphic #-}
-stimesPolymorphic nRaw = \ !bs -> case checkedIntegerToInt n of
+stimesPolymorphic nRaw !bs = case checkedIntegerToInt n of
   Just nInt
     | nInt >= 0  -> stimesNonNegativeInt nInt bs
     | otherwise  -> stimesNegativeErr


### PR DESCRIPTION
Otherwise, GHC may try to share the intermediate Integer between calls to the function with one argument.  This is usually terrible for performance; in any rare case where it is beneficial the programmer can still perform such sharing themselves.

I gave a bit more detail in this comment: https://github.com/haskell/bytestring/issues/493#issuecomment-1129450195


Floating the `where` block into the body of the lambda is also possible, but is uglier and IIRC also has no effect on the generated interface file.