### PR TITLE
Prepare 0.12.0.1 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+[0.12.0.1] — August 2023
+
+* Bug fixes:
+  * [Work around a GHC runtime linker issue on i386/PowerPC](https://github.com/haskell/bytestring/pull/604)
+
+[0.12.0.1]: https://github.com/haskell/bytestring/compare/0.12.0.0...0.12.0.1
+
 [0.12.0.0] — July 2023
 
 * __Breaking Changes__:
@@ -30,6 +37,13 @@
 
 
 [0.12.0.0]: https://github.com/haskell/bytestring/compare/0.11.5.0...0.12.0.0
+
+[0.11.5.1] — August 2023
+
+* Bug fixes:
+  * [Work around a GHC runtime linker issue on i386/PowerPC](https://github.com/haskell/bytestring/pull/604)
+
+[0.11.5.1]: https://github.com/haskell/bytestring/compare/0.11.5.0...0.11.5.1
 
 [0.11.5.0] — July 2023
 

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -1,5 +1,5 @@
 Name:                bytestring
-Version:             0.12.0.0
+Version:             0.12.0.1
 Synopsis:            Fast, compact, strict and lazy byte strings with a list interface
 Description:
     An efficient compact, immutable byte string type (both strict and lazy)


### PR DESCRIPTION
With #601 resolved I think we should make a patch-level 0.11.5.1 release so that ghc can use it in their stable branches.

I'm not sure it's worth bothering with an announcement. This should happen very soon if we want to catch 9.4.6.
