### PR TITLE
Fix typos

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -168,7 +168,7 @@
 * Performance improvements:
   * [Many functions returning `StrictByteString` can now return their results unboxed](https://github.com/haskell/bytestring/pull/580)
   * [Dead branches removed from `Lazy.toStrict`](https://github.com/haskell/bytestring/pull/590)
-  * [`Builder.toLazyByteString` re-uses under-filled buffers after copying their contents](https://github.com/haskell/bytestring/pull/581)
+  * [`Builder.toLazyByteString` reuses under-filled buffers after copying their contents](https://github.com/haskell/bytestring/pull/581)
 * Miscellaneous:
   * [Minor benchmarking improvements](https://github.com/haskell/bytestring/pull/577)
 <!--

--- a/Data/ByteString.hs
+++ b/Data/ByteString.hs
@@ -1723,7 +1723,7 @@ tailsNE :: ByteString -> NonEmpty ByteString
 tailsNE p | null p    = empty :| []
           | otherwise = p :| tails (unsafeTail p)
 
--- less efficent spacewise: tails (BS x l) = [BS (plusForeignPtr x n) (l-n) | n <- [0..l]]
+-- less efficient spacewise: tails (BS x l) = [BS (plusForeignPtr x n) (l-n) | n <- [0..l]]
 
 {-
 Note [Avoid NonEmpty combinators]

--- a/Data/ByteString/Builder.hs
+++ b/Data/ByteString/Builder.hs
@@ -24,7 +24,7 @@ For an /efficient implementation of an encoding/,
   the Haskell values to the resulting sequence of bytes /and/
   (b) that the representation of the resulting sequence
   is such that it can be consumed efficiently.
-'Builder's support (a) by providing an /O(1)/ concatentation operation
+'Builder's support (a) by providing an /O(1)/ concatenation operation
   and efficient implementations of basic encodings for 'Char's, 'Int's,
   and other standard Haskell values.
 They support (b) by providing their result as a 'L.LazyByteString',
@@ -148,7 +148,7 @@ For example,
 >renderRow :: Row -> Builder
 >renderRow  = mconcat . intersperse (charUtf8 ',') . map renderCell
 
-Similarly, using /O(n)/ concatentations like '++' or the equivalent 'Data.ByteString.concat'
+Similarly, using /O(n)/ concatenations like '++' or the equivalent 'Data.ByteString.concat'
   operations on strict and 'L.LazyByteString's should be avoided.
 The following definition of @renderString@ is also about 20% slower.
 

--- a/Data/ByteString/Builder/Internal.hs
+++ b/Data/ByteString/Builder/Internal.hs
@@ -869,7 +869,7 @@ wrappedBufferRangeCopyStep (BufferRange ip0 ipe) k =
 
 
 -- | Construct a 'Builder' that copies the 'S.StrictByteString's, if it is
--- smaller than the treshold, and inserts it directly otherwise.
+-- smaller than the threshold, and inserts it directly otherwise.
 --
 -- For example, @byteStringThreshold 1024@ copies 'S.StrictByteString's whose size
 -- is less or equal to 1kb, and inserts them directly otherwise. This implies
@@ -1017,7 +1017,7 @@ modUtf8_step !ip !len k (BufferRange op ope)
             !usable = avail `min` len
         -- null-termination makes it possible to read one more byte than the
         -- nominal input length, with any unexpected 0xC000 ending interpreted
-        -- as a NUL.  More typically, this simplifies hanlding of inputs where
+        -- as a NUL.  More typically, this simplifies handling of inputs where
         -- 0xC0 0x80 might otherwise be split across the "usable" input window.
         !ch <- peekElemOff ip (usable - 1)
         let !use | ch /= 0xC0 = usable
@@ -1308,7 +1308,7 @@ buildStepToCIOS (AllocationStrategy nextBuffer bufSize trim) =
                   else do buf' <- nextBuffer (Just (buf, bufSize))
                           fill nextStep buf'
 
-        -- Wrap and yield a chunk, trimming it if necesary
+        -- Wrap and yield a chunk, trimming it if necessary
         {-# INLINE wrapChunk #-}
         wrapChunk :: Ptr Word8 -> (Bool -> IO (ChunkIOStream a)) -> IO (ChunkIOStream a)
         wrapChunk !op' mkCIOS
@@ -1316,7 +1316,7 @@ buildStepToCIOS (AllocationStrategy nextBuffer bufSize trim) =
           | trim chunkSize size = do
               bs <- S.createFp chunkSize $ \fpbuf' ->
                         S.memcpyFp fpbuf' fpbuf chunkSize
-              -- It is not safe to re-use the old buffer (see #690),
+              -- It is not safe to reuse the old buffer (see #690),
               -- so we allocate a new buffer after trimming.
               return $ Yield1 bs (mkCIOS False)
           | otherwise            =

--- a/Data/ByteString/Builder/Prim.hs
+++ b/Data/ByteString/Builder/Prim.hs
@@ -520,7 +520,7 @@ primMapLazyByteStringFixed = primMapLazyByteStringBounded . toB
 --
 -- > primBounded (word32 c1) `mappend` primBounded (word32 c2)
 --
--- is rewritten such that the resulting 'Builder' checks only once, if ther are
+-- is rewritten such that the resulting 'Builder' checks only once, if there are
 -- at 8 free bytes, instead of checking twice, if there are 4 free bytes. This
 -- optimization is not observationally equivalent in a strict sense, as it
 -- influences the boundaries of the generated chunks. However, for a user of

--- a/Data/ByteString/Internal/Pure.hs
+++ b/Data/ByteString/Internal/Pure.hs
@@ -348,7 +348,7 @@ encodeUnsignedHex :: (Eq a, Num a, Integral a, Bits a) => a -> Ptr Word8 -> IO (
 {-# INLINABLE encodeUnsignedHex #-} -- for specialization
 encodeUnsignedHex !v !next_ptr = encodeUnsignedHex' v next_ptr next_ptr
 
--- | Encode positive number as little-endian hexdecimal, then reverse it.
+-- | Encode positive number as little-endian hexadecimal, then reverse it.
 --
 -- Take two pointers (orig_ptr, next_ptr) to support already encoded digits
 encodeUnsignedHex' :: (Eq a, Num a, Integral a, Bits a) => a -> Ptr Word8 -> Ptr Word8 -> IO (Ptr Word8)

--- a/Data/ByteString/Internal/Type.hs
+++ b/Data/ByteString/Internal/Type.hs
@@ -690,27 +690,27 @@ unpackAppendCharsLazy (BS fp len) cs
 -- For these unpack functions, since we're unpacking the whole list strictly we
 -- build up the result list in an accumulator. This means we have to build up
 -- the list starting at the end. So our traversal starts at the end of the
--- buffer and loops down until we hit the sentinal:
+-- buffer and loops down until we hit the sentinel:
 
 unpackAppendBytesStrict :: ByteString -> [Word8] -> [Word8]
 unpackAppendBytesStrict (BS fp len) xs =
     accursedUnutterablePerformIO $ unsafeWithForeignPtr fp $ \base ->
       loop (base `plusPtr` (-1)) (base `plusPtr` (-1+len)) xs
   where
-    loop !sentinal !p acc
-      | p == sentinal = return acc
+    loop !sentinel !p acc
+      | p == sentinel = return acc
       | otherwise     = do x <- peek p
-                           loop sentinal (p `plusPtr` (-1)) (x:acc)
+                           loop sentinel (p `plusPtr` (-1)) (x:acc)
 
 unpackAppendCharsStrict :: ByteString -> [Char] -> [Char]
 unpackAppendCharsStrict (BS fp len) xs =
     accursedUnutterablePerformIO $ unsafeWithForeignPtr fp $ \base ->
       loop (base `plusPtr` (-1)) (base `plusPtr` (-1+len)) xs
   where
-    loop !sentinal !p acc
-      | p == sentinal = return acc
+    loop !sentinel !p acc
+      | p == sentinel = return acc
       | otherwise     = do x <- peek p
-                           loop sentinal (p `plusPtr` (-1)) (w2c x:acc)
+                           loop sentinel (p `plusPtr` (-1)) (w2c x:acc)
 
 ------------------------------------------------------------------------
 

--- a/Data/ByteString/Lazy.hs
+++ b/Data/ByteString/Lazy.hs
@@ -327,7 +327,7 @@ cons c = Chunk (S.singleton c)
 -- may coalesce the new byte onto the first \'chunk\' rather than starting a
 -- new \'chunk\'.
 --
--- So that means you can't use a lazy recursive contruction like this:
+-- So that means you can't use a lazy recursive construction like this:
 --
 -- > let xs = cons' c xs in xs
 --
@@ -1522,7 +1522,7 @@ tailsNE bs = case uncons bs of
 --   is needed in the rest of the program.
 copy :: ByteString -> ByteString
 copy = foldrChunks (Chunk . S.copy) Empty
---TODO, we could coalese small blocks here
+--TODO, we could coalesce small blocks here
 --FIXME: probably not strict enough, if we're doing this to avoid retaining
 -- the parent blocks then we'd better copy strictly.
 

--- a/Data/ByteString/Lazy/Char8.hs
+++ b/Data/ByteString/Lazy/Char8.hs
@@ -294,7 +294,7 @@ cons = L.cons . c2w
 -- may coalesce the new byte onto the first \'chunk\' rather than starting a
 -- new \'chunk\'.
 --
--- So that means you can't use a lazy recursive contruction like this:
+-- So that means you can't use a lazy recursive construction like this:
 --
 -- > let xs = cons' c xs in xs
 --
@@ -893,7 +893,7 @@ lines (Chunk c0 cs0) = unNE $! go c0 cs0
         -- In particular, we don't strictly pattern match on 'cs'.
         --
         -- We can form `Chunk c ...` because the invariant is maintained
-        -- here and also by using `chunk` in the defintion of `c'` above.
+        -- here and also by using `chunk` in the definition of `c'` above.
         Nothing -> let ~(l:|ls) = lazyRest cs
                     in  Chunk c l :| ls
           where

--- a/Data/ByteString/Lazy/ReadInt.hs
+++ b/Data/ByteString/Lazy/ReadInt.hs
@@ -217,7 +217,7 @@ _readDecimal !r = consume
 -- accumulator would overflow return 'Overflow'.
 --
 _digits :: Word64           -- ^ maximum non-overflow value `div` 10
-        -> Word64           -- ^ maximum non-overflow vavlue `mod` 10
+        -> Word64           -- ^ maximum non-overflow value `mod` 10
         -> ForeignPtr Word8 -- ^ Input buffer
         -> Int              -- ^ Input length
         -> Word64           -- ^ Accumulated value of leading digits

--- a/Data/ByteString/Short/Internal.hs
+++ b/Data/ByteString/Short/Internal.hs
@@ -585,23 +585,23 @@ unpackAppendBytesLazy sbs = go 0 (length sbs)
 -- For these unpack functions, since we're unpacking the whole list strictly we
 -- build up the result list in an accumulator. This means we have to build up
 -- the list starting at the end. So our traversal starts at the end of the
--- buffer and loops down until we hit the sentinal:
+-- buffer and loops down until we hit the sentinel:
 
 unpackAppendCharsStrict :: ShortByteString -> Int -> Int -> [Char] -> [Char]
 unpackAppendCharsStrict !sbs off len = go (off-1) (off-1 + len)
   where
-    go !sentinal !i acc
-      | i == sentinal = acc
+    go !sentinel !i acc
+      | i == sentinel = acc
       | otherwise     = let !c = indexCharArray (asBA sbs) i
-                        in go sentinal (i-1) (c:acc)
+                        in go sentinel (i-1) (c:acc)
 
 unpackAppendBytesStrict :: ShortByteString -> Int -> Int -> [Word8] -> [Word8]
 unpackAppendBytesStrict !sbs off len = go (off-1) (off-1 + len)
   where
-    go !sentinal !i acc
-      | i == sentinal = acc
+    go !sentinel !i acc
+      | i == sentinel = acc
       | otherwise     = let !w = indexWord8Array (asBA sbs) i
-                         in go sentinal (i-1) (w:acc)
+                         in go sentinel (i-1) (w:acc)
 
 
 ------------------------------------------------------------------------

--- a/tests/builder/Data/ByteString/Builder/Tests.hs
+++ b/tests/builder/Data/ByteString/Builder/Tests.hs
@@ -319,7 +319,7 @@ recipeComponents (Recipe how firstSize otherSize cont as) =
     b = fromPut $ evalStateT (traverse_ buildAction as) firstSize
 
 
--- 'Arbitary' instances
+-- 'Arbitrary' instances
 -----------------------
 
 instance Arbitrary Mode where


### PR DESCRIPTION
Found via `codespell -L clen,ans,wordl,unio` and `typos --hidden --format brief`