### PR TITLE
Add NonEmpty variants of inits and tails

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1724,7 +1724,9 @@ Note [Avoid NonEmpty combinators]
 As of base-4.17, most of the NonEmpty API is surprisingly lazy.
 Using it without forcing the arguments yourself is just begging GHC
 to make your code waste time allocating useless selector thunks.
-"Refactor" with care!
+This may change in the future. See also this CLC issue:
+  https://github.com/haskell/core-libraries-committee/issues/107
+But until then, "refactor" with care!
 -}
 
 

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1692,26 +1692,42 @@ unzip ls = (pack (P.map fst ls), pack (P.map snd ls))
 
 -- | /O(n)/ Returns all initial segments of the given 'ByteString', shortest first.
 inits :: ByteString -> [ByteString]
+-- see Note [Avoid NonEmpty combinators]
 inits bs = NE.toList $! initsNE bs
 
 -- | /O(n)/ Returns all initial segments of the given 'ByteString', shortest first.
 --
 -- @since 0.11.4.0
 initsNE :: ByteString -> NonEmpty ByteString
+-- see Note [Avoid NonEmpty combinators]
 initsNE (BS x len) = empty :| [BS x n | n <- [1..len]]
 
 -- | /O(n)/ Returns all final segments of the given 'ByteString', longest first.
 tails :: ByteString -> [ByteString]
+-- see Note [Avoid NonEmpty combinators]
 tails bs = NE.toList $! tailsNE bs
 
 -- | /O(n)/ Returns all final segments of the given 'ByteString', longest first.
 --
 -- @since 0.11.4.0
 tailsNE :: ByteString -> NonEmpty ByteString
+-- see Note [Avoid NonEmpty combinators]
 tailsNE p | null p    = empty :| []
           | otherwise = p :| tails (unsafeTail p)
 
 -- less efficent spacewise: tails (BS x l) = [BS (plusForeignPtr x n) (l-n) | n <- [0..l]]
+
+{-
+Note [Avoid NonEmpty combinators]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As of base-4.17, most of the NonEmpty API is surprisingly lazy.
+Using it without forcing the arguments yourself is just begging GHC
+to make your code waste time allocating useless selector thunks.
+"Refactor" with care!
+-}
+
+
 
 -- ---------------------------------------------------------------------
 -- ** Ordered 'ByteString's

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -129,6 +129,8 @@ module Data.ByteString.Char8 (
         groupBy,
         inits,
         tails,
+        initsNE,
+        tailsNE,
         strip,
         stripPrefix,
         stripSuffix,
@@ -261,7 +263,7 @@ import qualified Data.ByteString.Unsafe as B
 
 -- Listy functions transparently exported
 import Data.ByteString (null,length,tail,init,append
-                       ,inits,tails,reverse,transpose
+                       ,inits,tails,initsNE,tailsNE,reverse,transpose
                        ,concat,take,takeEnd,drop,dropEnd,splitAt
                        ,intercalate,sort,isPrefixOf,isSuffixOf
                        ,isInfixOf,stripPrefix,stripSuffix

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1448,7 +1448,7 @@ initsNE = (Empty :|) . inits' id
     inits' _ Empty = []
     inits' f (Chunk c@(S.BS x len) cs)
       = [f (S.BS x n `Chunk` Empty) | n <- [1..len]]
-      ++ inits' (Chunk c . f) cs
+      ++ inits' (f . Chunk c) cs
 
 -- | /O(n)/ Returns all final segments of the given 'ByteString', longest first.
 tails :: ByteString -> [ByteString]

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1435,12 +1435,14 @@ unzip ls = (pack (List.map fst ls), pack (List.map snd ls))
 
 -- | Returns all initial segments of the given 'ByteString', shortest first.
 inits :: ByteString -> [ByteString]
+-- see Note [Avoid NonEmpty combinators] in Data.ByteString
 inits bs = NE.toList $! initsNE bs
 
 -- | Returns all initial segments of the given 'ByteString', shortest first.
 --
 -- @since 0.11.4.0
 initsNE :: ByteString -> NonEmpty ByteString
+-- see Note [Avoid NonEmpty combinators] in Data.ByteString
 initsNE = (Empty :|) . inits' id
   where
     inits' :: (ByteString -> ByteString) -> ByteString -> [ByteString]
@@ -1452,15 +1454,18 @@ initsNE = (Empty :|) . inits' id
 
 -- | /O(n)/ Returns all final segments of the given 'ByteString', longest first.
 tails :: ByteString -> [ByteString]
+-- see Note [Avoid NonEmpty combinators] in Data.ByteString
 tails bs = NE.toList $! tailsNE bs
 
 -- | /O(n)/ Returns all final segments of the given 'ByteString', longest first.
 --
 -- @since 0.11.4.0
 tailsNE :: ByteString -> NonEmpty ByteString
-tailsNE bs = case  uncons bs  of
+-- see Note [Avoid NonEmpty combinators] in Data.ByteString
+tailsNE bs = case uncons bs of
   Nothing -> Empty :| []
   Just (_, tl) -> bs :| tails tl
+
 
 -- ---------------------------------------------------------------------
 -- Low level constructors

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -124,6 +124,8 @@ module Data.ByteString.Lazy.Char8 (
         groupBy,
         inits,
         tails,
+        initsNE,
+        tailsNE,
         stripPrefix,
         stripSuffix,
 
@@ -233,7 +235,7 @@ import Data.ByteString.Lazy
         (fromChunks, toChunks
         ,empty,null,length,tail,init,append,reverse,transpose,cycle
         ,concat,take,takeEnd,drop,dropEnd,splitAt,intercalate
-        ,isPrefixOf,isSuffixOf,group,inits,tails,copy
+        ,isPrefixOf,isSuffixOf,group,inits,tails,initsNE,tailsNE,copy
         ,stripPrefix,stripSuffix
         ,hGetContents, hGet, hPut, getContents
         ,hGetNonBlocking, hPutNonBlocking

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -59,7 +59,6 @@ import qualified Data.ByteString.Lazy.Internal as B (invariant)
 #define BYTESTRING_TYPE B.ByteString
 #endif
 
-import Prelude hiding (head, tail)
 import Data.Int
 import Numeric.Natural (Natural)
 
@@ -67,10 +66,12 @@ import Text.Read
 
 #endif
 
+import Prelude hiding (head, tail)
 import Control.Arrow
 import Data.Char
 import Data.Foldable
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as NE
 import Data.Semigroup
 import Data.String
 import Data.Tuple
@@ -231,6 +232,10 @@ tests =
     \x -> map B.unpack (B.inits x) === List.inits (B.unpack x)
   , testProperty "tails" $
     \x -> map B.unpack (B.tails x) === List.tails (B.unpack x)
+  , testProperty "initsNE" $
+    \x -> NE.map B.unpack (B.initsNE x) === NE.inits (B.unpack x)
+  , testProperty "tailsNE" $
+    \x -> NE.map B.unpack (B.tailsNE x) === NE.tails (B.unpack x)
 #endif
   , testProperty "all" $
     \f x -> B.all f x === all f (B.unpack x)


### PR DESCRIPTION
See #552.

The lazy versions use new implementations:
- Lazy `tails` got about 10% faster. (A happy accident!)
- Lazy `inits` got much faster:
  - For the first few chunks it is about 50% faster, due to better fusion.
  - When there are many chunks it is about 2.5x faster.

The performance of the strict versions is unchanged. The `inits` benchmark with small chunks is on the slow side, taking a little over 100ms on my machine.