### PR TITLE
use vaulted centos packages to fix old-ghc ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,28 +184,6 @@ jobs:
     - name: Test
       run: cabal test -fpure-haskell --ghc-options=-fno-ignore-asserts --enable-tests --test-show-details=direct all
 
-  old-gcc:
-    needs: build
-    runs-on: ubuntu-latest
-    container:
-      image: centos:7
-    steps:
-    - name: install deps
-      run: |
-          # Fixing “No URLs in Mirrorlist” Error on CentOS 8 Stream
-          # https://bitsanddragons.wordpress.com/2024/06/04/fixing-no-urls-in-mirrorlist-error-on-centos-8-stream/
-          # https://archive.vn/dCjg1
-          sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-
-          yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl
-          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=9.2.8 sh
-    - uses: actions/checkout@v3 #This version must stay old enough to remain compatible with the container image
-    - name: test
-      run: |
-          source ~/.ghcup/env
-          cabal update
-          cabal run bytestring-tests
-
   i386:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,11 @@ jobs:
     steps:
     - name: install deps
       run: |
+          # Fixing “No URLs in Mirrorlist” Error on CentOS 8 Stream
+          # https://bitsanddragons.wordpress.com/2024/06/04/fixing-no-urls-in-mirrorlist-error-on-centos-8-stream/
+          # https://archive.vn/dCjg1
+          sed -i -e 's/mirrorlist/#mirrorlist/g' -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
           yum install -y gcc gmp gmp-devel make ncurses ncurses-compat-libs xz perl
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=9.2.8 sh
     - uses: actions/checkout@v3 #This version must stay old enough to remain compatible with the container image


### PR DESCRIPTION
Followed instructions from: https://bitsanddragons.wordpress.com/2024/06/04/fixing-no-urls-in-mirrorlist-error-on-centos-8-stream/