### PR TITLE
Improve benchmarks for small Builders

### DIFF
--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -155,7 +155,7 @@ import           System.IO.Unsafe (unsafeDupablePerformIO)
 data BufferRange = BufferRange {-# UNPACK #-} !(Ptr Word8)  -- First byte of range
                                {-# UNPACK #-} !(Ptr Word8)  -- First byte /after/ range
 
--- | @since 0.12.1.0
+-- | @since 0.12.2.0
 instance NFData BufferRange where
   rnf !_ = ()
 
@@ -168,7 +168,7 @@ data Buffer = Buffer {-# UNPACK #-} !(ForeignPtr Word8)
 -- this does not force the @ForeignPtrContents@ field
 -- of the underlying @ForeignPtr@.
 --
--- @since 0.12.1.0
+-- @since 0.12.2.0
 instance NFData Buffer where
   rnf !_ = ()
 

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -127,6 +127,7 @@ module Data.ByteString.Builder.Internal (
 ) where
 
 import           Control.Arrow (second)
+import           Control.DeepSeq (NFData(..))
 
 import           Data.Semigroup (Semigroup(..))
 import           Data.List.NonEmpty (NonEmpty(..))
@@ -154,11 +155,22 @@ import           System.IO.Unsafe (unsafeDupablePerformIO)
 data BufferRange = BufferRange {-# UNPACK #-} !(Ptr Word8)  -- First byte of range
                                {-# UNPACK #-} !(Ptr Word8)  -- First byte /after/ range
 
+-- | @since 0.12.1.0
+instance NFData BufferRange where
+  rnf !_ = ()
+
 -- | A 'Buffer' together with the 'BufferRange' of free bytes. The filled
 -- space starts at offset 0 and ends at the first free byte.
 data Buffer = Buffer {-# UNPACK #-} !(ForeignPtr Word8)
                      {-# UNPACK #-} !BufferRange
 
+-- | Like the @NFData@ instance for @StrictByteString@,
+-- this does not force the @ForeignPtrContents@ field
+-- of the underlying @ForeignPtr@.
+--
+-- @since 0.12.1.0
+instance NFData Buffer where
+  rnf !_ = ()
 
 -- | Combined size of the filled and free space in the buffer.
 {-# INLINE bufferSize #-}


### PR DESCRIPTION
...separated out from #569. The main improvement is that this separates the buffer allocation cost (which is similar for all `Builder`s) from the actual write/encoding cost.
