### PR TITLE
Use a more specific include than Rts.h

### DIFF
--- a/cbits/is-valid-utf8.c
+++ b/cbits/is-valid-utf8.c
@@ -50,7 +50,7 @@ SUCH DAMAGE.
 #endif
 
 #include <MachDeps.h>
-#include "Rts.h"
+#include "ghcplatform.h"
 
 #ifdef WORDS_BIGENDIAN
 #define to_little_endian(x) __builtin_bswap64(x)


### PR DESCRIPTION
The Rts.h include seems to cause build problems.
See also:
  https://gitlab.haskell.org/ghc/ghc/-/issues/23789
  https://github.com/haskell/bytestring/issues/606
