### PR TITLE
Explicitly implement `sconcat` in Semigroup instances

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -129,6 +129,7 @@ module Data.ByteString.Builder.Internal (
 import           Control.Arrow (second)
 
 import           Data.Semigroup (Semigroup(..))
+import           Data.List.NonEmpty (NonEmpty(..))
 
 import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal.Type as S
@@ -400,6 +401,7 @@ stimesNegativeErr
 instance Semigroup Builder where
   {-# INLINE (<>) #-}
   (<>) = append
+  sconcat (b:|bs) = b <> foldr mappend mempty bs
   {-# INLINE stimes #-}
   stimes = stimesBuilder
 

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -179,6 +179,8 @@ import Data.Monoid
   ( Monoid(..) )
 import Data.Semigroup
   ( Semigroup(..), stimesMonoid )
+import Data.List.NonEmpty
+  ( NonEmpty(..) )
 import Data.String
   ( IsString(..) )
 import Control.Applicative
@@ -309,6 +311,7 @@ instance Ord ShortByteString where
 
 instance Semigroup ShortByteString where
     (<>)    = append
+    sconcat (b:|bs) = concat (b:bs)
     stimes  = stimesMonoid
 
 instance Monoid ShortByteString where


### PR DESCRIPTION
Since `stimes` was explicitly implemented in #611: Closes #488. Closes #489.