### PR TITLE
Add a constraint reflecting #665 to the package description

### DIFF
--- a/bytestring.cabal
+++ b/bytestring.cabal
@@ -185,6 +185,13 @@ library
     if os(windows) && impl(ghc < 9.3)
       extra-libraries:  gcc
 
+  if arch(aarch64)
+    -- The libffi in Apple's darwin toolchain doesn't
+    -- play nice with -Wundef.  Recent GHCs work around this.
+    -- See also https://github.com/haskell/bytestring/issues/665
+    -- and https://gitlab.haskell.org/ghc/ghc/-/issues/23568
+    build-depends:    base (>= 4.17.2 && < 4.18) || >= 4.18.1
+
   include-dirs:      include
   install-includes:  fpstring.h
                      bytestring-cpp-macros.h


### PR DESCRIPTION
Some combinations of Apple toolchains and GHC versions will provide headers that anger -Werror=undef.  See discussion at that #665.

This is the same condition as in the Hackage revision 0.12.1.0-r1, but I've moved it out of the `else` branch so that it also applies if the pure-haskell flag is set.