### PR TITLE
Fix known type mismatch in sbs_elem_index

### DIFF
--- a/cbits/shortbytestring.c
+++ b/cbits/shortbytestring.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 
@@ -20,7 +21,7 @@ sbs_memcmp_off(const void *s1,
 
 ptrdiff_t
 sbs_elem_index(const void *s,
-            int c,
+            uint8_t c,
             size_t n)
 {
     const void *so = memchr(s, c, n);


### PR DESCRIPTION
See #653.  A complete audit has not been done,
but let's just fix the known bug anyway.