### PR TITLE
Use the strict/lazy type synonyms for better generated documentation

### DIFF
--- a/Data/ByteString/Builder/ASCII.hs
+++ b/Data/ByteString/Builder/ASCII.hs
@@ -240,14 +240,14 @@ floatHexFixed = P.primFixed P.floatHexFixed
 doubleHexFixed :: Double -> Builder
 doubleHexFixed = P.primFixed P.doubleHexFixed
 
--- | Encode each byte of a 'S.ByteString' using its fixed-width hex encoding.
+-- | Encode each byte of a 'S.StrictByteString' using its fixed-width hex encoding.
 {-# NOINLINE byteStringHex #-} -- share code
-byteStringHex :: S.ByteString -> Builder
+byteStringHex :: S.StrictByteString -> Builder
 byteStringHex = P.primMapByteStringFixed P.word8HexFixed
 
--- | Encode each byte of a lazy 'L.ByteString' using its fixed-width hex encoding.
+-- | Encode each byte of a 'L.LazyByteString' using its fixed-width hex encoding.
 {-# NOINLINE lazyByteStringHex #-} -- share code
-lazyByteStringHex :: L.ByteString -> Builder
+lazyByteStringHex :: L.LazyByteString -> Builder
 lazyByteStringHex = P.primMapLazyByteStringFixed P.word8HexFixed
 
 

--- a/Data/ByteString/Builder/Extra.hs
+++ b/Data/ByteString/Builder/Extra.hs
@@ -78,7 +78,7 @@ import Foreign
 --  * an IO action for writing the Builder's data into a user-supplied memory
 --    buffer.
 --
---  * a pre-existing chunks of data represented by a strict 'S.ByteString'
+--  * a pre-existing chunks of data represented by a 'S.StrictByteString'
 --
 -- While this is rather low level, it provides you with full flexibility in
 -- how the data is written out.
@@ -107,10 +107,10 @@ data Next =
 
      -- | In addition to the data that has just been written into your buffer
      -- by the 'BufferWriter' action, it gives you a pre-existing chunk
-     -- of data as a 'S.ByteString'. It also gives you the following 'BufferWriter'
+     -- of data as a 'S.StrictByteString'. It also gives you the following 'BufferWriter'
      -- action. It is safe to run this following action using a buffer with as
      -- much free space as was left by the previous run action.
-   | Chunk  !S.ByteString BufferWriter
+   | Chunk  !S.StrictByteString BufferWriter
 
 -- | Turn a 'Builder' into its initial 'BufferWriter' action.
 --

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -274,12 +274,12 @@ pack = packBytes
 unpack :: ByteString -> [Word8]
 unpack = unpackBytes
 
--- | /O(c)/ Convert a list of strict 'ByteString' into a lazy 'ByteString'
-fromChunks :: [P.ByteString] -> ByteString
+-- | /O(c)/ Convert a list of 'S.StrictByteString' into a 'LazyByteString'
+fromChunks :: [S.StrictByteString] -> LazyByteString
 fromChunks = List.foldr chunk Empty
 
--- | /O(c)/ Convert a lazy 'ByteString' into a list of strict 'ByteString'
-toChunks :: ByteString -> [P.ByteString]
+-- | /O(c)/ Convert a 'LazyByteString' into a list of 'S.StrictByteString'
+toChunks :: LazyByteString -> [S.StrictByteString]
 toChunks = foldrChunks (:) []
 
 ------------------------------------------------------------------------
@@ -845,7 +845,7 @@ dropEnd i p          = go D.empty p
                             getOutput (Chunk x out) deque'
             _ -> (reverseChunks out, deque)
 
-        -- reverse a `ByteString`s chunks, keeping all internal `S.ByteString`s
+        -- reverse a `ByteString`s chunks, keeping all internal `S.StrictByteString`s
         -- unchanged
         reverseChunks = foldlChunks (flip Chunk) empty
 
@@ -1714,7 +1714,7 @@ revChunks = List.foldl' (flip chunk) Empty
 -- reading the whole file via 'readFile' executes all three actions
 -- (open the file handle, read its content, close the file handle) before
 -- control moves to the following 'writeFile' action. This expectation holds
--- for the strict "Data.ByteString" API. However, the above lazy 'ByteString' variant
+-- for the strict "Data.ByteString" API. However, the above 'LazyByteString' variant
 -- of the program fails with @openBinaryFile: resource busy (file is locked)@.
 --
 -- The reason for this is that "Data.ByteString.Lazy" is specifically designed

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -83,13 +83,13 @@ import Control.Exception (assert)
 -- | A space-efficient representation of a 'Word8' vector, supporting many
 -- efficient operations.
 --
--- A lazy 'ByteString' contains 8-bit bytes, or by using the operations
+-- A 'LazyByteString' contains 8-bit bytes, or by using the operations
 -- from "Data.ByteString.Lazy.Char8" it can be interpreted as containing
 -- 8-bit characters.
 --
 #ifndef HS_BYTESTRING_ASSERTIONS
-data ByteString = Empty | Chunk  {-# UNPACK #-} !S.ByteString ByteString
-  -- INVARIANT: The S.ByteString field of any Chunk is not empty.
+data ByteString = Empty | Chunk  {-# UNPACK #-} !S.StrictByteString ByteString
+  -- INVARIANT: The S.StrictByteString field of any Chunk is not empty.
   -- (See also the 'invariant' and 'checkInvariant' functions.)
 
   -- To make testing of this invariant convenient, we add an
@@ -97,9 +97,9 @@ data ByteString = Empty | Chunk  {-# UNPACK #-} !S.ByteString ByteString
   -- preprocessor macro is defined, by renaming the actual constructor
   -- and providing a pattern synonym that does the checking:
 #else
-data ByteString = Empty | Chunk_ {-# UNPACK #-} !S.ByteString ByteString
+data ByteString = Empty | Chunk_ {-# UNPACK #-} !S.StrictByteString ByteString
 
-pattern Chunk :: S.ByteString -> ByteString -> ByteString
+pattern Chunk :: S.StrictByteString -> ByteString -> ByteString
 pattern Chunk c cs <- Chunk_ c cs where
   Chunk c@(S.BS _ len) cs = assert (len > 0) Chunk_ c cs
 
@@ -218,13 +218,13 @@ checkInvariant (Chunk c@(S.BS _ len) cs)
 ------------------------------------------------------------------------
 
 -- | Smart constructor for 'Chunk'. Guarantees the data type invariant.
-chunk :: S.ByteString -> ByteString -> ByteString
+chunk :: S.StrictByteString -> ByteString -> ByteString
 chunk c@(S.BS _ len) cs | len == 0  = cs
                         | otherwise = Chunk c cs
 {-# INLINE chunk #-}
 
 -- | Consume the chunks of a lazy ByteString with a natural right fold.
-foldrChunks :: (S.ByteString -> a -> a) -> a -> ByteString -> a
+foldrChunks :: (S.StrictByteString -> a -> a) -> a -> ByteString -> a
 foldrChunks f z = go
   where go Empty        = z
         go (Chunk c cs) = f c (go cs)
@@ -232,7 +232,7 @@ foldrChunks f z = go
 
 -- | Consume the chunks of a lazy ByteString with a strict, tail-recursive,
 -- accumulating left fold.
-foldlChunks :: (a -> S.ByteString -> a) -> a -> ByteString -> a
+foldlChunks :: (a -> S.StrictByteString -> a) -> a -> ByteString -> a
 foldlChunks f = go
   where go !a Empty        = a
         go !a (Chunk c cs) = go (f a c) cs
@@ -320,18 +320,18 @@ times n lbs0
 ------------------------------------------------------------------------
 -- Conversions
 
--- |/O(1)/ Convert a strict 'ByteString' into a lazy 'ByteString'.
-fromStrict :: S.ByteString -> ByteString
+-- |/O(1)/ Convert a 'S.StrictByteString' into a 'LazyByteString'.
+fromStrict :: S.StrictByteString -> LazyByteString
 fromStrict (S.BS _ 0) = Empty
 fromStrict bs = Chunk bs Empty
 
--- |/O(n)/ Convert a lazy 'ByteString' into a strict 'ByteString'.
+-- |/O(n)/ Convert a 'LazyByteString' into a 'S.StrictByteString'.
 --
--- Note that this is an /expensive/ operation that forces the whole lazy
--- ByteString into memory and then copies all the data. If possible, try to
+-- Note that this is an /expensive/ operation that forces the whole
+-- 'LazyByteString' into memory and then copies all the data. If possible, try to
 -- avoid converting back and forth between strict and lazy bytestrings.
 --
-toStrict :: ByteString -> S.ByteString
+toStrict :: LazyByteString -> S.StrictByteString
 toStrict = \cs -> goLen0 cs cs
     -- We pass the original [ByteString] (bss0) through as an argument through
     -- goLen0, goLen1, and goLen since we will need it again in goCopy. Passing

--- a/Data/ByteString/Lazy/Internal/Deque.hs
+++ b/Data/ByteString/Lazy/Internal/Deque.hs
@@ -1,5 +1,5 @@
 {- |
- A Deque used for accumulating `S.ByteString`s in `Data.ByteString.Lazy.dropEnd`.
+ A Deque used for accumulating `S.StrictByteString`s in `Data.ByteString.Lazy.dropEnd`.
 -}
 module Data.ByteString.Lazy.Internal.Deque (
     Deque (..),
@@ -15,11 +15,11 @@ import qualified Data.ByteString as S
 import Data.Int (Int64)
 import Prelude hiding (head, tail, length, null)
 
--- A `S.ByteString` Deque used as an accumulator for lazy
+-- A `S.StrictByteString` Deque used as an accumulator for lazy
 -- Bytestring operations
 data Deque = Deque
-    { front :: [S.ByteString]
-    , rear :: [S.ByteString]
+    { front :: [S.StrictByteString]
+    , rear :: [S.StrictByteString]
     , -- | Total length in bytes
       byteLength :: !Int64
     }
@@ -33,32 +33,32 @@ empty = Deque [] [] 0
 null :: Deque -> Bool
 null deque = byteLength deque == 0
 
--- Add a `S.ByteString` to the front of the `Deque`
+-- Add a `S.StrictByteString` to the front of the `Deque`
 -- O(1)
-cons :: S.ByteString -> Deque -> Deque
+cons :: S.StrictByteString -> Deque -> Deque
 cons x (Deque fs rs acc) = Deque (x : fs) rs (acc + len x)
 
--- Add a `S.ByteString` to the rear of the `Deque`
+-- Add a `S.StrictByteString` to the rear of the `Deque`
 -- O(1)
-snoc :: S.ByteString -> Deque -> Deque
+snoc :: S.StrictByteString -> Deque -> Deque
 snoc x (Deque fs rs acc) = Deque fs (x : rs) (acc + len x)
 
-len :: S.ByteString -> Int64
+len :: S.StrictByteString -> Int64
 len x = fromIntegral $ S.length x
 
--- Pop a `S.ByteString` from the front of the `Deque`
+-- Pop a `S.StrictByteString` from the front of the `Deque`
 -- Returns the bytestring and the updated Deque, or Nothing if the Deque is empty
 -- O(1) , occasionally O(n)
-popFront :: Deque -> Maybe (S.ByteString, Deque)
+popFront :: Deque -> Maybe (S.StrictByteString, Deque)
 popFront (Deque [] rs acc) = case reverse rs of
     [] -> Nothing
     x : xs -> Just (x, Deque xs [] (acc - len x))
 popFront (Deque (x : xs) rs acc) = Just (x, Deque xs rs (acc - len x))
 
--- Pop a `S.ByteString` from the rear of the `Deque`
+-- Pop a `S.StrictByteString` from the rear of the `Deque`
 -- Returns the bytestring and the updated Deque, or Nothing if the Deque is empty
 -- O(1) , occasionally O(n)
-popRear :: Deque -> Maybe (Deque, S.ByteString)
+popRear :: Deque -> Maybe (Deque, S.StrictByteString)
 popRear (Deque fs [] acc) = case reverse fs of
     [] -> Nothing
     x : xs -> Just (Deque [] xs (acc - len x), x)


### PR DESCRIPTION
While using qualified names such as `S.ByteString` or `L.ByteString`
allows for GHC to disambiguate between the strict and lazy variants, the
generated haddocks end up being quite confusing, prime examples being
`fromStrict` and `toStrict`.

![image](https://github.com/haskell/bytestring/assets/69002988/a8c03350-86eb-4d44-ac4c-a79fce7dbf2c)

This patch replaces such uses with the type synonyms `StrictByteString` and `LazyByteString` to (hopefully) make the docs a bit clearer.

![image](https://github.com/haskell/bytestring/assets/69002988/583453f7-09be-4313-aa2a-139f558b1a0b)
