### PR TITLE
Prepare 0.12.0.2 release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+[0.12.0.2] — August 2023
+
+* Bug fixes:
+  * [Fix `clockid_t`-related build failures on some platforms](https://github.com/haskell/bytestring/pull/607)
+
+[0.12.0.2]: https://github.com/haskell/bytestring/compare/0.12.0.1...0.12.0.2
+
 [0.12.0.1] — August 2023
 
 * Bug fixes:
@@ -37,6 +44,13 @@
 
 
 [0.12.0.0]: https://github.com/haskell/bytestring/compare/0.11.5.0...0.12.0.0
+
+[0.11.5.2] — August 2023
+
+* Bug fixes:
+  * [Fix `clockid_t`-related build failures on some platforms](https://github.com/haskell/bytestring/pull/607)
+
+[0.11.5.2]: https://github.com/haskell/bytestring/compare/0.11.5.1...0.11.5.2
 
 [0.11.5.1] — August 2023
 

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -1,5 +1,5 @@
 Name:                bytestring
-Version:             0.12.0.1
+Version:             0.12.0.2
 Synopsis:            Fast, compact, strict and lazy byte strings with a list interface
 Description:
     An efficient compact, immutable byte string type (both strict and lazy)


### PR DESCRIPTION
See [ghc issue 23789](https://gitlab.haskell.org/ghc/ghc/-/issues/23789).