### PR TITLE
Deprecate memcpy and memset

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1,9 +1,11 @@
+{-# OPTIONS_HADDOCK prune #-}
+{-# LANGUAGE Trustworthy #-}
+
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TupleSections #-}
-{-# OPTIONS_HADDOCK prune #-}
-{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Data.ByteString
@@ -243,7 +245,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Word                (Word8)
 
 import Control.Exception        (IOException, catch, finally, assert, throwIO)
-import Control.Monad            (when, void)
+import Control.Monad            (when)
 
 import Foreign.C.String         (CString, CStringLen)
 import Foreign.C.Types          (CSize (CSize), CInt (CInt))
@@ -251,6 +253,7 @@ import Foreign.ForeignPtr       (ForeignPtr, touchForeignPtr)
 import Foreign.ForeignPtr.Unsafe(unsafeForeignPtrToPtr)
 import Foreign.Marshal.Alloc    (allocaBytes)
 import Foreign.Marshal.Array    (allocaArray)
+import Foreign.Marshal.Utils
 import Foreign.Ptr
 import Foreign.Storable         (Storable(..))
 
@@ -845,14 +848,12 @@ scanr1 f ps = case unsnoc ps of
 -- the value of every element. The following holds:
 --
 -- > replicate w c = unfoldr w (\u -> Just (u,u)) c
---
--- This implementation uses @memset(3)@
 replicate :: Int -> Word8 -> ByteString
 replicate w c
     | w <= 0    = empty
     | otherwise = unsafeCreateFp w $ \fptr ->
         unsafeWithForeignPtr fptr $ \ptr ->
-                      void $ memset ptr c (fromIntegral w)
+                      fillBytes ptr c (fromIntegral w)
 {-# INLINE replicate #-}
 
 -- | /O(n)/, where /n/ is the length of the result.  The 'unfoldr'
@@ -1721,12 +1722,15 @@ tailsNE p | null p    = empty :| []
 Note [Avoid NonEmpty combinators]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As of base-4.17, most of the NonEmpty API is surprisingly lazy.
+As of base-4.18, most of the NonEmpty API is surprisingly lazy.
 Using it without forcing the arguments yourself is just begging GHC
 to make your code waste time allocating useless selector thunks.
 This may change in the future. See also this CLC issue:
   https://github.com/haskell/core-libraries-committee/issues/107
 But until then, "refactor" with care!
+
+(Even for uses of NonEmpty near lazy ByteStrings, we don't want
+the extra laziness of the NonEmpty API.)
 -}
 
 
@@ -1743,18 +1747,17 @@ sort (BS input l)
     unsafeWithForeignPtr destFP $ \dest -> c_sort dest (fromIntegral l)
   | otherwise = unsafeCreateFp l $ \p -> allocaArray 256 $ \arr -> do
 
-    _ <- memset (castPtr arr) 0 (256 * fromIntegral (sizeOf (undefined :: CSize)))
+    fillBytes (castPtr arr) 0 (256 * sizeOf (undefined :: Int))
     unsafeWithForeignPtr input (\x -> countOccurrences arr x l)
 
     let go 256 !_   = return ()
         go i   !ptr = do n <- peekElemOff arr i
-                         when (n /= 0) $ void $ memset ptr (fromIntegral i) n
+                         when (n /= 0) $ fillBytes ptr (fromIntegral i) n
                          go (i + 1) (ptr `plusPtr` fromIntegral n)
     unsafeWithForeignPtr p (go 0)
   where
     -- Count the number of occurrences of each byte.
-    -- Used by 'sort'
-    countOccurrences :: Ptr CSize -> Ptr Word8 -> Int -> IO ()
+    countOccurrences :: Ptr Int -> Ptr Word8 -> Int -> IO ()
     countOccurrences !counts !str !len = go 0
      where
         go !i | i == len    = return ()
@@ -1774,7 +1777,7 @@ sort (BS input l)
 useAsCString :: ByteString -> (CString -> IO a) -> IO a
 useAsCString (BS fp l) action =
   allocaBytes (l+1) $ \buf -> do
-    unsafeWithForeignPtr fp $ \p -> memcpy buf p l
+    unsafeWithForeignPtr fp $ \p -> copyBytes buf p l
     pokeByteOff buf l (0::Word8)
     action (castPtr buf)
 
@@ -1801,7 +1804,7 @@ packCString cstr = do
 -- Haskell heap.
 packCStringLen :: CStringLen -> IO ByteString
 packCStringLen (cstr, len) | len >= 0 = createFp len $ \fp ->
-    unsafeWithForeignPtr fp $ \p -> memcpy p (castPtr cstr) len
+    unsafeWithForeignPtr fp $ \p -> copyBytes p (castPtr cstr) len
 packCStringLen (_, len) =
     moduleErrorIO "packCStringLen" ("negative length: " ++ show len)
 


### PR DESCRIPTION
Starting with ghc-9.8, `copyBytes` and `fillBytes` from `base` will use dedicated primops that ghc can sometimes emit better code for if the length is known and small enough.  We should take advantage of this rather than using a foreign call that ghc won't recognize.

See also https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9629