### PR TITLE
Remove NOINLINE on lowerTable

### DIFF
--- a/Data/ByteString/Builder/Prim/Internal/Base16.hs
+++ b/Data/ByteString/Builder/Prim/Internal/Base16.hs
@@ -36,7 +36,6 @@ foreign import ccall "&hs_bytestring_lower_hex_table"
 
 -- | The encoding table for hexadecimal values with lower-case characters;
 -- e.g., deadbeef.
-{-# NOINLINE lowerTable #-}
 lowerTable :: EncodingTable
 lowerTable = case c_lower_hex_table of
   Ptr p# -> EncodingTable p#


### PR DESCRIPTION
This seems to exist for no reason, and prevents case-of-known-constructor from eliminating an indirection in downstream modules.