### PR TITLE
Allow the result of unsafeCreate to be unboxed

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -267,7 +267,6 @@ import GHC.IO.Handle.Types
 import GHC.IO.Buffer
 import GHC.IO.BufferedIO as Buffered
 import GHC.IO.Encoding          (getFileSystemEncoding)
-import GHC.IO                   (unsafePerformIO, unsafeDupablePerformIO)
 import GHC.Foreign              (newCStringLen, peekCStringLen)
 import GHC.Stack.Types          (HasCallStack)
 import Data.Char                (ord)
@@ -887,7 +886,7 @@ unfoldr f = concat . unfoldChunk 32 64
 unfoldrN :: Int -> (a -> Maybe (Word8, a)) -> a -> (ByteString, Maybe a)
 unfoldrN i f x0
     | i < 0     = (empty, Just x0)
-    | otherwise = unsafePerformIO $ createFpAndTrim' i $ \p -> go p x0 0
+    | otherwise = unsafeDupablePerformIO $ createFpAndTrim' i $ \p -> go p x0 0
   where
     go !p !x !n = go' x n
       where

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -51,6 +51,7 @@ module Data.ByteString.Internal (
         mallocByteString,
 
         -- * Conversion to and from ForeignPtrs
+        mkDeferredByteString,
         fromForeignPtr,
         toForeignPtr,
         fromForeignPtr0,

--- a/Data/ByteString/Internal.hs
+++ b/Data/ByteString/Internal.hs
@@ -58,6 +58,7 @@ module Data.ByteString.Internal (
 
         -- * Utilities
         nullForeignPtr,
+        deferForeignPtrAvailability,
         SizeOverflowException,
         overflowError,
         checkedAdd,

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -247,6 +247,8 @@ pokeFpByteOff fp off val = unsafeWithForeignPtr fp $ \p ->
 --
 -- The opaque bits evaporate during CorePrep, so using
 -- 'deferForeignPtrAvailability' incurs no direct overhead.
+--
+-- @since 0.11.5.0
 deferForeignPtrAvailability :: ForeignPtr a -> IO (ForeignPtr a)
 deferForeignPtrAvailability (ForeignPtr addr0# guts) = IO $ \s0 ->
   case lazy runRW# (\_ -> (# s0, addr0# #)) of

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -667,7 +667,7 @@ createFpUptoN :: Int -> (ForeignPtr Word8 -> IO Int) -> IO ByteString
 createFpUptoN l action = do
     fp <- mallocByteString l
     l' <- action fp
-    assert (l' <= l) $ mkDeferredByteString fp' l'
+    assert (l' <= l) $ mkDeferredByteString fp l'
 {-# INLINE createFpUptoN #-}
 
 -- | Like 'createFpUptoN', but also returns an additional value created by the

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -140,8 +140,9 @@ import Data.Word
 import Data.Data                (Data(..), mkNoRepType)
 
 import GHC.Base                 (nullAddr#,realWorld#,unsafeChr)
-import GHC.Exts                 (IsList(..), Addr#, minusAddr#, noinline, runRW#)
+import GHC.Exts                 (IsList(..), Addr#, minusAddr#)
 import GHC.CString              (unpackCString#)
+import GHC.Magic                (runRW#, lazy)
 
 #define TIMES_INT_2_AVAILABLE MIN_VERSION_ghc_prim(0,7,0)
 #if TIMES_INT_2_AVAILABLE
@@ -245,9 +246,9 @@ pokeFpByteOff fp off val = unsafeWithForeignPtr fp $ \p ->
 -- the (no-op) @'deferForeignPtrAvailability' x@ call is complete.
 deferForeignPtrAvailability :: ForeignPtr a -> IO (ForeignPtr a)
 deferForeignPtrAvailability (ForeignPtr addr0# guts) = IO $ \s0 ->
-  -- The "noinline runRW#" gunk gets erased during CorePrep,
-  -- so this should have no direct overhead.
-  case noinline runRW# (\_ -> (# s0, addr0# #)) of
+  -- The "lazy runRW#" gunk gets erased during CorePrep,
+  -- leaving just the unboxed tuple, so this should have no direct overhead.
+  case lazy runRW# (\_ -> (# s0, addr0# #)) of
     (# s1, addr1# #) -> (# s1, ForeignPtr addr1# guts #)
 
 unsafeDupablePerformIO :: IO a -> a

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -62,6 +62,7 @@ module Data.ByteString.Internal.Type (
         mallocByteString,
 
         -- * Conversion to and from ForeignPtrs
+        mkDeferredByteString,
         fromForeignPtr,
         toForeignPtr,
         fromForeignPtr0,
@@ -253,6 +254,14 @@ deferForeignPtrAvailability :: ForeignPtr a -> IO (ForeignPtr a)
 deferForeignPtrAvailability (ForeignPtr addr0# guts) = IO $ \s0 ->
   case lazy runRW# (\_ -> (# s0, addr0# #)) of
     (# s1, addr1# #) -> (# s1, ForeignPtr addr1# guts #)
+
+-- | Variant of 'fromForeignPtr0' that calls 'deferForeignPtrAvailability'
+--
+-- @since 0.11.5.0
+mkDeferredByteString :: ForeignPtr Word8 -> Int -> IO ByteString
+mkDeferredByteString fp len = do
+  deferredFp <- deferForeignPtrAvailability fp
+  pure $! BS deferredFp len
 
 unsafeDupablePerformIO :: IO a -> a
 -- Why does this exist? In base-4.15.1.0 until at least base-4.18.0.0,
@@ -607,8 +616,8 @@ fromForeignPtr fp o = BS (plusForeignPtr fp o)
 
 -- | @since 0.11.0.0
 fromForeignPtr0 :: ForeignPtr Word8
-               -> Int -- ^ Length
-               -> ByteString
+                -> Int -- ^ Length
+                -> ByteString
 fromForeignPtr0 = BS
 {-# INLINE fromForeignPtr0 #-}
 
@@ -648,8 +657,7 @@ createFp :: Int -> (ForeignPtr Word8 -> IO ()) -> IO ByteString
 createFp l action = do
     fp <- mallocByteString l
     action fp
-    fp' <- deferForeignPtrAvailability fp
-    return $! BS fp' l
+    mkDeferredByteString fp l
 {-# INLINE createFp #-}
 
 -- | Given a maximum size @l@ and an action @f@ that fills the 'ByteString'
@@ -659,8 +667,7 @@ createFpUptoN :: Int -> (ForeignPtr Word8 -> IO Int) -> IO ByteString
 createFpUptoN l action = do
     fp <- mallocByteString l
     l' <- action fp
-    fp' <- deferForeignPtrAvailability fp
-    assert (l' <= l) $ return $! BS fp' l'
+    assert (l' <= l) $ mkDeferredByteString fp' l'
 {-# INLINE createFpUptoN #-}
 
 -- | Like 'createFpUptoN', but also returns an additional value created by the
@@ -669,8 +676,8 @@ createFpUptoN' :: Int -> (ForeignPtr Word8 -> IO (Int, a)) -> IO (ByteString, a)
 createFpUptoN' l action = do
     fp <- mallocByteString l
     (l', res) <- action fp
-    fp' <- deferForeignPtrAvailability fp
-    assert (l' <= l) $ return (BS fp' l', res)
+    bs <- mkDeferredByteString fp l'
+    assert (l' <= l) $ pure (bs, res)
 {-# INLINE createFpUptoN' #-}
 
 -- | Given the maximum size needed and a function to make the contents
@@ -685,22 +692,20 @@ createFpAndTrim :: Int -> (ForeignPtr Word8 -> IO Int) -> IO ByteString
 createFpAndTrim l action = do
     fp <- mallocByteString l
     l' <- action fp
-    fp' <- deferForeignPtrAvailability fp
     if assert (0 <= l' && l' <= l) $ l' >= l
-        then return $! BS fp' l
-        else createFp l' $ \dest -> memcpyFp dest fp' l'
+        then mkDeferredByteString fp l
+        else createFp l' $ \dest -> memcpyFp dest fp l'
 {-# INLINE createFpAndTrim #-}
 
 createFpAndTrim' :: Int -> (ForeignPtr Word8 -> IO (Int, Int, a)) -> IO (ByteString, a)
 createFpAndTrim' l action = do
     fp <- mallocByteString l
     (off, l', res) <- action fp
-    fp' <- deferForeignPtrAvailability fp
-    if assert (0 <= l' && l' <= l) $ l' >= l
-        then return (BS fp' l, res)
-        else do ps <- createFp l' $ \dest ->
-                        memcpyFp dest (fp' `plusForeignPtr` off) l'
-                return (ps, res)
+    bs <- if assert (0 <= l' && l' <= l) $ l' >= l
+        then mkDeferredByteString fp l -- entire buffer used => offset is zero
+        else createFp l' $ \dest ->
+               memcpyFp dest (fp `plusForeignPtr` off) l'
+    return (bs, res)
 {-# INLINE createFpAndTrim' #-}
 
 

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -254,11 +254,13 @@ deferForeignPtrAvailability (ForeignPtr addr0# guts) = IO $ \s0 ->
 unsafeDupablePerformIO :: IO a -> a
 -- Why does this exist? As of base-4.18.0.0, the version of
 -- unsafeDupablePerformIO in base prevents unboxing of its results
--- with an opaque call to lazy, for reasons described in
--- Note [unsafePerformIO and strictness].  Even if we accept the
--- (very questionable) premise that the sort of function described
--- in that note should work, we expect no such calls to be made in
--- the context of bytestring.  (And we really want unboxing!)
+-- with an opaque call to GHC.Exts.lazy, for reasons described in
+-- Note [unsafePerformIO and strictness] in GHC.IO.Unsafe. (See
+-- https://hackage.haskell.org/package/base-4.18.0.0/docs/src/GHC.IO.Unsafe.html#line-30 .)
+-- Even if we accept the (very questionable) premise that the sort of
+-- function described in that note should work, we expect no such
+-- calls to be made in the context of bytestring.  (And we really want
+-- unboxing!)
 unsafeDupablePerformIO (IO act) = case runRW# act of (# _, res #) -> res
 
 

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -161,8 +161,9 @@ module Data.ByteString.Short.Internal (
     useAsCStringLen,
   ) where
 
-import Data.ByteString.Internal
+import Data.ByteString.Internal.Type
   ( ByteString(..)
+  , unsafeDupablePerformIO
   , accursedUnutterablePerformIO
   , checkedAdd
   )
@@ -241,7 +242,7 @@ import GHC.Exts
   , writeWord8Array#
   , unsafeFreezeByteArray#
   , touch# )
-import GHC.IO
+import GHC.IO hiding ( unsafeDupablePerformIO )
 import GHC.ForeignPtr
   ( ForeignPtr(ForeignPtr)
   , ForeignPtrContents(PlainPtr)
@@ -268,7 +269,7 @@ import Prelude
   , snd
   )
 
-import qualified Data.ByteString.Internal as BS
+import qualified Data.ByteString.Internal.Type as BS
 
 import qualified Data.List as List
 import qualified GHC.Exts


### PR DESCRIPTION
By removing the `lazy` from the implementation of `unsafeDupablePerformIO`, this patch allows the simplifier to unbox intermediate `StrictByteString`s in many more situations.

This improved freedom for the simplifier comes at a price: It creates opportunities for the simplifier to perform reads at the newly-unboxed addresses before the buffer has actually been initialized. To prevent this from causing problems, the `deferForeignPtrAvailability` function is introduced. (I'm not _entirely_ sure this provides enough protection in a multi-threaded context on all architectures. Maybe @bgamari can comment? But it's at least no more unsafe than the `ShortByteString` stuff already is.)

Supersedes #466.