### PR TITLE
Fix spelling of "recommended" in docs.

### DIFF
--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -22,7 +22,7 @@
 -- are encoded as strict 'Word8' arrays of bytes, held in a 'ForeignPtr',
 -- and can be passed between C and Haskell with little effort.
 --
--- The recomended way to assemble ByteStrings from smaller parts
+-- The recommended way to assemble ByteStrings from smaller parts
 -- is to use the builder monoid from "Data.ByteString.Builder".
 --
 -- This module is intended to be imported @qualified@, to avoid name

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -30,7 +30,7 @@
 -- operations lazy ByteStrings are usually within a few percent of
 -- strict ones.
 --
--- The recomended way to assemble lazy ByteStrings from smaller parts
+-- The recommended way to assemble lazy ByteStrings from smaller parts
 -- is to use the builder monoid from "Data.ByteString.Builder".
 --
 -- This module is intended to be imported @qualified@, to avoid name


### PR DESCRIPTION
A small PR that fixes the spelling of "recommended" in the Haddock documentation.