### PR TITLE
Data.ByteString.Short: import members of class Eq and class Ord explicitly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-14-2
+    image_family: freebsd-14-3
   install_script:
     - pkg install -y git gmake
     - curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,8 @@ task:
     platform: openbsd
   install_script: pkg_add ghc cabal-install git
   script:
-    - export CABAL_DIR=/tmp/.cabal
+    - mkdir -p /home/cabal
+    - ln -s /home/cabal $HOME/.cabal
     - cabal update
     - cabal test --test-show-details=direct
 

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -229,7 +229,9 @@ import GHC.Stack.Types
   ( HasCallStack )
 import GHC.Word
 import Prelude
-  ( Eq(..), Ord(..), Ordering(..), Read(..), Show(..)
+  ( Eq, (==), (/=)
+  , Ord, compare, (<), (<=), (>), (>=), min, max
+  , Ordering(..), Read(..), Show(..)
   , ($), ($!), error, (++), (.), (||)
   , String, userError
   , Bool(..), (&&), otherwise

--- a/tests/LazyHClose.hs
+++ b/tests/LazyHClose.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE CPP #-}
+{- HLINT ignore "Use fewer imports" -}
+
 module LazyHClose (testSuite) where
 
 import Control.Monad (void, forM_)
@@ -6,13 +9,22 @@ import Foreign.C.String (withCString)
 import Foreign.ForeignPtr (finalizeForeignPtr)
 import System.IO (openFile, openTempFile, hClose, hPutStrLn, IOMode(..))
 import System.Posix.Internals (c_unlink)
-import Test.Tasty (TestTree, testGroup, withResource)
+import Test.Tasty (TestTree, withResource)
 import Test.Tasty.QuickCheck (testProperty, ioProperty)
 
 import qualified Data.ByteString            as S
 import qualified Data.ByteString.Char8      as S8
 import qualified Data.ByteString.Lazy       as L
 import qualified Data.ByteString.Lazy.Char8 as L8
+
+#if MIN_VERSION_tasty(1,5,4)
+import Test.Tasty (inOrderTestGroup)
+#else
+import Test.Tasty (testGroup)
+
+inOrderTestGroup :: String -> [TestTree] -> TestTree
+inOrderTestGroup = testGroup
+#endif
 
 n :: Int
 n = 1000
@@ -21,7 +33,7 @@ testSuite :: TestTree
 testSuite = withResource
   (do (fn, h) <- openTempFile "." "lazy-hclose-test.tmp"; hPutStrLn h "x"; hClose h; pure fn)
   removeFile $ \fn' ->
-    testGroup "LazyHClose"
+    inOrderTestGroup "LazyHClose"
     [ testProperty "Testing resource leaks for Strict.readFile" $ ioProperty $
       forM_ [1..n] $ const $ do
         fn <- fn'


### PR DESCRIPTION
This is in case someone in future actually implements "The Eq of no (/=)" proposal (https://github.com/haskell/core-libraries-committee/issues/3), which will make `Eq(..)` not to import `(/=)`.

I'm not aware of any proposals to change the composition of `Ord(..)` at the moment, but it feels more consistent to make it explicit too.