### PR TITLE
Use default-extensions to tidy up a bit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           curl -s https://hackage.haskell.org/package/data-array-byte-0.1/data-array-byte-0.1.tar.gz | tar xz
           ghc --version
-          ghc --make -Iinclude -itests:tests/builder:data-array-byte-0.1 -o Main cbits/*.c tests/Main.hs +RTS -s
+          ghc --make -XBangPatterns -XDeriveDataTypeable -XDeriveGeneric -XDeriveLift -XFlexibleContexts -XFlexibleInstances -XLambdaCase -XMagicHash -XMultiWayIf -XNamedFieldPuns -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeApplications -XTypeOperators -XUnboxedTuples -optP-Wall -optP-Werror=undef -DPURE_HASKELL=0 -Iinclude -itests:tests/builder:data-array-byte-0.1 -o Main cbits/*.c tests/Main.hs +RTS -s
           ./Main +RTS -s
 
   bounds-checking:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           curl -s https://hackage.haskell.org/package/data-array-byte-0.1/data-array-byte-0.1.tar.gz | tar xz
           ghc --version
-          ghc --make -XBangPatterns -XDeriveDataTypeable -XDeriveGeneric -XDeriveLift -XFlexibleContexts -XFlexibleInstances -XLambdaCase -XMagicHash -XMultiWayIf -XNamedFieldPuns -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeApplications -XTypeOperators -XUnboxedTuples -optP-Wall -optP-Werror=undef -DPURE_HASKELL=0 -Iinclude -itests:tests/builder:data-array-byte-0.1 -o Main cbits/*.c tests/Main.hs +RTS -s
+          ghc --make -XHaskell2010 -XBangPatterns -XDeriveDataTypeable -XDeriveGeneric -XDeriveLift -XFlexibleContexts -XFlexibleInstances -XLambdaCase -XMagicHash -XMultiWayIf -XNamedFieldPuns -XPatternSynonyms -XRankNTypes -XScopedTypeVariables -XStandaloneDeriving -XTupleSections -XTypeApplications -XTypeOperators -XUnboxedTuples -optP-Wall -optP-Werror=undef -DPURE_HASKELL=0 -Iinclude -itests:tests/builder:data-array-byte-0.1 -o Main cbits/*.c tests/Main.hs +RTS -s
           ./Main +RTS -s
 
   bounds-checking:

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1,11 +1,6 @@
-{-# OPTIONS_HADDOCK prune #-}
 {-# LANGUAGE Trustworthy #-}
 
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_HADDOCK prune #-}
 
 -- |
 -- Module      : Data.ByteString

--- a/Data/ByteString/Builder.hs
+++ b/Data/ByteString/Builder.hs
@@ -1,7 +1,8 @@
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Trustworthy #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports -fno-warn-orphans #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+  --instance Show Builder, instance IsString Builder
+
 {- | Copyright   : (c) 2010 Jasper Van der Jeugt
                    (c) 2010 - 2011 Simon Meier
 License     : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/Extra.hs
+++ b/Data/ByteString/Builder/Extra.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Trustworthy #-}
+
 -----------------------------------------------------------------------------
 -- | Copyright : (c) 2010      Jasper Van der Jeugt
 --               (c) 2010-2011 Simon Meier

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE ScopedTypeVariables, CPP, BangPatterns, RankNTypes, TupleSections #-}
 {-# LANGUAGE Unsafe #-}
+
 {-# OPTIONS_HADDOCK not-home #-}
+
 -- | Copyright : (c) 2010 - 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
 --

--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BangPatterns, ScopedTypeVariables #-}
-{-# LANGUAGE MagicHash, UnboxedTuples, PatternGuards #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
+
 {- | Copyright : (c) 2010-2011 Simon Meier
                  (c) 2010      Jasper van der Jeugt
 License        : BSD3-style (see LICENSE)
@@ -457,17 +455,14 @@ import qualified Data.ByteString               as S
 import qualified Data.ByteString.Internal      as S
 import qualified Data.ByteString.Lazy.Internal as L
 
-import           Data.Monoid
-import           Data.Char (chr, ord)
-import           Control.Monad ((<=<), unless)
+import           Data.Char (ord)
 
 import           Data.ByteString.Builder.Prim.Internal hiding (size, sizeBound)
-import qualified Data.ByteString.Builder.Prim.Internal as I (size, sizeBound)
+import qualified Data.ByteString.Builder.Prim.Internal as I
 import           Data.ByteString.Builder.Prim.Binary
 import           Data.ByteString.Builder.Prim.ASCII
 
 import           Foreign
-import           Foreign.C.Types
 import           Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import           GHC.Word (Word8 (..))
 import           GHC.Exts

--- a/Data/ByteString/Builder/Prim/ASCII.hs
+++ b/Data/ByteString/Builder/Prim/ASCII.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 -- | Copyright   : (c) 2010 Jasper Van der Jeugt
 --                 (c) 2010 - 2011 Simon Meier
 -- License       : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/Prim/Binary.hs
+++ b/Data/ByteString/Builder/Prim/Binary.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE Trustworthy #-}
 
-{-# LANGUAGE TypeApplications #-}
-
 -- | Copyright   : (c) 2010-2011 Simon Meier
 -- License       : BSD3-style (see LICENSE)
 --

--- a/Data/ByteString/Builder/Prim/Internal.hs
+++ b/Data/ByteString/Builder/Prim/Internal.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE ScopedTypeVariables, CPP #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Unsafe #-}
+
 {-# OPTIONS_HADDOCK not-home #-}
+
 -- |
 -- Copyright   : 2010-2011 Simon Meier, 2010 Jasper van der Jeugt
 -- License     : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/Prim/Internal/Base16.hs
+++ b/Data/ByteString/Builder/Prim/Internal/Base16.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE CPP #-}
+
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)

--- a/Data/ByteString/Builder/RealFloat/D2S.hs
+++ b/Data/ByteString/Builder/RealFloat/D2S.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+
 -- |
 -- Module      : Data.ByteString.Builder.RealFloat.D2S
 -- Copyright   : (c) Lawrence Wu 2021

--- a/Data/ByteString/Builder/RealFloat/F2S.hs
+++ b/Data/ByteString/Builder/RealFloat/F2S.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns, MagicHash #-}
+
 -- |
 -- Module      : Data.ByteString.Builder.RealFloat.F2S
 -- Copyright   : (c) Lawrence Wu 2021

--- a/Data/ByteString/Builder/RealFloat/Internal.hs
+++ b/Data/ByteString/Builder/RealFloat/Internal.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE ScopedTypeVariables, ExplicitForAll #-}
-{-# LANGUAGE BangPatterns, MagicHash, UnboxedTuples #-}
 {-# LANGUAGE CPP #-}
+
 {-# LANGUAGE RecordWildCards #-}
+
 -- |
 -- Module      : Data.ByteString.Builder.RealFloat.Internal
 -- Copyright   : (c) Lawrence Wu 2021

--- a/Data/ByteString/Builder/RealFloat/TableGenerator.hs
+++ b/Data/ByteString/Builder/RealFloat/TableGenerator.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns, MagicHash, UnboxedTuples #-}
 -- |
 -- Module      : Data.ByteString.Builder.RealFloat.TableGenerator
 -- Copyright   : (c) Lawrence Wu 2021

--- a/Data/ByteString/Char8.hs
+++ b/Data/ByteString/Char8.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
-{-# OPTIONS_HADDOCK prune #-}
 {-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_HADDOCK prune #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
+  -- We use the deprecated Data.ByteString.{hGetLine,getLine} to
+  -- define the not-deprecated Char8 versions of the same functions.
 
 -- |
 -- Module      : Data.ByteString.Char8

--- a/Data/ByteString/Internal/Pure.hs
+++ b/Data/ByteString/Internal/Pure.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MultiWayIf #-}
-
 -- Enable yields to make `isValidUtf8` safe to use on large inputs.
 {-# OPTIONS_GHC -fno-omit-yields #-}
 

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -1,17 +1,12 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Unsafe #-}
 
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE PatternSynonyms #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
 {-# LANGUAGE TemplateHaskellQuotes #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UnliftedFFITypes #-}
 {-# LANGUAGE ViewPatterns #-}
-
-{-# OPTIONS_HADDOCK not-home #-}
 
 -- |
 -- Module      : Data.ByteString.Internal.Type

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -1,9 +1,6 @@
-{-# OPTIONS_HADDOCK prune #-}
 {-# LANGUAGE Trustworthy #-}
 
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_HADDOCK prune #-}
 
 -- |
 -- Module      : Data.ByteString.Lazy

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeApplications #-}
+
 {-# OPTIONS_HADDOCK prune #-}
 
 -- |

--- a/Data/ByteString/Lazy/Internal.hs
+++ b/Data/ByteString/Lazy/Internal.hs
@@ -1,15 +1,9 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Unsafe #-}
 
-#ifdef HS_BYTESTRING_ASSERTIONS
-{-# LANGUAGE PatternSynonyms #-}
-#endif
-
 {-# OPTIONS_HADDOCK not-home #-}
+
+{-# LANGUAGE TypeFamilies #-}
 
 -- |
 -- Module      : Data.ByteString.Lazy.Internal

--- a/Data/ByteString/Lazy/ReadInt.hs
+++ b/Data/ByteString/Lazy/ReadInt.hs
@@ -1,9 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- This file is also included by "Data.ByteString.ReadInt", after defining
 -- "BYTESTRING_STRICT".  The two modules share much of their code, but

--- a/Data/ByteString/Lazy/ReadNat.hs
+++ b/Data/ByteString/Lazy/ReadNat.hs
@@ -1,9 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- This file is included by "Data.ByteString.ReadInt", after defining
 -- "BYTESTRING_STRICT".  The two modules are largely identical, except for the

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -1,26 +1,13 @@
-{-# LANGUAGE BangPatterns             #-}
 {-# LANGUAGE CPP                      #-}
-{-# LANGUAGE DeriveDataTypeable       #-}
-{-# LANGUAGE DeriveGeneric            #-}
-{-# LANGUAGE DeriveLift               #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase               #-}
-{-# LANGUAGE MagicHash                #-}
-{-# LANGUAGE MultiWayIf               #-}
-{-# LANGUAGE PatternSynonyms          #-}
-{-# LANGUAGE RankNTypes               #-}
-{-# LANGUAGE ScopedTypeVariables      #-}
-{-# LANGUAGE TemplateHaskellQuotes    #-}
-{-# LANGUAGE TupleSections            #-}
-{-# LANGUAGE TypeFamilies             #-}
-{-# LANGUAGE UnboxedTuples            #-}
-{-# LANGUAGE UnliftedFFITypes         #-}
 {-# LANGUAGE Unsafe                   #-}
-{-# LANGUAGE ViewPatterns             #-}
 
 {-# OPTIONS_HADDOCK not-home #-}
-
 {-# OPTIONS_GHC -fexpose-all-unfoldings #-}
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE UnliftedFFITypes         #-}
+{-# LANGUAGE ViewPatterns             #-}
 
 #include "bytestring-cpp-macros.h"
 

--- a/Data/ByteString/Unsafe.hs
+++ b/Data/ByteString/Unsafe.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE Unsafe #-}
 
 -- |

--- a/Data/ByteString/Utils/UnalignedAccess.hs
+++ b/Data/ByteString/Utils/UnalignedAccess.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE CPP #-}
+
+#include "bytestring-cpp-macros.h"
+
 -- |
 -- Module      : Data.ByteString.Utils.UnalignedAccess
 -- Copyright   : (c) Matthew Craven 2023-2024
@@ -7,13 +11,6 @@
 -- Portability : non-portable
 --
 -- Primitives for reading and writing at potentially-unaligned memory locations
-
-{-# LANGUAGE CPP #-}
-
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UnboxedTuples #-}
-
-#include "bytestring-cpp-macros.h"
 
 module Data.ByteString.Utils.UnalignedAccess
   ( unalignedWriteU16

--- a/bench/BenchAll.hs
+++ b/bench/BenchAll.hs
@@ -7,11 +7,6 @@
 -- Portability : tested on GHC only
 --
 
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE PackageImports      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MagicHash           #-}
-
 module Main (main) where
 
 import           Data.Foldable                         (foldMap)

--- a/bench/BenchBoundsCheckFusion.hs
+++ b/bench/BenchBoundsCheckFusion.hs
@@ -8,8 +8,6 @@
 --
 -- Benchmark that the bounds checks fuse.
 
-{-# LANGUAGE PackageImports, ScopedTypeVariables, BangPatterns #-}
-
 module BenchBoundsCheckFusion (benchBoundsCheckFusion) where
 
 import Prelude hiding (words)

--- a/bench/BenchCSV.hs
+++ b/bench/BenchCSV.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Copyright   : (c) 2010-2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)
@@ -8,9 +10,6 @@
 --
 -- Running example for documentation of Data.ByteString.Builder
 --
-
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module BenchCSV (benchCSV) where
 

--- a/bench/BenchIndices.hs
+++ b/bench/BenchIndices.hs
@@ -6,8 +6,6 @@
 --
 -- Benchmark elemIndex, findIndex, elemIndices, and findIndices
 
-{-# LANGUAGE BangPatterns        #-}
-
 module BenchIndices (benchIndices) where
 
 import           Data.Foldable                         (foldMap)

--- a/bench/BenchReadInt.hs
+++ b/bench/BenchReadInt.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Copyright   : (c) 2021 Viktor Dukhovni
 -- License     : BSD3-style (see LICENSE)
@@ -6,14 +8,6 @@
 --
 -- Benchmark readInt and variants, readWord and variants,
 -- readInteger and readNatural
-
-{-# LANGUAGE
-    CPP
-  , BangPatterns
-  , OverloadedStrings
-  , TypeApplications
-  , ScopedTypeVariables
-  #-}
 
 module BenchReadInt (benchReadInt) where
 

--- a/bench/BenchShort.hs
+++ b/bench/BenchShort.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE PackageImports      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE MagicHash           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 
 module BenchShort (benchShort) where

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -149,7 +149,7 @@ library
                    Data.ByteString.Utils.UnalignedAccess
 
   ghc-options:     -Wall -fwarn-tabs -Wincomplete-uni-patterns
-                   -optP -Wall -optP -Werror=undef
+                   -optP-Wall -optP-Werror=undef
                    -O2
                    -fmax-simplifier-iterations=10
                    -fdicts-cheap

--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -1,3 +1,5 @@
+Cabal-Version:       2.2
+
 Name:                bytestring
 Version:             0.13.0.0
 Synopsis:            Fast, compact, strict and lazy byte strings with a list interface
@@ -41,7 +43,7 @@ Description:
     .
     > import qualified Data.ByteString as BS
 
-License:             BSD3
+License:             BSD-3-Clause
 License-file:        LICENSE
 Category:            Data
 Copyright:           Copyright (c) Don Stewart          2005-2009,
@@ -65,7 +67,6 @@ Tested-With:         GHC==9.4.1,
                      GHC==8.2.2,
                      GHC==8.0.2
 Build-Type:          Simple
-Cabal-Version:       >= 1.10
 extra-source-files:  README.md Changelog.md include/bytestring-cpp-macros.h
 
 Flag pure-haskell
@@ -82,65 +83,77 @@ source-repository head
   type:     git
   location: https://github.com/haskell/bytestring
 
+
+common language
+  default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    DeriveDataTypeable
+    DeriveGeneric
+    DeriveLift
+    FlexibleContexts
+    FlexibleInstances
+    LambdaCase
+    MagicHash
+    MultiWayIf
+    NamedFieldPuns
+    PatternSynonyms
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeOperators
+    UnboxedTuples
+
 library
-  build-depends:     base >= 4.9 && < 5, ghc-prim, deepseq, template-haskell
+  import:          language
+  build-depends:   base >= 4.9 && < 5, ghc-prim, deepseq, template-haskell
 
   if impl(ghc < 9.4)
     build-depends: data-array-byte >= 0.1 && < 0.2
 
-  exposed-modules:   Data.ByteString
-                     Data.ByteString.Char8
-                     Data.ByteString.Unsafe
-                     Data.ByteString.Internal
-                     Data.ByteString.Lazy
-                     Data.ByteString.Lazy.Char8
-                     Data.ByteString.Lazy.Internal
-                     Data.ByteString.Short
-                     Data.ByteString.Short.Internal
+  exposed-modules: Data.ByteString
+                   Data.ByteString.Char8
+                   Data.ByteString.Unsafe
+                   Data.ByteString.Internal
+                   Data.ByteString.Lazy
+                   Data.ByteString.Lazy.Char8
+                   Data.ByteString.Lazy.Internal
+                   Data.ByteString.Short
+                   Data.ByteString.Short.Internal
 
-                     Data.ByteString.Builder
-                     Data.ByteString.Builder.Extra
-                     Data.ByteString.Builder.Prim
-                     Data.ByteString.Builder.RealFloat
+                   Data.ByteString.Builder
+                   Data.ByteString.Builder.Extra
+                   Data.ByteString.Builder.Prim
+                   Data.ByteString.Builder.RealFloat
 
-                     -- perhaps only exposed temporarily
-                     Data.ByteString.Builder.Internal
-                     Data.ByteString.Builder.Prim.Internal
-  other-modules:     Data.ByteString.Builder.ASCII
-                     Data.ByteString.Builder.Prim.ASCII
-                     Data.ByteString.Builder.Prim.Binary
-                     Data.ByteString.Builder.Prim.Internal.Base16
-                     Data.ByteString.Builder.Prim.Internal.Floating
-                     Data.ByteString.Builder.RealFloat.F2S
-                     Data.ByteString.Builder.RealFloat.D2S
-                     Data.ByteString.Builder.RealFloat.Internal
-                     Data.ByteString.Builder.RealFloat.TableGenerator
-                     Data.ByteString.Internal.Type
-                     Data.ByteString.Lazy.ReadInt
-                     Data.ByteString.Lazy.ReadNat
-                     Data.ByteString.ReadInt
-                     Data.ByteString.ReadNat
-                     Data.ByteString.Utils.ByteOrder
-                     Data.ByteString.Utils.UnalignedAccess
+                   -- perhaps only exposed temporarily
+                   Data.ByteString.Builder.Internal
+                   Data.ByteString.Builder.Prim.Internal
+  other-modules:   Data.ByteString.Builder.ASCII
+                   Data.ByteString.Builder.Prim.ASCII
+                   Data.ByteString.Builder.Prim.Binary
+                   Data.ByteString.Builder.Prim.Internal.Base16
+                   Data.ByteString.Builder.Prim.Internal.Floating
+                   Data.ByteString.Builder.RealFloat.F2S
+                   Data.ByteString.Builder.RealFloat.D2S
+                   Data.ByteString.Builder.RealFloat.Internal
+                   Data.ByteString.Builder.RealFloat.TableGenerator
+                   Data.ByteString.Internal.Type
+                   Data.ByteString.Lazy.ReadInt
+                   Data.ByteString.Lazy.ReadNat
+                   Data.ByteString.ReadInt
+                   Data.ByteString.ReadNat
+                   Data.ByteString.Utils.ByteOrder
+                   Data.ByteString.Utils.UnalignedAccess
 
-  default-language:  Haskell2010
-  other-extensions:  CPP,
-                     ForeignFunctionInterface,
-                     BangPatterns
-                     UnliftedFFITypes,
-                     MagicHash,
-                     UnboxedTuples,
-                     DeriveDataTypeable
-                     ScopedTypeVariables
-                     RankNTypes
-                     NamedFieldPuns
-
-  ghc-options:      -Wall -fwarn-tabs -Wincomplete-uni-patterns
-                    -optP -Wall -optP -Werror=undef
-                    -O2
-                    -fmax-simplifier-iterations=10
-                    -fdicts-cheap
-                    -fspec-constr-count=6
+  ghc-options:     -Wall -fwarn-tabs -Wincomplete-uni-patterns
+                   -optP -Wall -optP -Werror=undef
+                   -O2
+                   -fmax-simplifier-iterations=10
+                   -fdicts-cheap
+                   -fspec-constr-count=6
 
   if arch(javascript) || flag(pure-haskell)
     cpp-options: -DPURE_HASKELL=1
@@ -177,6 +190,7 @@ library
                      bytestring-cpp-macros.h
 
 test-suite bytestring-tests
+  import:           language
   type:             exitcode-stdio-1.0
   main-is:          Main.hs
   other-modules:    Builder
@@ -205,11 +219,12 @@ test-suite bytestring-tests
                     template-haskell,
                     transformers >= 0.3,
                     syb
+
   ghc-options:      -fwarn-unused-binds
                     -threaded -rtsopts
-  default-language: Haskell2010
 
 benchmark bytestring-bench
+  import:           language
   main-is:          BenchAll.hs
   other-modules:    BenchBoundsCheckFusion
                     BenchCount
@@ -219,7 +234,7 @@ benchmark bytestring-bench
                     BenchShort
   type:             exitcode-stdio-1.0
   hs-source-dirs:   bench
-  default-language: Haskell2010
+
   ghc-options:      -O2 "-with-rtsopts=-A32m"
   if impl(ghc >= 8.6)
     ghc-options:    -fproc-alignment=64

--- a/tests/IsValidUtf8.hs
+++ b/tests/IsValidUtf8.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 module IsValidUtf8 (testSuite) where
 
 import Data.Bits (shiftR, (.&.), shiftL)

--- a/tests/Lift.hs
+++ b/tests/Lift.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE TemplateHaskell #-}
+
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 module Lift (testSuite) where
 
 import           Test.Tasty (TestTree, testGroup)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1,10 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE UnboxedTuples #-}
-
 -- We need @AllowAmbiguousTypes@ in order to be able to use @TypeApplications@
 -- to disambiguate the desired instance of class methods whose instance cannot
 -- be inferred from the caller's context.  We would otherwise have to use

--- a/tests/Properties/ByteString.hs
+++ b/tests/Properties/ByteString.hs
@@ -7,9 +7,6 @@
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-
 -- We need @AllowAmbiguousTypes@ in order to be able to use @TypeApplications@
 -- to disambiguate the desired instance of class methods whose instance cannot
 -- be inferred from the caller's context.  We would otherwise have to use

--- a/tests/QuickCheckUtils.hs
+++ b/tests/QuickCheckUtils.hs
@@ -1,8 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module QuickCheckUtils

--- a/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/TestUtils.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)

--- a/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Prim/Tests.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE MagicHash #-}
-
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns     #-}
-{-# LANGUAGE MagicHash        #-}
-{-# LANGUAGE CPP              #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 -- |
 -- Copyright   : (c) 2011 Simon Meier
 -- License     : BSD3-style (see LICENSE)


### PR DESCRIPTION
...mostly because the manually enabling `BangPatterns` or `MagicHash` or `TypeApplications` separately in each module has gotten a bit old.