### PR TITLE
Remove useless INLINE on `compareLength` for lazy bytestrings.

### DIFF
--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -584,7 +584,6 @@ compareLength :: ByteString -> Int64 -> Ordering
 compareLength _ toCmp | toCmp < 0 = GT
 compareLength Empty toCmp         = compare 0 toCmp
 compareLength (Chunk c cs) toCmp  = compareLength cs (toCmp - fromIntegral (S.length c))
-{-# INLINE compareLength #-}
 
 {-# RULES
 "ByteString.Lazy length/compareN -> compareLength" [~1] forall t n.


### PR DESCRIPTION
The function is self-recursive so will never inline. I also don't see the benefit of the INLINE pragma in the first place.

Fixes #704.