### PR TITLE
Check the no-empty-chunks invariant in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           dist-newstyle
         key: ${{ runner.os }}-9.2.2
     - name: Test
-      run: cabal test --ghc-options='-fcheck-prim-bounds -fno-ignore-asserts'
+      run: cabal test --ghc-options='-fcheck-prim-bounds -fno-ignore-asserts -DHS_BYTESTRING_ASSERTIONS'
 
   old-gcc:
     needs: build

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface, BangPatterns #-}
 {-# LANGUAGE UnliftedFFITypes, MagicHash,
-            UnboxedTuples, DeriveDataTypeable #-}
+            UnboxedTuples #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE PatternSynonyms, ViewPatterns #-}
@@ -135,7 +135,6 @@ import Data.Bits                ((.&.))
 import Data.Char                (ord)
 import Data.Word
 
-import Data.Typeable            (Typeable)
 import Data.Data                (Data(..), mkNoRepType)
 
 import GHC.Base                 (nullAddr#,realWorld#,unsafeChr)
@@ -242,7 +241,6 @@ pokeFpByteOff fp off val = unsafeWithForeignPtr fp $ \p ->
 data ByteString = BS {-# UNPACK #-} !(ForeignPtr Word8) -- payload
                      {-# UNPACK #-} !Int                -- length
                      -- ^ @since 0.11.0.0
-    deriving (Typeable)
 
 -- | Type synonym for the strict flavour of 'ByteString'.
 --

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -495,12 +495,22 @@ foldr' f a = go
 -- argument, and thus must be applied to non-empty 'ByteString's.
 foldl1 :: HasCallStack => (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 foldl1 _ Empty        = errorEmptyList "foldl1"
-foldl1 f (Chunk c cs) = foldl f (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+foldl1 f (Chunk c cs) = go (S.unsafeHead c) (S.unsafeTail c) cs
+  where
+    go v x xs = let v' = S.foldl f v x
+      in case xs of
+      Empty -> v'
+      Chunk x' xs' -> go v' x' xs'
 
 -- | 'foldl1'' is like 'foldl1', but strict in the accumulator.
 foldl1' :: HasCallStack => (Word8 -> Word8 -> Word8) -> ByteString -> Word8
 foldl1' _ Empty        = errorEmptyList "foldl1'"
-foldl1' f (Chunk c cs) = foldl' f (S.unsafeHead c) (Chunk (S.unsafeTail c) cs)
+foldl1' f (Chunk c cs) = go (S.unsafeHead c) (S.unsafeTail c) cs
+  where
+    go !v x xs = let v' = S.foldl' f v x
+      in case xs of
+      Empty -> v'
+      Chunk x' xs' -> go v' x' xs'
 
 -- | 'foldr1' is a variant of 'foldr' that has no starting value argument,
 -- and thus must be applied to non-empty 'ByteString's

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Unsafe #-}
+
+#ifdef HS_BYTESTRING_ASSERTIONS
+{-# LANGUAGE PatternSynonyms #-}
+#endif
+
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- |
@@ -24,7 +29,7 @@
 module Data.ByteString.Lazy.Internal (
 
         -- * The lazy @ByteString@ type and representation
-        ByteString(..),
+        ByteString(Empty, Chunk),
         LazyByteString,
         chunk,
         foldrChunks,
@@ -71,6 +76,11 @@ import GHC.Exts                 (IsList(..))
 
 import qualified Language.Haskell.TH.Syntax as TH
 
+#ifdef HS_BYTESTRING_ASSERTIONS
+import Control.Exception (assert)
+#endif
+
+
 -- | A space-efficient representation of a 'Word8' vector, supporting many
 -- efficient operations.
 --
@@ -78,9 +88,23 @@ import qualified Language.Haskell.TH.Syntax as TH
 -- from "Data.ByteString.Lazy.Char8" it can be interpreted as containing
 -- 8-bit characters.
 --
-data ByteString = Empty | Chunk {-# UNPACK #-} !S.ByteString ByteString
+data ByteString = Empty
+#ifndef HS_BYTESTRING_ASSERTIONS
+  | Chunk {-# UNPACK #-} !S.ByteString ByteString
+#else
+  | Chunk_ {-# UNPACK #-} !S.ByteString ByteString
+#endif
     deriving (Typeable, TH.Lift)
 -- See 'invariant' function later in this module for internal invariants.
+
+#ifdef HS_BYTESTRING_ASSERTIONS
+pattern Chunk :: S.ByteString -> ByteString -> ByteString
+pattern Chunk c cs <- Chunk_ c cs where
+  Chunk c@(S.BS _ len) cs = assert (len > 0) Chunk_ c cs
+
+{-# COMPLETE Empty, Chunk #-}
+#endif
+
 
 -- | Type synonym for the lazy flavour of 'ByteString'.
 --
@@ -158,15 +182,19 @@ unpackChars (Chunk c cs) = S.unpackAppendCharsLazy c (unpackChars cs)
 
 ------------------------------------------------------------------------
 
+-- We no longer use these invariant-checking functions internally,
+-- preferring an assertion on `Chunk` itself, controlled by the
+-- HS_BYTESTRING_ASSERTIONS preprocessor macro.
+
 -- | The data type invariant:
 -- Every ByteString is either 'Empty' or consists of non-null 'S.ByteString's.
--- All functions must preserve this, and the QC properties must check this.
+-- All functions must preserve this.
 --
 invariant :: ByteString -> Bool
 invariant Empty                     = True
 invariant (Chunk (S.BS _ len) cs) = len > 0 && invariant cs
 
--- | In a form that checks the invariant lazily.
+-- | ...in a form that checks the invariant lazily.
 checkInvariant :: ByteString -> ByteString
 checkInvariant Empty = Empty
 checkInvariant (Chunk c@(S.BS _ len) cs)

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -90,6 +90,7 @@ import Control.Exception (assert)
 #ifndef HS_BYTESTRING_ASSERTIONS
 data ByteString = Empty | Chunk  {-# UNPACK #-} !S.ByteString ByteString
   -- INVARIANT: The S.ByteString field of any Chunk is not empty.
+  -- (See also the 'invariant' and 'checkInvariant' functions.)
 
   -- To make testing of this invariant convenient, we add an
   -- assertion to that effect when the HS_BYTESTRING_ASSERTIONS

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -43,7 +43,6 @@ import GHC.IO.Encoding
 module Properties.ByteStringLazy (tests) where
 #define BYTESTRING_TYPE B.ByteString
 import qualified Data.ByteString.Lazy as B
-import qualified Data.ByteString.Lazy.Internal as B (invariant)
 #endif
 
 #else
@@ -55,7 +54,6 @@ import qualified Data.ByteString.Char8 as B
 #else
 module Properties.ByteStringLazyChar8 (tests) where
 import qualified Data.ByteString.Lazy.Char8 as B
-import qualified Data.ByteString.Lazy.Internal as B (invariant)
 #define BYTESTRING_TYPE B.ByteString
 #endif
 
@@ -352,8 +350,6 @@ tests =
     \f x -> B.takeWhileEnd f x === B.reverse (B.takeWhile f (B.reverse x))
 
 #ifdef BYTESTRING_LAZY
-  , testProperty "invariant" $
-    \x -> B.invariant x
   , testProperty "fromChunks . toChunks" $
     \x -> B.fromChunks (B.toChunks x) === x
   , testProperty "toChunks . fromChunks" $

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -22,7 +22,6 @@ import Foreign.C (CChar)
 import qualified Data.ByteString.Short as SB
 import qualified Data.ByteString      as P
 import qualified Data.ByteString.Lazy as L
-import qualified Data.ByteString.Lazy.Internal as L (checkInvariant,ByteString(..))
 
 import qualified Data.ByteString.Char8      as PC
 import qualified Data.ByteString.Lazy.Char8 as LC
@@ -46,8 +45,7 @@ instance Arbitrary L.ByteString where
   arbitrary = sized $ \n -> do numChunks <- choose (0, n)
                                if numChunks == 0
                                    then return L.empty
-                                   else fmap (L.checkInvariant .
-                                              L.fromChunks .
+                                   else fmap (L.fromChunks .
                                               filter (not . P.null)) $
                                             vectorOf numChunks
                                                      (sizedByteString


### PR DESCRIPTION
More specifically, the idea is to make every call to `Chunk` check the invariant, at least in the bounds-checking job.