### PR TITLE
Builder: Re-use the old buffer after trimming

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -1090,7 +1090,7 @@ buildStepToCIOS (AllocationStrategy nextBuffer bufSize trim) =
                 -- Checking for empty case avoids allocating 'n-1' empty
                 -- buffers for 'n' insertChunkH right after each other.
                 if isEmpty
-                  then fill nextStep buf
+                  then fill nextStep (Buffer fpbuf (BufferRange pbuf pe))
                   else do buf' <- nextBuffer (Just (buf, bufSize))
                           fill nextStep buf'
 
@@ -1101,8 +1101,9 @@ buildStepToCIOS (AllocationStrategy nextBuffer bufSize trim) =
           | trim chunkSize size = do
               bs <- S.createFp chunkSize $ \fpbuf' ->
                         S.memcpyFp fpbuf' fpbuf chunkSize
-              -- FIXME: We could reuse the trimmed buffer here.
-              return $ Yield1 bs (mkCIOS False)
+              -- Instead of allocating a new buffer after trimming,
+              -- we re-use the old buffer and consider it empty.
+              return $ Yield1 bs (mkCIOS True)
           | otherwise            =
               return $ Yield1 (S.BS fpbuf chunkSize) (mkCIOS False)
           where


### PR DESCRIPTION
It might be nice to work out how much this affects the balance of power between trimming and not trimming. But it's a nice incremental improvement without that.