### PR TITLE
Paramatarize Handle for lazy ByteString 

### DIFF
--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -31,7 +31,11 @@ module Data.ByteString.Internal.Type (
         ),
 
         StrictByteString,
-
+        Scope
+        ( With
+        , Free
+        ),
+        BsHandle(BsHandle),
         -- * Internal indexing
         findIndexOrLength,
 
@@ -197,6 +201,7 @@ import GHC.ForeignPtr           (unsafeWithForeignPtr)
 
 import qualified Language.Haskell.TH.Lib as TH
 import qualified Language.Haskell.TH.Syntax as TH
+import System.IO                (Handle)
 
 #if !HS_unsafeWithForeignPtr_AVAILABLE
 unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
@@ -351,6 +356,10 @@ instance Data ByteString where
     1 -> k (z packBytes)
     _ -> error "gunfold: unexpected constructor of strict ByteString"
   dataTypeOf _   = byteStringDataType
+
+data Scope = With | Free deriving (Show, Eq)
+
+newtype BsHandle (s :: Scope) = BsHandle Handle deriving (Show, Eq)
 
 packConstr :: Constr
 packConstr = mkConstr byteStringDataType "pack" [] Prefix

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -236,7 +236,7 @@ import Data.ByteString.Lazy
         ,concat,take,takeEnd,drop,dropEnd,splitAt,intercalate
         ,isPrefixOf,isSuffixOf,group,inits,tails,initsNE,tailsNE,copy
         ,stripPrefix,stripSuffix
-        ,hGetContents, hGet, hPut, getContents
+        ,GetContents(hGetContents), BsHandle, hGet, hPut, getContents, stdout
         ,hGetNonBlocking, hPutNonBlocking
         ,putStr, hPutStr, interact
         ,readFile,writeFile,appendFile,compareLength)
@@ -262,8 +262,6 @@ import Prelude hiding
         ,unwords,words,all,concatMap,scanl,scanl1,scanr,scanr1
         ,readFile,writeFile,appendFile,replicate,getContents,getLine,putStr,putStrLn
         ,zip,zipWith,unzip,notElem,repeat,iterate,interact,cycle)
-
-import System.IO            (Handle, stdout)
 
 ------------------------------------------------------------------------
 
@@ -929,7 +927,7 @@ unwords = intercalate (singleton ' ')
 -- Other threads might write to the 'Handle' in between,
 -- and hence 'hPutStrLn' alone is not suitable for concurrent writes.
 --
-hPutStrLn :: Handle -> ByteString -> IO ()
+hPutStrLn :: BsHandle s -> ByteString -> IO ()
 hPutStrLn h ps = hPut h ps >> hPut h (L.singleton 0x0a)
 
 -- | Write a ByteString to 'stdout', appending a newline byte.

--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -51,11 +51,25 @@ testSuite = withResource
         S.last r `seq` return ()
         appendFile fn "" -- will fail, if fn has not been closed yet
 
-    , testProperty "Testing lazy hGetContents" $ ioProperty $
+    , testProperty "Testing Free lazy hGetContents" $ ioProperty $
       forM_ [1..n] $ const $ do
         fn <- fn'
-        h <- openFile fn ReadMode
+        h <- L.openBinaryFile fn ReadMode
         r <- L.hGetContents h
+        L.last r `seq` return ()
+        appendFile fn "" -- will fail, if fn has not been closed yet
+    , testProperty "Testing With lazy hGetContents" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        L.withBinaryFile fn ReadMode $
+          \h -> do
+            r <- L.hGetContents h
+            L.last r `seq` return ()
+        appendFile fn "" -- will fail, if fn has not been closed yet
+    , testProperty "Testing lazy withBinaryFile seq result" $ ioProperty $
+      forM_ [1..n] $ const $ do
+        fn <- fn'
+        r <- L.withBinaryFile fn ReadMode L.hGetContents
         L.last r `seq` return ()
         appendFile fn "" -- will fail, if fn has not been closed yet
     ]


### PR DESCRIPTION
Handle type parameter disambiguates hGetContents behavior.

https://github.com/haskell/bytestring/issues/707
