### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -186,7 +186,6 @@ library
       extra-libraries:  gcc
 
   include-dirs:      include
-  includes:          fpstring.h
   install-includes:  fpstring.h
                      bytestring-cpp-macros.h
 


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355