### PR TITLE
Implement stimes for Builder and ShortByteString

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -128,9 +128,7 @@ module Data.ByteString.Builder.Internal (
 
 import           Control.Arrow (second)
 
-#if !(MIN_VERSION_base(4,11,0))
-import           Data.Semigroup (Semigroup((<>)))
-#endif
+import           Data.Semigroup (Semigroup(..))
 
 import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal.Type as S
@@ -382,9 +380,25 @@ empty = Builder ($)
 append :: Builder -> Builder -> Builder
 append (Builder b1) (Builder b2) = Builder $ b1 . b2
 
+stimesBuilder :: Integral t => t -> Builder -> Builder
+{-# INLINABLE stimesBuilder #-}
+stimesBuilder n b
+  | n >= 0 = go n
+  | otherwise = stimesNegativeErr
+  where go 0 = empty
+        go k = b `append` go (k - 1)
+
+stimesNegativeErr :: Builder
+-- See Note [Float error calls out of INLINABLE things]
+-- in Data.ByteString.Internal.Type
+stimesNegativeErr
+  = errorWithoutStackTrace "stimes @Builder: non-negative multiplier expected"
+
 instance Semigroup Builder where
   {-# INLINE (<>) #-}
   (<>) = append
+  {-# INLINE stimes #-}
+  stimes = stimesBuilder
 
 instance Monoid Builder where
   {-# INLINE mempty #-}

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -184,7 +184,7 @@ import Data.Data
 import Data.Monoid
   ( Monoid(..) )
 import Data.Semigroup
-  ( Semigroup((<>)) )
+  ( Semigroup(..), stimesMonoid )
 import Data.String
   ( IsString(..) )
 import Control.Applicative
@@ -313,6 +313,7 @@ instance Ord ShortByteString where
 
 instance Semigroup ShortByteString where
     (<>)    = append
+    stimes  = stimesMonoid
 
 instance Monoid ShortByteString where
     mempty  = empty

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -250,10 +250,8 @@ tests =
     \x y -> B.unpack (mappend x y) === B.unpack x `mappend` B.unpack y
   , testProperty "<>" $
     \x y -> B.unpack (x <> y) === B.unpack x <> B.unpack y
-#ifndef BYTESTRING_SHORT
   , testProperty "stimes" $
-    \(Sqrt (NonNegative n)) (Sqrt x) -> stimes (n :: Int) (x :: BYTESTRING_TYPE) === mtimesDefault n x
-#endif
+    \(Sqrt (NonNegative n)) (Sqrt x) -> stimes (n :: Int) (x :: BYTESTRING_TYPE) === stimesMonoid n x
 
   , testProperty "break" $
     \f x -> (B.unpack *** B.unpack) (B.break f x) === break f (B.unpack x)


### PR DESCRIPTION
I implemented `stimes` for `Builder` in #587 after being unpleasantly not-quite-surprised by the fact that it doesn't work with a multiplier of zero in the tests I wrote in that patch. But the change is unrelated, so I've broken it off into another pull request.

We could also now newtype-derive `Semigroup` and `Monoid` for `ShortByteString` with base-4.18 and newer, but I haven't done so yet because I'm undecided on whether that should be considered a breaking change for PVP purposes: It would change the types of errors we throw on overflow from our own `SizeOverflowException` to whatever `Data.Array.Byte` chooses to throw. (Error message quality is about the same in both cases, I think.)
